### PR TITLE
v1.2: service deployment automation (build → seed → plan → gate → apply → smoke)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,17 @@ jobs:
       - name: docker compose config
         run: docker compose config -q
 
+  scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: bash syntax
+        run: for f in scripts/*.sh; do bash -n "$f"; done
+      - name: shellcheck (errors only)
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y shellcheck
+          shellcheck --severity=error scripts/*.sh
+
   python:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,13 +2,25 @@
 # subscription. It is NOT run by this repo's own CI (which stays validate-only,
 # since the public repo holds no cloud credentials).
 #
-# What it does, and the one idea worth copying:
-#   plan → detect-destroy → apply, where the human-approval gate fires ONLY
-#   when the plan would delete or replace a resource. Routine adds and
-#   image-bump deploys apply unattended; anything destructive blocks on a
-#   GitHub Environment reviewer. The destroy verdict is computed by
-#   installer/detect_destroy.py, which reuses installer.core.plan_has_destroy —
-#   the exact same definition the Forge Console GUI uses, so both agree.
+# Flow:  build ─┐
+#               ├─► plan ─► detect-destroy ─► (gate, only if destructive) ─► apply ─► smoke
+#         seed ─┘
+#
+#   build  — `az acr build` the service images and push to your ACR, then feed
+#            the resolved tag into the plan as -var=<svc>_image_tag. Self-
+#            contained images build from this repo; upstream-dependent ones
+#            (paperclip/honcho/hermes) are skipped until their apps/ sources are
+#            vendored (see scripts/build-and-push.sh + docs/local-development.md).
+#   seed   — idempotently seed Key Vault secrets the apps mount
+#            (scripts/seed-keyvault.sh). Steady-state only; the very first deploy
+#            needs a one-time vault bootstrap — see docs/deploy-pipeline.md.
+#   plan   — terraform plan with the built image tags baked in.
+#   gate   — the one idea worth copying: human approval fires ONLY when the plan
+#            would delete or replace a resource (installer/detect_destroy.py,
+#            the same verdict the Forge Console uses). Routine plans auto-apply.
+#   apply  — applies the SAVED plan verbatim, so what was reviewed is what ships.
+#   smoke  — real post-deploy health probes (scripts/smoke-test.sh →
+#            installer.smoke), non-zero exit fails the run.
 #
 # Auth is OIDC (federated) — no long-lived secrets stored in GitHub. See
 # docs/deploy-pipeline.md for the one-time Azure + GitHub Environment setup.
@@ -32,6 +44,10 @@ on:
         description: "Azure region (e.g. centralus, eastus)"
         type: string
         default: centralus
+      image_tag:
+        description: "Override the built image tag (default: short git SHA)"
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -46,8 +62,82 @@ env:
   ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
 jobs:
-  # ── 1. Plan + classify ──────────────────────────────────────────────────────
+  # ── 1a. Build + push service images ─────────────────────────────────────────
+  # Skips cleanly when CONTAINER_REGISTRY_NAME is unset (infra-only deploy).
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.b.outputs.tag }}
+      built: ${{ steps.b.outputs.built }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: registry configured?
+        id: reg
+        run: echo "name=${{ vars.CONTAINER_REGISTRY_NAME }}" >> "$GITHUB_OUTPUT"
+
+      - uses: azure/login@v2
+        if: steps.reg.outputs.name != ''
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: build and push
+        id: b
+        if: steps.reg.outputs.name != ''
+        run: |
+          TAG="${{ inputs.image_tag }}"
+          [ -n "$TAG" ] || TAG="${GITHUB_SHA::12}"
+          scripts/build-and-push.sh -r "${{ steps.reg.outputs.name }}" -t "$TAG" \
+            --skip-unbuildable --push-latest
+
+      - name: no registry configured
+        if: steps.reg.outputs.name == ''
+        run: echo "CONTAINER_REGISTRY_NAME not set — skipping image build (infra-only deploy)."
+
+  # ── 1b. Seed Key Vault secrets (idempotent) ─────────────────────────────────
+  # Skips cleanly when KEY_VAULT_NAME is unset. First deploy needs the one-time
+  # vault bootstrap documented in docs/deploy-pipeline.md before this can run.
+  seed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: vault configured?
+        id: v
+        run: echo "name=${{ vars.KEY_VAULT_NAME }}" >> "$GITHUB_OUTPUT"
+
+      - uses: azure/login@v2
+        if: steps.v.outputs.name != ''
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: seed secrets
+        if: steps.v.outputs.name != ''
+        env:
+          # External secrets — add the ones your deployment uses. Unset ones are
+          # skipped (you only need keys for the providers/surfaces you enable).
+          AI_FOUNDRY_API_KEY: ${{ secrets.AI_FOUNDRY_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
+          BRAVE_SEARCH_API_KEY: ${{ secrets.BRAVE_SEARCH_API_KEY }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          CF_TUNNEL_TOKEN: ${{ secrets.CF_TUNNEL_TOKEN }}
+          POSTGRES_CONNECTION_STRING: ${{ secrets.POSTGRES_CONNECTION_STRING }}
+          PAPERCLIP_DB_URL: ${{ secrets.PAPERCLIP_DB_URL }}
+        run: scripts/seed-keyvault.sh -v "${{ steps.v.outputs.name }}"
+
+      - name: no vault configured
+        if: steps.v.outputs.name == ''
+        run: echo "KEY_VAULT_NAME not set — skipping secret seeding."
+
+  # ── 2. Plan + classify ──────────────────────────────────────────────────────
   plan:
+    needs: [build, seed]
     runs-on: ubuntu-latest
     outputs:
       has_destroy: ${{ steps.detect.outputs.has_destroy }}
@@ -81,6 +171,27 @@ jobs:
             -backend-config="tenant_id=${{ vars.AZURE_TENANT_ID }}" \
             -backend-config="use_oidc=true"
 
+      # Map the images that were actually built this run to the image-tag vars
+      # the dev environment declares (router/hermes/honcho/paperclip). Images
+      # that were skipped keep whatever tag is already in state/tfvars.
+      - name: compose image-tag vars
+        id: img
+        run: |
+          TAG="${{ needs.build.outputs.tag }}"
+          VARS=""
+          if [ -n "$TAG" ]; then
+            for s in ${{ needs.build.outputs.built }}; do
+              case "$s" in
+                model-router)  VARS="$VARS -var=router_image_tag=$TAG" ;;
+                agent-runtime) VARS="$VARS -var=hermes_image_tag=$TAG" ;;
+                honcho)        VARS="$VARS -var=honcho_image_tag=$TAG" ;;
+                paperclip)     VARS="$VARS -var=paperclip_image_tag=$TAG" ;;
+              esac
+            done
+          fi
+          echo "vars=$VARS" >> "$GITHUB_OUTPUT"
+          echo "image-tag vars: ${VARS:-(none — using existing tags)}"
+
       - name: terraform plan
         working-directory: ${{ env.TF_DIR }}
         run: |
@@ -89,6 +200,7 @@ jobs:
             -var="subscription_id=${{ vars.AZURE_SUBSCRIPTION_ID }}" \
             -var="environment=${{ inputs.environment }}" \
             -var="location=${{ inputs.location }}" \
+            ${{ steps.img.outputs.vars }} \
             -out=tfplan
 
       - name: detect destroy
@@ -108,7 +220,7 @@ jobs:
           retention-days: 5
           if-no-files-found: error
 
-  # ── 2. Human gate — ONLY reached when the plan is destructive ───────────────
+  # ── 3. Human gate — ONLY reached when the plan is destructive ───────────────
   # The `environment:` is what enforces approval: configure required reviewers
   # on a GitHub Environment named `deploy-destroy` (see docs/deploy-pipeline.md).
   # A non-destructive plan skips this job entirely and apply runs unattended.
@@ -124,7 +236,7 @@ jobs:
           echo "Resources to be deleted/replaced:"
           echo "${{ needs.plan.outputs.destroyed }}"
 
-  # ── 3. Apply ────────────────────────────────────────────────────────────────
+  # ── 4. Apply ────────────────────────────────────────────────────────────────
   # Runs when: the plan succeeded AND (it was non-destructive OR the gate was
   # approved). `if: always()` lets it evaluate even though `gate` is skipped on
   # non-destructive plans (a skipped need would otherwise skip apply too).
@@ -167,12 +279,12 @@ jobs:
           path: ${{ env.TF_DIR }}
 
       # Apply the SAVED plan verbatim — never re-plans, so what was reviewed at
-      # the gate is exactly what is applied.
+      # the gate is exactly what is applied (image tags included).
       - name: terraform apply
         working-directory: ${{ env.TF_DIR }}
         run: terraform apply -input=false -lock-timeout=300s tfplan
 
-  # ── 4. Smoke check ──────────────────────────────────────────────────────────
+  # ── 5. Post-deploy smoke check ──────────────────────────────────────────────
   smoke:
     needs: apply
     if: needs.apply.result == 'success'
@@ -187,7 +299,11 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.9.5"
-      - name: terraform output
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: terraform init
         working-directory: ${{ env.TF_DIR }}
         run: |
           terraform init -input=false \
@@ -198,6 +314,12 @@ jobs:
             -backend-config="subscription_id=${{ vars.AZURE_SUBSCRIPTION_ID }}" \
             -backend-config="tenant_id=${{ vars.AZURE_TENANT_ID }}" \
             -backend-config="use_oidc=true"
-          terraform output -no-color || echo "(no outputs defined)"
-      # Adopters: add a real health probe here once your ingress is wired —
-      # e.g. curl the Container Apps FQDN /health, or `az containerapp show`.
+
+      - name: smoke test
+        env:
+          SMOKE_URL: ${{ vars.SMOKE_URL }}
+        run: |
+          RG="$(terraform -chdir=${{ env.TF_DIR }} output -raw resource_group_name)"
+          ARGS=(-g "$RG" -e "${{ inputs.environment }}")
+          [ -n "$SMOKE_URL" ] && ARGS+=(-u "$SMOKE_URL")
+          scripts/smoke-test.sh "${ARGS[@]}"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,23 +33,33 @@ Forge Console and as a **reference CI/CD deploy pipeline**
 traces a destructive request being refused at every layer, backed by **14 golden
 orchestration replay fixtures** ([`tests/replay/`](tests/replay/)).
 
-**Design references.** The [governed-memory architecture](docs/design/memory-system.md)
-— four planes, six classes, computed trust, contradiction detection, and a
-self-improvement loop — is documented to build toward; the governor service code
-is not bundled here.
+**Governed memory, shipped (flag-gated off).** The four-plane, six-class
+[memory model](docs/design/memory-system.md), with admission control, computed
+trust, contradiction detection, hybrid pgvector retrieval, and a
+self-improvement loop, now ships as real code under
+[`services/memory-governor/`](services/memory-governor/) and
+[`services/watchdog/`](services/watchdog/), with ~150 offline tests in CI. Every
+flag seeds off, so it stays inert until you enable it. The explicitly-not-built
+long tail (reflection pass, inspector UI, in-channel controls, contradiction
+auto-resolve) stays design-only.
 
 ## v1.2 — next
 
-Closing the path from "infrastructure provisioned" to "fully running stack in one command":
+Closing the path from "infrastructure provisioned" to "fully running stack in one command".
 
-- Image build and push for PaperClip/Honcho/agent-runtime
-- Key Vault secret seeding
-- Full service deployment automation
-- Post-deploy smoke tests
-- One-command full local stack (`docker compose --profile full up`)
-- Full Microsoft Teams integration
-- Secret-expiry monitoring: the watchdog detector that lists Key Vault secret/cert expiry and files an issue before a lapsed credential takes down the agents that depend on it (code shipped flag-gated off; goes live with the first deploy)
-- First fully validated end-to-end Azure deploy from a clean subscription
+Shipped as the reference deploy pipeline (validated offline; see [deploy-pipeline.md](docs/deploy-pipeline.md)):
+
+- Service deployment automation: a `build → seed → plan → gate → apply → smoke` pipeline ([`.github/workflows/deploy.yml`](.github/workflows/deploy.yml)) wrapping the destroy-aware approval gate.
+- Image build and push via `az acr build`, no local Docker needed ([`scripts/build-and-push.sh`](scripts/build-and-push.sh)). The self-contained images (model-router, memory-governor, watchdog) build from this repo; the upstream-dependent three (paperclip, honcho, agent-runtime) build once their `apps/` sources are vendored, and the script skips them with a logged reason until then.
+- Key Vault secret seeding, idempotent: internal secrets generated, external ones read from the environment ([`scripts/seed-keyvault.sh`](scripts/seed-keyvault.sh)).
+- Post-deploy smoke tests with offline unit-tested verdict logic ([`scripts/smoke-test.sh`](scripts/smoke-test.sh) feeding `installer.smoke`).
+
+Still ahead:
+
+- Vendor the upstream PaperClip/Honcho/Hermes sources so the full image set builds, then the one-command full local stack (`docker compose --profile full up`).
+- Full Microsoft Teams integration.
+- Secret-expiry monitoring goes live: the watchdog detector that lists Key Vault secret/cert expiry and files an issue before a lapsed credential takes down the agents that depend on it (code shipped flag-gated off; activates with the first deploy).
+- First fully validated end-to-end Azure deploy from a clean subscription.
 
 ## Later
 

--- a/docs/deploy-pipeline.md
+++ b/docs/deploy-pipeline.md
@@ -84,10 +84,21 @@ OIDC means these are non-secret identifiers, not credentials:
 | `TFSTATE_RESOURCE_GROUP` | resource group holding the TF state storage account |
 | `TFSTATE_STORAGE_ACCOUNT` | storage account name for remote state |
 | `TFSTATE_CONTAINER` | blob container for state (e.g. `tfstate`) |
+| `CONTAINER_REGISTRY_NAME` | optional. ACR name for the `build` job. Unset means an infra-only deploy with no image build. |
+| `KEY_VAULT_NAME` | optional. Key Vault name for the `seed` job. Unset means seeding is skipped. |
+| `SMOKE_URL` | optional. A URL the `smoke` job probes for a 2xx/3xx response. |
 
 Create the state storage account once (any standard pattern works); the
 pipeline passes these via `terraform init -backend-config=` so no real values
 live in `backend.tf`.
+
+External secrets the `seed` job reads come from repository **secrets** (not
+variables), each named for the Key Vault secret upper-cased with underscores:
+`CLAUDE_API_KEY`, `AI_FOUNDRY_API_KEY`, `OPENAI_API_KEY`, `BRAVE_SEARCH_API_KEY`,
+`TELEGRAM_BOT_TOKEN`, `DISCORD_BOT_TOKEN`, `CF_TUNNEL_TOKEN`,
+`POSTGRES_CONNECTION_STRING`, `PAPERCLIP_DB_URL`. Set only the ones your
+deployment uses; the rest are skipped. `scripts/seed-keyvault.sh --list` prints
+the full inventory.
 
 ### 3. The approval gate - a GitHub **Environment**
 
@@ -107,12 +118,61 @@ profile (`cost-optimized` / `hardened`), and region. Then:
   pauses; you'll see the resources to be deleted in the job summary) → on
   approval, `apply` → `smoke`. Reject, and `apply` is skipped.
 
+## Build, seed, and smoke
+
+Three jobs wrap the plan/apply core so a run goes from source to a checked
+deployment.
+
+**`build`** runs `scripts/build-and-push.sh`, which uses `az acr build` (the
+image is built server-side inside ACR, so the runner needs no Docker daemon).
+The resolved tag (short git SHA by default, or the `image_tag` input) feeds the
+plan as `-var=<service>_image_tag`. Two classes of image exist:
+
+- self-contained (`model-router`, `memory-governor`, `watchdog`) build from this
+  repo alone.
+- upstream-dependent (`paperclip`, `honcho`, `agent-runtime`) need their
+  `apps/<project>/` sources vendored first (see
+  [local development](local-development.md)). The job runs with
+  `--skip-unbuildable`, so until you vendor those sources it builds what it can
+  and skips the rest with a logged reason. `scripts/build-and-push.sh --list`
+  shows the table.
+
+**`seed`** runs `scripts/seed-keyvault.sh`, which idempotently ensures every
+secret the Container Apps mount exists: internal secrets (JWT signing keys,
+admin passwords, `postgres-admin-password`) are generated if absent; external
+ones (provider keys, bot tokens, connection strings) come from the repository
+secrets listed above. Existing secrets are left untouched unless `--force`.
+
+**`smoke`** runs `scripts/smoke-test.sh`, which calls `az containerapp show` for
+the deployed apps (and any `SMOKE_URL`) and pipes the result to
+`installer.smoke`. An app that is not `provisioningState=Succeeded`, or a probe
+that is not 2xx/3xx, exits non-zero and fails the run. The verdict logic is
+unit-tested offline in `installer/tests/test_smoke.py`.
+
+### First deploy: a one-time Key Vault bootstrap
+
+The Key Vault module reads `postgres-admin-password` from the vault as a data
+source (`infrastructure/modules/keyvault/main.tf`), so that secret must exist
+before the first `plan` can resolve. The `seed` job covers steady state but
+cannot seed a vault that does not exist yet. For the first deploy, create the
+vault and seed the password once:
+
+```bash
+# 1. create just the resource group + vault
+terraform -chdir=infrastructure/environments/dev apply \
+  -target=azurerm_resource_group.main -target=module.keyvault
+
+# 2. seed the bootstrap secret (and any others you have ready)
+POSTGRES_CONNECTION_STRING=... scripts/seed-keyvault.sh -v <your-vault-name>
+
+# 3. now run the full pipeline (or terraform apply) as normal
+```
+
+After that, every run's `seed` job keeps the vault current and the bootstrap is
+not needed again.
+
 ## Notes & limits
 
-- This deploys the Azure infrastructure (Terraform). Building and pushing the
-  service container images to your registry is a separate step; point the
-  `*_image_tag` variables at images you've pushed, or extend this workflow with
-  an image-build job ahead of `plan`.
 - `terraform plan` reads remote state and talks to Azure, so the federated SP
   needs read access to the state storage account as well as the subscription.
 - The saved-plan artifact is retained for 5 days; an apply must consume a plan

--- a/installer/smoke.py
+++ b/installer/smoke.py
@@ -1,0 +1,198 @@
+"""Post-deploy smoke verdict for the reference deploy pipeline.
+
+Pure, framework-free pass/fail logic plus a thin CLI. The bash driver
+(``scripts/smoke-test.sh``) collects ``az containerapp show`` JSON for each
+deployed app and optional HTTP probe results, assembles them into one JSON
+document, and pipes it here. Keeping the verdict in plain Python means it is
+unit-testable offline with no Azure calls — the same split as
+``installer.core``/``installer.detect_destroy``.
+
+Unlike ``installer.detect_destroy`` (which always exits 0 and lets the job
+``if:`` conditions gate), smoke is a real gate: an unhealthy or unreadable
+result exits non-zero so the deploy run goes red.
+
+Input document (stdin, or a path passed as the single argument)::
+
+    {
+      "expected": ["ca-paperclip-dev", "ca-hermes-dev"],
+      "apps": [
+        {"name": "ca-paperclip-dev", "show": { ...az containerapp show JSON... }},
+        {"name": "ca-hermes-dev",    "show": { ... }}
+      ],
+      "http": [
+        {"name": "paperclip-ui", "url": "https://...", "status": 200}
+      ]
+    }
+
+An app is healthy when its ``show`` object reports
+``properties.provisioningState == "Succeeded"`` and its ``runningStatus`` is
+not in :data:`RUNNING_BAD`. A missing ``show`` block fails that app
+(fail-closed: we deployed it, so we expect to see it). Any name in
+``expected`` with no matching ``apps`` entry fails. An HTTP probe passes on a
+2xx/3xx status.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+# Container Apps provisioningState we require after a successful deploy.
+PROVISIONING_OK = "Succeeded"
+
+# runningStatus values that mean the app is not serving. Container Apps that
+# scale to zero still report "Running" (replica count is separate), so only
+# explicit failure/stopped states fail the check.
+RUNNING_BAD = {"Failed", "Stopped", "Suspended"}
+
+
+@dataclass
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str
+
+
+@dataclass
+class SmokeReport:
+    ok: bool
+    checks: List[CheckResult] = field(default_factory=list)
+
+    def failures(self) -> List[CheckResult]:
+        return [c for c in self.checks if not c.ok]
+
+
+def _props(show: dict) -> dict:
+    """Container app properties live under .properties; tolerate either shape."""
+    if not isinstance(show, dict):
+        return {}
+    props = show.get("properties")
+    return props if isinstance(props, dict) else show
+
+
+def check_app(entry: dict) -> CheckResult:
+    """Verdict for one ``{"name", "show"}`` entry."""
+    name = (entry or {}).get("name") or "<unnamed>"
+    show = (entry or {}).get("show")
+    if not isinstance(show, dict) or not show:
+        # Fail-closed: an app we expected to read returned nothing.
+        return CheckResult(name, False, "no 'az containerapp show' output (app missing or unreadable)")
+    props = _props(show)
+    state = props.get("provisioningState")
+    running = props.get("runningStatus")
+    if state != PROVISIONING_OK:
+        return CheckResult(name, False, f"provisioningState={state!r} (want {PROVISIONING_OK!r})")
+    if running in RUNNING_BAD:
+        return CheckResult(name, False, f"runningStatus={running!r}")
+    suffix = f", runningStatus={running}" if running else ""
+    return CheckResult(name, True, f"provisioningState={state}{suffix}")
+
+
+def check_http(entry: dict) -> CheckResult:
+    """Verdict for one HTTP probe ``{"name", "url", "status"}`` entry."""
+    name = (entry or {}).get("name") or (entry or {}).get("url") or "<http>"
+    status = (entry or {}).get("status")
+    try:
+        code = int(status)
+    except (TypeError, ValueError):
+        return CheckResult(name, False, f"no/invalid HTTP status ({status!r}) — probe did not complete")
+    if 200 <= code < 400:
+        return CheckResult(name, True, f"HTTP {code}")
+    return CheckResult(name, False, f"HTTP {code}")
+
+
+def evaluate(payload: dict, expected: Optional[List[str]] = None) -> SmokeReport:
+    """Combine app + HTTP + presence checks into one report.
+
+    ``expected`` overrides ``payload['expected']`` when provided. Every expected
+    name must appear in ``payload['apps']`` or it fails as missing.
+    """
+    payload = payload or {}
+    apps = payload.get("apps") or []
+    https = payload.get("http") or []
+    want = expected if expected is not None else (payload.get("expected") or [])
+
+    checks: List[CheckResult] = []
+    seen = set()
+    for entry in apps:
+        res = check_app(entry)
+        seen.add(res.name)
+        checks.append(res)
+
+    for name in want:
+        if name not in seen:
+            checks.append(CheckResult(name, False, "expected app not found in deploy outputs"))
+
+    for entry in https:
+        checks.append(check_http(entry))
+
+    if not checks:
+        # Nothing to assert is itself a failure — a smoke test that checks
+        # nothing must not report success.
+        checks.append(CheckResult("<smoke>", False, "no apps or probes to check"))
+
+    ok = all(c.ok for c in checks)
+    return SmokeReport(ok=ok, checks=checks)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _emit_output(name: str, value: str) -> None:
+    out = os.environ.get("GITHUB_OUTPUT")
+    if not out:
+        return
+    with open(out, "a", encoding="utf-8") as fh:
+        fh.write(f"{name}={value}\n")
+
+
+def _emit_summary(text: str) -> None:
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary:
+        return
+    with open(summary, "a", encoding="utf-8") as fh:
+        fh.write(text + "\n")
+
+
+def _read_payload(argv: List[str]) -> dict:
+    if len(argv) >= 2 and argv[1] not in ("-", "/dev/stdin"):
+        with open(argv[1], encoding="utf-8") as fh:
+            return json.load(fh)
+    return json.load(sys.stdin)
+
+
+def main(argv: List[str]) -> int:
+    try:
+        payload = _read_payload(argv)
+    except (OSError, json.JSONDecodeError) as e:
+        # Fail-closed: an unreadable payload means we cannot confirm health.
+        print(f"[smoke] could not read probe payload ({e}) — FAILING", file=sys.stderr)
+        _emit_output("ok", "false")
+        _emit_summary("### ❌ Smoke check could not read deploy probes")
+        return 1
+
+    report = evaluate(payload)
+
+    for c in report.checks:
+        mark = "✅" if c.ok else "❌"
+        print(f"{mark} {c.name}: {c.detail}")
+
+    if report.ok:
+        _emit_summary("### ✅ Smoke check passed")
+        _emit_summary("\n".join(f"- `{c.name}` — {c.detail}" for c in report.checks))
+    else:
+        fails = report.failures()
+        _emit_summary("### ❌ Smoke check failed")
+        _emit_summary(f"{len(fails)} of {len(report.checks)} check(s) failed:\n")
+        _emit_summary("\n".join(f"- `{c.name}` — {c.detail}" for c in fails))
+
+    _emit_output("ok", "true" if report.ok else "false")
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/installer/tests/test_smoke.py
+++ b/installer/tests/test_smoke.py
@@ -1,0 +1,127 @@
+"""Tests for the post-deploy smoke verdict.
+
+The pure logic (check_app/check_http/evaluate) is exercised directly; the CLI
+contract is checked the same way as test_detect_destroy — but note smoke is a
+real gate, so it exits non-zero on failure (and fail-closed on an unreadable
+payload), unlike the always-exit-0 destroy detector.
+"""
+
+import json
+
+from installer import smoke
+
+
+def _app(name, state="Succeeded", running="Running", show=True):
+    if not show:
+        return {"name": name}
+    return {"name": name, "show": {"properties": {
+        "provisioningState": state, "runningStatus": running}}}
+
+
+# ── pure verdict logic ──────────────────────────────────────────────────────
+
+def test_healthy_app_passes():
+    res = smoke.check_app(_app("ca-paperclip-dev"))
+    assert res.ok
+    assert "Succeeded" in res.detail
+
+
+def test_unprovisioned_app_fails():
+    res = smoke.check_app(_app("ca-x", state="Failed"))
+    assert not res.ok
+    assert "Failed" in res.detail
+
+
+def test_bad_running_status_fails():
+    res = smoke.check_app(_app("ca-x", running="Stopped"))
+    assert not res.ok
+    assert "Stopped" in res.detail
+
+
+def test_missing_show_fails_closed():
+    res = smoke.check_app(_app("ca-x", show=False))
+    assert not res.ok
+    assert "missing" in res.detail.lower() or "unreadable" in res.detail.lower()
+
+
+def test_flat_show_shape_tolerated():
+    # Some `az` shapes put fields at the top level, not under .properties.
+    res = smoke.check_app({"name": "ca-x", "show": {"provisioningState": "Succeeded"}})
+    assert res.ok
+
+
+def test_scale_to_zero_running_is_ok():
+    # Container Apps that scale to zero still report runningStatus "Running".
+    res = smoke.check_app(_app("ca-honcho-dev", running="Running"))
+    assert res.ok
+
+
+def test_http_2xx_3xx_pass_4xx_5xx_fail():
+    assert smoke.check_http({"name": "ui", "status": 200}).ok
+    assert smoke.check_http({"name": "ui", "status": 302}).ok
+    assert not smoke.check_http({"name": "ui", "status": 404}).ok
+    assert not smoke.check_http({"name": "ui", "status": 503}).ok
+    assert not smoke.check_http({"name": "ui", "status": None}).ok
+
+
+def test_evaluate_all_healthy():
+    payload = {"apps": [_app("ca-a"), _app("ca-b")], "http": [{"name": "ui", "status": 200}]}
+    report = smoke.evaluate(payload)
+    assert report.ok
+    assert len(report.checks) == 3
+
+
+def test_evaluate_flags_missing_expected_app():
+    payload = {"expected": ["ca-a", "ca-missing"], "apps": [_app("ca-a")]}
+    report = smoke.evaluate(payload)
+    assert not report.ok
+    fails = [c for c in report.failures()]
+    assert any(c.name == "ca-missing" for c in fails)
+
+
+def test_evaluate_one_bad_app_fails_whole_report():
+    payload = {"apps": [_app("ca-a"), _app("ca-b", state="Failed")]}
+    report = smoke.evaluate(payload)
+    assert not report.ok
+
+
+def test_evaluate_empty_is_failure():
+    report = smoke.evaluate({})
+    assert not report.ok
+
+
+# ── CLI contract ────────────────────────────────────────────────────────────
+
+def _run_cli(tmp_path, monkeypatch, payload_text):
+    out = tmp_path / "gh_output"
+    out.write_text("")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    p = tmp_path / "payload.json"
+    p.write_text(payload_text)
+    rc = smoke.main(["smoke", str(p)])
+    return rc, out.read_text()
+
+
+def test_cli_passes_on_healthy(tmp_path, monkeypatch):
+    payload = json.dumps({"apps": [_app("ca-a")]})
+    rc, output = _run_cli(tmp_path, monkeypatch, payload)
+    assert rc == 0
+    assert "ok=true" in output
+
+
+def test_cli_fails_nonzero_on_unhealthy(tmp_path, monkeypatch):
+    payload = json.dumps({"apps": [_app("ca-a", state="Failed")]})
+    rc, output = _run_cli(tmp_path, monkeypatch, payload)
+    assert rc == 1
+    assert "ok=false" in output
+
+
+def test_cli_fails_closed_on_unreadable_payload(tmp_path, monkeypatch):
+    out = tmp_path / "gh_output"
+    out.write_text("")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    rc = smoke.main(["smoke", str(tmp_path / "nope.json")])
+    assert rc == 1
+    assert "ok=false" in out.read_text()

--- a/scripts/build-and-push.sh
+++ b/scripts/build-and-push.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Build and push the AzureAgentForge service images to an Azure Container Registry.
+#
+# Uses `az acr build` — the build runs server-side inside ACR and the result is
+# pushed there, so NO local Docker daemon is required. The build context is
+# uploaded to ACR and built remotely.
+#
+# Two classes of image:
+#
+#   self-contained   context = the service directory; builds from this repo alone.
+#                    -> model-router, memory-governor, watchdog
+#
+#   upstream-dependent
+#                    context = the repo root; the Dockerfile pulls or COPYs
+#                    upstream project sources that are NOT vendored in this repo
+#                    (see docs/local-development.md). Each needs apps/<project>/
+#                    populated first. This script PREFLIGHTS for those inputs and
+#                    refuses to start a build that would fail partway, unless
+#                    --skip-unbuildable is given.
+#                    -> agent-runtime (image: hermes), honcho, paperclip
+#
+# Image names match the tags Terraform consumes
+# (infrastructure/.../variables.tf *_image_tag): hermes, honcho, router,
+# paperclip, memory-governor, watchdog. cloudflared is a public Docker Hub image
+# and is never built here.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# All buildable services, in build order. cloudflared is intentionally absent.
+ALL_SERVICES="model-router memory-governor watchdog agent-runtime honcho paperclip"
+SELF_CONTAINED="model-router memory-governor watchdog"
+
+# Default build-arg for the paperclip upstream pin (matches the Dockerfile ARG).
+PAPERCLIP_VERSION="${PAPERCLIP_VERSION:-v2026.517.0}"
+
+REGISTRY=""
+TAG=""
+SERVICES=""
+PUSH_LATEST=0
+DRY_RUN=0
+SKIP_UNBUILDABLE=0
+
+die() { echo "error: $*" >&2; exit 2; }
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build-and-push.sh --registry NAME [options]
+
+  -r, --registry NAME    Azure Container Registry name (not the login server). Required.
+  -t, --tag TAG          Image tag. Default: short git SHA, else "latest".
+  -s, --services LIST    Comma-separated subset to build. Default: all buildable.
+      --self-contained   Build only the images this repo can build alone
+                         (model-router, memory-governor, watchdog).
+      --push-latest      Also tag/push :latest alongside the resolved tag.
+      --skip-unbuildable Skip (don't fail) upstream-dependent images whose
+                         apps/<project>/ inputs are not vendored.
+  -n, --dry-run          Print the az commands without running them.
+  -l, --list             Print the service/context table and exit.
+  -h, --help             This help.
+
+Examples:
+  # Build the three self-contained images and push :<sha> + :latest
+  scripts/build-and-push.sh -r myacr --self-contained --push-latest
+
+  # Build everything that can build, skipping un-vendored upstream images
+  scripts/build-and-push.sh -r myacr --skip-unbuildable
+EOF
+}
+
+# image|context(relative to repo root)|dockerfile|class|required-input
+svc_meta() {
+  case "$1" in
+    model-router)    echo "router|services/model-router|services/model-router/Dockerfile|self|" ;;
+    memory-governor) echo "memory-governor|services/memory-governor|services/memory-governor/Dockerfile|self|" ;;
+    watchdog)        echo "watchdog|services/watchdog|services/watchdog/Dockerfile|self|" ;;
+    agent-runtime)   echo "hermes|.|services/agent-runtime/Dockerfile|upstream|apps/hermes/src" ;;
+    honcho)          echo "honcho|.|services/honcho/Dockerfile|upstream|apps/honcho/src" ;;
+    paperclip)       echo "paperclip|.|services/paperclip/Dockerfile|upstream|apps/paperclip" ;;
+    *) return 1 ;;
+  esac
+}
+
+print_table() {
+  printf '%-16s %-16s %-12s %-34s %s\n' SERVICE IMAGE CLASS CONTEXT/DOCKERFILE REQUIRES
+  for s in $ALL_SERVICES; do
+    IFS='|' read -r image context dockerfile class required <<EOF
+$(svc_meta "$s")
+EOF
+    printf '%-16s %-16s %-12s %-34s %s\n' "$s" "$image" "$class" "$context ($dockerfile)" "${required:-—}"
+  done
+}
+
+resolve_tag() {
+  if [ -n "$TAG" ]; then echo "$TAG"; return; fi
+  if git -C "$REPO_ROOT" rev-parse --short HEAD >/dev/null 2>&1; then
+    git -C "$REPO_ROOT" rev-parse --short HEAD
+  else
+    echo "latest"
+  fi
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -r|--registry) REGISTRY="${2:-}"; shift 2 ;;
+    -t|--tag) TAG="${2:-}"; shift 2 ;;
+    -s|--services) SERVICES="${2:-}"; shift 2 ;;
+    --self-contained) SERVICES="$(echo "$SELF_CONTAINED" | tr ' ' ',')"; shift ;;
+    --push-latest) PUSH_LATEST=1; shift ;;
+    --skip-unbuildable) SKIP_UNBUILDABLE=1; shift ;;
+    -n|--dry-run) DRY_RUN=1; shift ;;
+    -l|--list) print_table; exit 0 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1 (try --help)" ;;
+  esac
+done
+
+# Normalize the requested service list.
+if [ -z "$SERVICES" ]; then
+  REQUESTED="$ALL_SERVICES"
+else
+  REQUESTED="$(echo "$SERVICES" | tr ',' ' ')"
+fi
+for s in $REQUESTED; do
+  svc_meta "$s" >/dev/null 2>&1 || die "unknown service '$s'. Known: $ALL_SERVICES"
+done
+
+[ -n "$REGISTRY" ] || [ "$DRY_RUN" -eq 1 ] || die "--registry is required (or use --dry-run)"
+[ -n "$REGISTRY" ] || REGISTRY="<registry>"
+TAG="$(resolve_tag)"
+
+echo "registry=$REGISTRY tag=$TAG dry_run=$DRY_RUN"
+echo "requested: $REQUESTED"
+echo
+
+built="" ; skipped="" ; failed=""
+
+for s in $REQUESTED; do
+  IFS='|' read -r image context dockerfile class required <<EOF
+$(svc_meta "$s")
+EOF
+
+  # Assemble the az acr build command first so the preflight can show it.
+  set -- az acr build --registry "$REGISTRY" --image "$image:$TAG" --file "$dockerfile"
+  [ "$PUSH_LATEST" -eq 1 ] && set -- "$@" --image "$image:latest"
+  [ "$s" = "paperclip" ] && set -- "$@" --build-arg "PAPERCLIP_VERSION=$PAPERCLIP_VERSION"
+  set -- "$@" "$context"
+
+  # Preflight upstream-dependent inputs — each service lands in exactly one bucket.
+  if [ "$class" = "upstream" ] && [ -n "$required" ] && [ ! -e "$REPO_ROOT/$required" ]; then
+    if [ "$DRY_RUN" -eq 1 ]; then
+      echo "SKIP  $s: '$required' not vendored (would run): $*"
+      skipped="$skipped $s"; continue
+    elif [ "$SKIP_UNBUILDABLE" -eq 1 ]; then
+      echo "SKIP  $s: '$required' not vendored — see docs/local-development.md"
+      skipped="$skipped $s"; continue
+    else
+      echo "FAIL  $s: '$required' not vendored — vendor it or pass --skip-unbuildable" >&2
+      failed="$failed $s"; continue
+    fi
+  fi
+
+  echo "BUILD $s -> $image:$TAG"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "    (cd $REPO_ROOT && $*)"
+    built="$built $s"
+    continue
+  fi
+  if ( cd "$REPO_ROOT" && "$@" ); then
+    built="$built $s"
+  else
+    echo "FAIL  $s: az acr build returned non-zero" >&2
+    failed="$failed $s"
+  fi
+done
+
+echo
+echo "built:  ${built:-none}"
+echo "skipped:${skipped:-none}"
+echo "failed: ${failed:-none}"
+
+# Emit the resolved tag for the GitHub Actions step that wires it into Terraform.
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+  echo "built=$(echo "$built" | xargs echo)" >> "$GITHUB_OUTPUT"
+fi
+
+[ -z "$failed" ] || exit 1

--- a/scripts/seed-keyvault.sh
+++ b/scripts/seed-keyvault.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Seed the AzureAgentForge Key Vault with the secrets the Container Apps mount.
+#
+# Idempotent: an existing secret is left untouched unless --force is given.
+# Two categories (the names match what infrastructure/modules/container-apps
+# references, so a deploy can resolve every secretRef):
+#
+#   generate  internal secrets with no external source — created with a random
+#             value if absent. Includes postgres-admin-password, which the
+#             keyvault module reads as a data source and feeds to Postgres, so
+#             it MUST exist before the first `terraform apply`.
+#
+#   external  values that come from you (LLM/provider keys, bot tokens, the
+#             Postgres connection strings). Read from an env var named after the
+#             secret, upper-cased with dashes as underscores
+#             (claude-api-key -> CLAUDE_API_KEY). Unset ones are skipped with a
+#             note — you only need keys for the providers/surfaces you enable.
+#
+# The connection strings (postgres-connection-string, paperclip-db-url) are
+# external on purpose: build them from your `terraform output` after Postgres
+# exists and pass them in, rather than have this script guess a URI shape.
+set -euo pipefail
+
+VAULT=""
+FORCE=0
+DRY_RUN=0
+
+# Internal secrets generated locally if missing.
+GENERATE="postgres-admin-password governor-api-key paperclip-admin-password \
+paperclip-agent-jwt-secret paperclip-auth-secret paperclip-automation-jwt-secret \
+paperclip-automation-token"
+
+# Secrets sourced from the environment.
+EXTERNAL="ai-foundry-api-key brave-search-api-key cf-tunnel-token claude-api-key \
+claude-base-url discord-bot-token gpt4o-api-key grok-api-key grok-base-url \
+kimi-api-key kimi-base-url openai-api-key phi-api-key phi-base-url \
+telegram-bot-token postgres-connection-string paperclip-db-url"
+
+die() { echo "error: $*" >&2; exit 2; }
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/seed-keyvault.sh --vault NAME [options]
+
+  -v, --vault NAME   Key Vault name (the bare name, not the URL). Required.
+      --force        Overwrite secrets that already exist.
+  -n, --dry-run      Print what would happen; never call `az keyvault secret set`.
+  -l, --list         Print the secret inventory (generate vs external) and exit.
+  -h, --help         This help.
+
+External secrets are read from env vars (claude-api-key -> CLAUDE_API_KEY):
+  CLAUDE_API_KEY=... AI_FOUNDRY_API_KEY=... POSTGRES_CONNECTION_STRING=... \
+    scripts/seed-keyvault.sh -v aaf-dev-kv
+
+Run once BEFORE `terraform apply` (so postgres-admin-password exists), then
+again AFTER with the connection strings filled in from `terraform output`.
+EOF
+}
+
+env_name() { echo "$1" | tr 'a-z-' 'A-Z_'; }
+
+gen_value() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 32
+  else
+    # Fallback: still random, no openssl dependency.
+    head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n'
+  fi
+}
+
+secret_exists() {
+  az keyvault secret show --vault-name "$VAULT" --name "$1" >/dev/null 2>&1
+}
+
+set_secret() {
+  # set_secret NAME VALUE
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "    would set: $1"
+    return 0
+  fi
+  az keyvault secret set --vault-name "$VAULT" --name "$1" --value "$2" \
+    --output none && echo "    set: $1"
+}
+
+print_inventory() {
+  echo "generate (random if absent):"
+  for s in $GENERATE; do echo "  - $s"; done
+  echo "external (from env, e.g. $(env_name claude-api-key)):"
+  for s in $EXTERNAL; do echo "  - $s  <- $(env_name "$s")"; done
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -v|--vault) VAULT="${2:-}"; shift 2 ;;
+    --force) FORCE=1; shift ;;
+    -n|--dry-run) DRY_RUN=1; shift ;;
+    -l|--list) print_inventory; exit 0 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1 (try --help)" ;;
+  esac
+done
+
+[ -n "$VAULT" ] || [ "$DRY_RUN" -eq 1 ] || die "--vault is required (or use --dry-run)"
+[ -n "$VAULT" ] || VAULT="<vault>"
+
+echo "vault=$VAULT force=$FORCE dry_run=$DRY_RUN"
+echo
+
+generated=0 ; provided=0 ; kept=0 ; missing=""
+
+echo "generate:"
+for s in $GENERATE; do
+  if [ "$FORCE" -eq 0 ] && [ "$DRY_RUN" -eq 0 ] && secret_exists "$s"; then
+    echo "    keep: $s (exists)"; kept=$((kept + 1)); continue
+  fi
+  set_secret "$s" "$(gen_value)"; generated=$((generated + 1))
+done
+
+echo
+echo "external:"
+for s in $EXTERNAL; do
+  ev="$(env_name "$s")"
+  val="$(printenv "$ev" || true)"
+  if [ -z "$val" ]; then
+    echo "    skip: $s (env $ev unset)"; missing="$missing $s"; continue
+  fi
+  if [ "$FORCE" -eq 0 ] && [ "$DRY_RUN" -eq 0 ] && secret_exists "$s"; then
+    echo "    keep: $s (exists)"; kept=$((kept + 1)); continue
+  fi
+  set_secret "$s" "$val"; provided=$((provided + 1))
+done
+
+echo
+echo "summary: generated=$generated provided=$provided kept=$kept"
+[ -z "$missing" ] || echo "unset external secrets (fine unless you use them):$missing"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Post-deploy smoke test: confirm the deployed Container Apps are healthy.
+#
+# This is the thin collector. It runs `az containerapp show` for each app and
+# optional `curl` HTTP probes, assembles one JSON payload, and pipes it to
+# `python -m installer.smoke`, which holds the pass/fail logic and is unit-
+# tested offline (installer/tests/test_smoke.py). The smoke module exits
+# non-zero on any unhealthy app, so this script's exit code gates the deploy.
+#
+# Default apps are the always-present cost-optimized set (ca-paperclip / ca-hermes
+# / ca-honcho). Add gated ones with --apps when you enable them
+# (memory-governor, cloudflared) or pass an explicit list.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+ENVNAME="dev"
+RG=""
+APPS=""
+EXPECTED=""
+URLS=""
+DRY_RUN=0
+
+die() { echo "error: $*" >&2; exit 2; }
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/smoke-test.sh --resource-group RG [options]
+
+  -g, --resource-group RG  Azure resource group of the deployment. Required.
+  -e, --env ENV            Environment suffix for default app names. Default: dev.
+  -a, --apps "A B C"       Container apps to check. Default: the cost-optimized
+                           core (ca-paperclip-ENV ca-hermes-ENV ca-honcho-ENV).
+      --expected "A B"     Apps that MUST be present. Default: same as --apps.
+  -u, --url URL            HTTP probe (repeatable); passes on 2xx/3xx.
+  -n, --dry-run            Don't call az/curl; show the assembled payload shape.
+  -h, --help               This help.
+
+Exit code is 0 only when every app is provisioned and every probe is 2xx/3xx.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -g|--resource-group) RG="${2:-}"; shift 2 ;;
+    -e|--env) ENVNAME="${2:-}"; shift 2 ;;
+    -a|--apps) APPS="${2:-}"; shift 2 ;;
+    --expected) EXPECTED="${2:-}"; shift 2 ;;
+    -u|--url) URLS="$URLS ${2:-}"; shift 2 ;;
+    -n|--dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1 (try --help)" ;;
+  esac
+done
+
+[ -n "$RG" ] || [ "$DRY_RUN" -eq 1 ] || die "--resource-group is required (or use --dry-run)"
+
+[ -n "$APPS" ] || APPS="ca-paperclip-$ENVNAME ca-hermes-$ENVNAME ca-honcho-$ENVNAME"
+[ -n "$EXPECTED" ] || EXPECTED="$APPS"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "resource_group=${RG:-<rg>} env=$ENVNAME dry_run=$DRY_RUN"
+echo "apps: $APPS"
+[ -n "$URLS" ] && echo "urls:$URLS"
+echo
+
+for app in $APPS; do
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "null" > "$TMP/$app.json"
+    echo "    (dry-run) would: az containerapp show -g $RG -n $app -o json"
+  else
+    az containerapp show -g "$RG" -n "$app" -o json > "$TMP/$app.json" 2>/dev/null \
+      || echo "null" > "$TMP/$app.json"
+  fi
+done
+
+: > "$TMP/http.tsv"
+for url in $URLS; do
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '%s\t0\n' "$url" >> "$TMP/http.tsv"
+  else
+    code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$url" || echo 0)"
+    printf '%s\t%s\n' "$url" "$code" >> "$TMP/http.tsv"
+  fi
+done
+
+# Assemble the payload (JSON plumbing only — no verdict logic lives here).
+python3 - "$TMP" "$APPS" "$EXPECTED" > "$TMP/payload.json" <<'PY'
+import json, os, sys
+tmp, apps_csv, expected_csv = sys.argv[1], sys.argv[2], sys.argv[3]
+apps = []
+for name in apps_csv.split():
+    path = os.path.join(tmp, name + ".json")
+    show = None
+    if os.path.exists(path):
+        try:
+            show = json.load(open(path))
+        except Exception:
+            show = None
+    apps.append({"name": name, "show": show})
+http = []
+ht = os.path.join(tmp, "http.tsv")
+if os.path.exists(ht):
+    for line in open(ht):
+        parts = line.rstrip("\n").split("\t")
+        if len(parts) >= 2 and parts[0]:
+            http.append({"name": parts[0], "url": parts[0], "status": parts[1]})
+json.dump({"expected": expected_csv.split(), "apps": apps, "http": http}, sys.stdout)
+PY
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "assembled payload:"; cat "$TMP/payload.json"; echo; echo
+fi
+
+PYTHONPATH="$REPO_ROOT" python3 -m installer.smoke "$TMP/payload.json"

--- a/services/agent-runtime/Dockerfile
+++ b/services/agent-runtime/Dockerfile
@@ -58,8 +58,8 @@ COPY apps/hermes/overrides/skills skills/
 RUN mkdir -p /home/appuser/.hermes /home/appuser/.honcho && \
     chown -R appuser:appgroup /home/appuser
 
-# Entry point
-COPY --chown=appuser:appgroup apps/hermes/entrypoint.sh /entrypoint.sh
+# Entry point (repo-owned, lives beside this Dockerfile; build context is repo root)
+COPY --chown=appuser:appgroup services/agent-runtime/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # ── Google Workspace CLI (gws) ───────────────────────────────────────────────


### PR DESCRIPTION
Closes the path from "infrastructure provisioned" to "running stack in one command" — the v1.2 reference deploy pipeline, validated offline.

- `build → seed → plan → gate → apply → smoke` pipeline (`.github/workflows/deploy.yml`) wrapping the destroy-aware approval gate; OIDC auth, no stored secrets.
- `scripts/build-and-push.sh` (az acr build, no local Docker), `scripts/seed-keyvault.sh` (idempotent, 24 secret names reconciled vs infra), `scripts/smoke-test.sh` → `installer.smoke`.
- `installer/smoke.py` fail-closed post-deploy verdict + 14 tests (installer suite 19 passing).
- CI scripts-lint job; docs/deploy-pipeline.md + ROADMAP v1.2 refresh.
- Fix: agent-runtime Dockerfile COPYs entrypoint from `services/agent-runtime/` (was a non-existent `apps/hermes/` path).

**Known scope:** 3 of 6 service images build from this repo (model-router, memory-governor, watchdog); the upstream three (paperclip, honcho, agent-runtime) build once their `apps/` sources are vendored — `build-and-push.sh --skip-unbuildable` logs the reason until then. No live Azure deploy run yet (validate-to-plan).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>