### PR TITLE
test: cover unknown persona routing fallback

### DIFF
--- a/services/model-router/tests/test_routing.py
+++ b/services/model-router/tests/test_routing.py
@@ -110,6 +110,22 @@ def test_select_tier_persona_lookup():
         main.PERSONA_TIERS.update(original)
 
 
+def test_select_tier_unknown_persona_defaults_to_gpt4o_mini():
+    """An unmapped persona falls back to the default tier instead of erroring."""
+    original = dict(main.PERSONA_TIERS)
+    main.PERSONA_TIERS.clear()
+    main.PERSONA_TIERS["known-persona"] = "phi4"
+    try:
+        tier = main.select_tier({
+            "persona": "unknown-persona",
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+        assert tier == "gpt4o-mini"
+    finally:
+        main.PERSONA_TIERS.clear()
+        main.PERSONA_TIERS.update(original)
+
+
 # ── _build_fallback_chain ────────────────────────────────────────────────────
 
 def test_fallback_chain_is_list_of_registered_tiers():


### PR DESCRIPTION
## What this changes

Adds a focused model-router unit test covering an unmapped persona/role so `select_tier` keeps defaulting to `gpt4o-mini` instead of erroring or selecting an unrelated mapped tier.

Closes #4

## Type

- [ ] Bug fix
- [ ] Feature / enhancement
- [ ] Documentation
- [ ] Infrastructure (Terraform)

## Validation

Confirm the gates pass (see [CONTRIBUTING.md](../CONTRIBUTING.md)):

- [ ] `terraform validate` passes; both `cost-optimized` and `hardened` profiles `plan` clean
- [ ] `docker compose config` is valid (if compose changed)
- [x] Tests pass (`agents/` and `services/model-router/`) — ran `pytest -q tests/test_routing.py` from `services/model-router` (20 passed)
- [ ] `gitleaks` clean — no secrets, no real hostnames or personal data
- [ ] Docs updated to match the change

## Notes

N/A for Terraform, Docker Compose, gitleaks, and docs: this PR only adds a model-router routing unit test.
