### PR TITLE
docs: align getting started with fresh clone

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,10 +38,10 @@ Pick a path:
 | Docker Desktop | Path A; Docker Compose ships with it |
 | LLM endpoint | Azure AI Foundry (primary) or any OpenAI-compatible base URL |
 
-The stack defaults to Azure AI Foundry with grok-4-fast-reasoning as its
-primary model. If you do not have an AI Foundry project yet, set
-`LLM_PROVIDER=openai_compat` and point `OPENAI_COMPAT_BASE_URL` at any
-compatible endpoint (Ollama, vLLM, or a hosted API) instead.
+The local router registers a `gpt4o-mini` tier when you provide either the
+`AZURE_FOUNDRY_*` pair or the direct `GPT4O_*` pair. Optional tiers such as
+Grok, Kimi, Claude, and Phi are registered only when their own env vars are
+set.
 
 ---
 
@@ -62,12 +62,11 @@ AZURE_FOUNDRY_ENDPOINT=https://<your-project>.openai.azure.com/
 AZURE_FOUNDRY_API_KEY=<your-key>
 ```
 
-Or, for any OpenAI-compatible endpoint:
+Or point the primary tier at any OpenAI-compatible endpoint:
 
 ```
-LLM_PROVIDER=openai_compat
-OPENAI_COMPAT_BASE_URL=http://localhost:11434/v1   # example: local Ollama
-OPENAI_COMPAT_API_KEY=ollama                        # placeholder if not required
+GPT4O_BASE_URL=http://localhost:11434/v1   # example: local Ollama/vLLM
+GPT4O_API_KEY=ollama                        # placeholder if not required
 ```
 
 The Postgres defaults (`POSTGRES_USER=aaf`, `POSTGRES_PASSWORD=localdev`,
@@ -93,11 +92,11 @@ tiers but still accepts requests on port 8080.
 | model-router | http://localhost:8080 | LLM proxy |
 | postgres | localhost:5432 | Database with pgvector |
 
-PaperClip and Honcho sit behind the `full` Compose profile. Their Dockerfiles
-build from upstream sources (paperclipai/paperclip, plastic-labs/honcho) not
-included in this repo; you need to clone those first. The full local stack with
-PaperClip at localhost:3099 is a one-command experience in v1.1.
-See [ROADMAP.md](../ROADMAP.md).
+PaperClip and Honcho sit behind the `full` Compose profile. A fresh clone only
+runs the default Postgres + model-router slice; the full profile needs upstream
+PaperClip/Honcho/Hermes source trees staged for the Docker build and is not yet
+a one-command local setup. When that profile is fully staged, PaperClip listens
+on its default port 3100. See [ROADMAP.md](../ROADMAP.md).
 
 ### 3. Add agents and connect chat surfaces
 


### PR DESCRIPTION
## What this changes

Updates `docs/getting-started.md` so the fresh-clone local setup matches the current router env vars and Compose profile behavior.

Closes #1

## Type

- [ ] Bug fix
- [ ] Feature / enhancement
- [x] Documentation
- [ ] Infrastructure (Terraform)

## Validation

Confirm the gates pass (see [CONTRIBUTING.md](../CONTRIBUTING.md)):

- [ ] `terraform validate` passes; both `cost-optimized` and `hardened` profiles `plan` clean
- [x] `docker compose config` is valid (if compose changed)
- [ ] Tests pass (`agents/` and `services/model-router/`)
- [x] `gitleaks` clean — no secrets, no real hostnames or personal data
- [x] Docs updated to match the change

## Notes

- Ran `docker compose config` successfully.
- Ran `python3 -m py_compile services/model-router/main.py` successfully as a lightweight router sanity check.
- Ran a small link check for `docs/getting-started.md`; all local links resolved.
- Could not run `terraform validate` because Terraform is not installed in this environment.
