### PR TITLE
docs: add Kimi persona tier example

### DIFF
--- a/services/model-router/README.md
+++ b/services/model-router/README.md
@@ -70,7 +70,7 @@ Set `PERSONA_TIERS_JSON` to a JSON object mapping agent/persona names to tier ke
 {"orchestrator": "claude-sonnet-4-6", "coder": "gpt-4o-mini"}
 ```
 
-The tier value must be a key present in `MODELS` at request time (i.e. a registered tier such as `gpt4o-mini`, `phi4`, or an optional tier you enabled — **not** the abstract `frontier`/`standard`/`economy` labels used in agent profiles). `persona-tiers.example.json` ships a working default that targets only the two always-registered tiers (`gpt4o-mini` for higher-value roles, `phi4` for economy roles), so it routes correctly on a vanilla Foundry-only stack; repoint roles at richer tiers (e.g. a `CLAUDE` tier) once you register them.
+The tier value must be a key present in `MODELS` at request time (i.e. a registered tier such as `gpt4o-mini`, `phi4`, or an optional tier you enabled — **not** the abstract `frontier`/`standard`/`economy` labels used in agent profiles). `persona-tiers.example.json` includes a Kimi example (`researcher` → `kimi-k2`) to show how to route a persona to another OpenAI-compatible provider; use it after registering the `KIMI` tier with `KIMI_BASE_URL`, `KIMI_API_KEY`, and `KIMI_MODEL=kimi-k2`, or change that role back to an always-registered tier on a vanilla Foundry-only stack.
 
 ### Fallback chain
 

--- a/services/model-router/persona-tiers.example.json
+++ b/services/model-router/persona-tiers.example.json
@@ -1,6 +1,6 @@
 {
   "orchestrator": "gpt4o-mini",
-  "researcher": "gpt4o-mini",
+  "researcher": "kimi-k2",
   "strategy": "gpt4o-mini",
   "coder": "gpt4o-mini",
   "infrastructure": "gpt4o-mini",


### PR DESCRIPTION
## What this changes

Adds a Kimi (`kimi-k2`) persona-tier mapping example for the `researcher` persona and documents how to enable or swap that optional OpenAI-compatible tier.

Closes #3

## Type

- [ ] Bug fix
- [ ] Feature / enhancement
- [x] Documentation
- [ ] Infrastructure (Terraform)

## Validation

Confirm the gates pass (see [CONTRIBUTING.md](../CONTRIBUTING.md)):

- [ ] `terraform validate` passes; both `cost-optimized` and `hardened` profiles `plan` clean
- [ ] `docker compose config` is valid (if compose changed)
- [x] Tests pass (`agents/` and `services/model-router/`) — ran `pytest -q services/model-router/tests` (19 passed)
- [ ] `gitleaks` clean — no secrets, no real hostnames or personal data (`gitleaks` not installed locally; not run)
- [x] Docs updated to match the change

Additional checks:

- `python3 -m json.tool services/model-router/persona-tiers.example.json` passed
- `git diff --check` passed

## Notes

This is a docs/config-example-only change. The Kimi mapping requires registering the optional `KIMI` tier with `KIMI_MODEL=kimi-k2`; the README notes that vanilla Foundry-only deployments can change the role back to an always-registered tier.
