### PR TITLE
feat(monitoring): observability alert rules + workbook (opt-in)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,8 +59,9 @@ Still ahead:
 - Vendor the upstream PaperClip/Honcho/Hermes sources so the full image set builds, then the one-command full local stack (`docker compose --profile full up`).
 - Microsoft Teams integration: shipped as the `teams-bridge` service (a Bot Framework messaging endpoint that files inbound Teams messages as Orchestrator issues and replies with Adaptive Cards), gated by the `teams_enabled` variable at parity with Discord/Telegram ([`services/teams-bridge`](services/teams-bridge/), [`integrations/teams`](integrations/teams/)). Internal ingress by default; going live needs the Cloudflare-tunnel exposure + Bot Framework JWT validation noted in the service README.
 - Secret-expiry monitoring goes live: the watchdog detector that lists Key Vault secret/cert expiry and files an issue before a lapsed credential takes down the agents that depend on it. Detector + watchdog wiring shipped and **now unit-tested** (8 boundary tests in `services/watchdog/tests/test_secret_expiry.py`); opt-in via `WATCHDOG_KEY_VAULT_URI`, activates with the first deploy.
+- Observability surface in the monitoring module ([`infrastructure/modules/monitoring`](infrastructure/modules/monitoring/)): three Log Analytics alert rules (watchdog critical findings, Key Vault secret expiry, watchdog run failures) wired to an email action group, plus an Azure Monitor workbook for watchdog activity and gateway health. Queries match the services' existing console-log markers — no app changes. Both opt-in (`alert_emails`, `enable_observability_workbook`); the default footprint is unchanged. `terraform validate` clean.
 - First fully validated end-to-end Azure deploy from a clean subscription.
 
 ## Later
 
-Multi-tenant implementation (the [`roadmap/multi-tenant/`](roadmap/multi-tenant/) design). More chat surfaces. Observability pipeline.
+Multi-tenant implementation (the [`roadmap/multi-tenant/`](roadmap/multi-tenant/) design). More chat surfaces. A fuller observability pipeline (distributed tracing, SLO burn-rate alerts) building on the v1.2 alert rules + workbook.

--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -169,6 +169,12 @@ module "monitoring" {
   tags                  = local.common_tags
   log_retention_in_days = var.log_retention_in_days
   log_daily_quota_gb    = var.log_daily_quota_gb
+
+  # Observability (opt-in). No alert_emails → no action group / alert rules;
+  # workbook off by default. Defaults keep the deploy footprint unchanged.
+  alert_emails                  = var.alert_emails
+  watchdog_app_name             = var.watchdog_app_name
+  enable_observability_workbook = var.enable_observability_workbook
 }
 
 # Outputs

--- a/infrastructure/environments/dev/variables.tf
+++ b/infrastructure/environments/dev/variables.tf
@@ -226,6 +226,25 @@ variable "log_daily_quota_gb" {
   default     = 1
 }
 
+# Observability: alerts + workbook (opt-in)
+variable "alert_emails" {
+  description = "Email recipients for the platform alert action group (watchdog critical findings, secret expiry, watchdog run failures). Empty = no action group / no alert rules created."
+  type        = list(string)
+  default     = []
+}
+
+variable "watchdog_app_name" {
+  description = "Container App/Job name to scope the alert + workbook log queries (e.g. caj-watchdog-dev). Empty matches across all apps on the unique [watchdog] log markers."
+  type        = string
+  default     = ""
+}
+
+variable "enable_observability_workbook" {
+  description = "Create the Azure Monitor observability workbook (watchdog activity, secret expiry, gateway health). Off by default."
+  type        = bool
+  default     = false
+}
+
 # Cloudflared ingress
 variable "cloudflared_enabled" {
   description = "Run the Cloudflared tunnel container for ingress (hardened). When false, use Azure Container Apps managed ingress."

--- a/infrastructure/modules/monitoring/README.md
+++ b/infrastructure/modules/monitoring/README.md
@@ -1,0 +1,58 @@
+# Monitoring module
+
+Log Analytics workspace + Application Insights, plus an **opt-in** observability
+layer: alert rules and an Azure Monitor workbook over the platform's Container
+Apps console logs.
+
+## What it creates
+
+| Resource | When | Notes |
+|---|---|---|
+| `azurerm_log_analytics_workspace` | always | Retention + daily cap are cost-profile tunable. |
+| `azurerm_application_insights` | always | Workspace-based. |
+| `azurerm_monitor_action_group` | `alert_emails` non-empty | Email receivers, common alert schema. |
+| 3× `azurerm_monitor_scheduled_query_rules_alert_v2` | `alert_emails` non-empty | Watchdog critical / secret expiry / watchdog run failure. |
+| `azurerm_application_insights_workbook` | `enable_observability_workbook = true` | One pane: watchdog activity, secret expiry, gateway health. |
+
+Set neither variable and the module is exactly its v1.0 form (workspace +
+App Insights) with no new resources — clean-fork safe.
+
+## The log-marker contract
+
+The alerts and workbook query Container Apps console logs
+(`ContainerAppConsoleLogs_CL`, populated because the managed environment is
+wired to this workspace). They match the stable markers the services already
+emit — no app changes, no structured-logging migration required:
+
+| Signal | Source line | Emitter |
+|---|---|---|
+| Critical finding filed | `[watchdog] filed [critical] …` | `services/watchdog/watchdog.py` |
+| Secret at/near expiry | `[watchdog] filed [...] Key Vault secret '…' …` | `detect_expiring_secrets` → filer |
+| Watchdog internal failure | `[watchdog] … failed: …` / `… refusing to run` (stderr) | `services/watchdog/watchdog.py` |
+| Gateway upstream failure | `call_failed` / `primary_failed` / `fallback_failed` / `passthrough fallback` | `services/model-router/main.py` |
+
+If you rename these markers, update the queries in `alerts.tf` to match.
+
+## Enabling
+
+```hcl
+# infrastructure/environments/dev/<profile>.tfvars  (or -var on the CLI)
+alert_emails                  = ["oncall@example.com"]
+enable_observability_workbook = true
+
+# Optional: scope queries to just the watchdog job. Left empty, the queries
+# match across all apps on the unique [watchdog] markers — which is the safer
+# default, since Container App *Job* log rows don't always populate
+# ContainerAppName_s.
+# watchdog_app_name = "caj-watchdog-dev"
+```
+
+`alert_evaluation_frequency` (default `PT15M`) and `alert_window_duration`
+(default `PT1H`) tune how often each rule runs and how far back it looks.
+
+## Alert semantics
+
+Each rule fires when its query returns **any** row in the window (`Count > 0`),
+with `failing_periods = 1/1` so a single matching log line pages immediately —
+these are low-frequency, high-signal events, not noisy metrics. Severities:
+watchdog-critical = Sev1, secret-expiry and watchdog-failure = Sev2.

--- a/infrastructure/modules/monitoring/alerts.tf
+++ b/infrastructure/modules/monitoring/alerts.tf
@@ -1,0 +1,280 @@
+# Observability: alert rules + workbook over the Log Analytics workspace.
+#
+# Everything here is additive and count-gated so the default deploy footprint
+# is unchanged:
+#   - Alert rules + action group exist only when `alert_emails` is non-empty.
+#   - The workbook exists only when `enable_observability_workbook = true`.
+# A clean fork that sets neither gets exactly the v1.0 monitoring module
+# (workspace + Application Insights) with no new resources.
+#
+# Signals come from Container Apps console logs (the managed environment ships
+# stdout/stderr to this workspace as `ContainerAppConsoleLogs_CL`). The
+# watchdog emits stable, greppable markers:
+#   stdout: "[watchdog] filed [<severity>] <title>"  (one per filed issue)
+#   stderr: "[watchdog] <step> failed: ..."          (fetch/token/flag errors)
+# and the model-router logs "call_failed"/"primary_failed"/"fallback_failed".
+# The queries below match those markers directly.
+
+locals {
+  alerts_enabled = length(var.alert_emails) > 0
+
+  # Optional scoping to the watchdog's container app/job. Empty → match across
+  # all apps in the workspace. Rendered as a KQL line that is a no-op when blank.
+  watchdog_app_filter = (
+    var.watchdog_app_name != ""
+    ? "| where ContainerAppName_s == \"${var.watchdog_app_name}\""
+    : ""
+  )
+}
+
+# ─── Action group (notification target) ──────────────────────────────────────
+resource "azurerm_monitor_action_group" "alerts" {
+  count               = local.alerts_enabled ? 1 : 0
+  name                = "ag-${var.project}-${var.environment}"
+  resource_group_name = var.resource_group_name
+  # short_name is capped at 12 chars by Azure.
+  short_name = substr("aaf${var.environment}", 0, 12)
+  tags       = var.tags
+
+  dynamic "email_receiver" {
+    for_each = var.alert_emails
+    content {
+      name                    = "email-${email_receiver.key}"
+      email_address           = email_receiver.value
+      use_common_alert_schema = true
+    }
+  }
+}
+
+# ─── Alert: watchdog filed a CRITICAL issue ──────────────────────────────────
+# A critical finding (adapter total failure, expired secret, budget blowout)
+# means an agent path is already broken. Page on the first occurrence.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "watchdog_critical" {
+  count                   = local.alerts_enabled ? 1 : 0
+  name                    = "alert-${var.project}-${var.environment}-watchdog-critical"
+  resource_group_name     = var.resource_group_name
+  location                = var.location
+  description             = "The platform watchdog filed a CRITICAL issue — an agent path is broken (adapter failure, expired secret, or budget blowout)."
+  display_name            = "Watchdog: critical issue filed (${var.environment})"
+  severity                = 1
+  enabled                 = true
+  evaluation_frequency    = var.alert_evaluation_frequency
+  window_duration         = var.alert_window_duration
+  scopes                  = [azurerm_log_analytics_workspace.main.id]
+  auto_mitigation_enabled = false
+
+  criteria {
+    query                   = <<-KQL
+      ContainerAppConsoleLogs_CL
+      ${local.watchdog_app_filter}
+      | where Log_s has "[watchdog] filed [critical]"
+    KQL
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.alerts[0].id]
+  }
+
+  tags = var.tags
+}
+
+# ─── Alert: Key Vault secret expiry filed ────────────────────────────────────
+# The secret-expiry detector files an issue before a credential lapses. Catch
+# both the "expires in N days" (high) and "has expired" (critical) variants so
+# the warning lands while there's still time to rotate.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "secret_expiry" {
+  count                   = local.alerts_enabled ? 1 : 0
+  name                    = "alert-${var.project}-${var.environment}-secret-expiry"
+  resource_group_name     = var.resource_group_name
+  location                = var.location
+  description             = "The watchdog flagged a Key Vault secret/cert at or near expiry. Rotate it before the agents that depend on it stall."
+  display_name            = "Watchdog: secret expiry (${var.environment})"
+  severity                = 2
+  enabled                 = true
+  evaluation_frequency    = var.alert_evaluation_frequency
+  window_duration         = var.alert_window_duration
+  scopes                  = [azurerm_log_analytics_workspace.main.id]
+  auto_mitigation_enabled = false
+
+  criteria {
+    query                   = <<-KQL
+      ContainerAppConsoleLogs_CL
+      ${local.watchdog_app_filter}
+      | where Log_s has "[watchdog] filed" and Log_s has "Key Vault secret"
+    KQL
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.alerts[0].id]
+  }
+
+  tags = var.tags
+}
+
+# ─── Alert: watchdog run failure ─────────────────────────────────────────────
+# The watchdog itself failing (MSI token, run/event fetch, flag check, Key
+# Vault list) means the platform is flying blind — no findings get filed at
+# all. Surface its own stderr failures so a dead watchdog doesn't pass silently.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "watchdog_run_failure" {
+  count                   = local.alerts_enabled ? 1 : 0
+  name                    = "alert-${var.project}-${var.environment}-watchdog-failure"
+  resource_group_name     = var.resource_group_name
+  location                = var.location
+  description             = "The watchdog logged an internal failure (token, fetch, flag check, or Key Vault list). It may not be filing findings — the platform is unmonitored until this clears."
+  display_name            = "Watchdog: run failure (${var.environment})"
+  severity                = 2
+  enabled                 = true
+  evaluation_frequency    = var.alert_evaluation_frequency
+  window_duration         = var.alert_window_duration
+  scopes                  = [azurerm_log_analytics_workspace.main.id]
+  auto_mitigation_enabled = false
+
+  criteria {
+    query                   = <<-KQL
+      ContainerAppConsoleLogs_CL
+      ${local.watchdog_app_filter}
+      | where Log_s startswith "[watchdog]" and Log_s has_any ("failed", "refusing to run")
+    KQL
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.alerts[0].id]
+  }
+
+  tags = var.tags
+}
+
+# ─── Observability workbook ──────────────────────────────────────────────────
+# A single pane over watchdog activity, secret expiry, and gateway health.
+# Opt-in (off by default) since it's a convenience surface, not a guardrail.
+locals {
+  # Deterministic GUID for the workbook name (uuid() would churn on every plan).
+  workbook_uuid = uuidv5("url", "aaf-observability-${var.project}-${var.environment}")
+
+  workbook_json = jsonencode({
+    version = "Notebook/1.0"
+    items = [
+      {
+        type = 1
+        content = {
+          json = "# AAF Platform Observability — ${upper(var.environment)}\n\nWatchdog findings, Key Vault secret expiry, and model-router gateway health. All tiles query Container Apps console logs (`ContainerAppConsoleLogs_CL`)."
+        }
+      },
+      {
+        type = 3
+        content = {
+          version      = "KqlItem/1.0"
+          query        = "ContainerAppConsoleLogs_CL\n| where Log_s startswith '[watchdog] filed'\n| summarize Issues = count() by bin(TimeGenerated, 1h)\n| render timechart"
+          size         = 0
+          title        = "Watchdog issues filed (per hour)"
+          timeContext  = { durationMs = 604800000 }
+          queryType    = 0
+          resourceType = "microsoft.operationalinsights/workspaces"
+        }
+      },
+      {
+        type = 3
+        content = {
+          version      = "KqlItem/1.0"
+          query        = "ContainerAppConsoleLogs_CL\n| where Log_s has '[watchdog] filed'\n| parse Log_s with * '[watchdog] filed [' Severity ']' *\n| summarize Count = count() by Severity\n| render piechart"
+          size         = 0
+          title        = "Watchdog findings by severity (7d)"
+          timeContext  = { durationMs = 604800000 }
+          queryType    = 0
+          resourceType = "microsoft.operationalinsights/workspaces"
+        }
+      },
+      {
+        type = 3
+        content = {
+          version      = "KqlItem/1.0"
+          query        = "ContainerAppConsoleLogs_CL\n| where Log_s has '[watchdog] filed' and Log_s has 'Key Vault secret'\n| project TimeGenerated, Finding = Log_s\n| order by TimeGenerated desc"
+          size         = 0
+          title        = "Key Vault secret-expiry findings (7d)"
+          timeContext  = { durationMs = 604800000 }
+          queryType    = 0
+          resourceType = "microsoft.operationalinsights/workspaces"
+        }
+      },
+      {
+        type = 3
+        content = {
+          version      = "KqlItem/1.0"
+          query        = "ContainerAppConsoleLogs_CL\n| where Log_s startswith '[watchdog]' and Log_s has_any ('failed', 'refusing to run')\n| project TimeGenerated, Error = Log_s\n| order by TimeGenerated desc"
+          size         = 0
+          title        = "Watchdog run failures (7d)"
+          timeContext  = { durationMs = 604800000 }
+          queryType    = 0
+          resourceType = "microsoft.operationalinsights/workspaces"
+        }
+      },
+      {
+        type = 3
+        content = {
+          version      = "KqlItem/1.0"
+          query        = "ContainerAppConsoleLogs_CL\n| where Log_s has_any ('call_failed', 'primary_failed', 'fallback_failed', 'passthrough fallback')\n| summarize Failures = count() by bin(TimeGenerated, 1h)\n| render timechart"
+          size         = 0
+          title        = "Model-router upstream failures & fallbacks (per hour)"
+          timeContext  = { durationMs = 604800000 }
+          queryType    = 0
+          resourceType = "microsoft.operationalinsights/workspaces"
+        }
+      }
+    ]
+  })
+}
+
+resource "azurerm_application_insights_workbook" "observability" {
+  count               = var.enable_observability_workbook ? 1 : 0
+  name                = local.workbook_uuid
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  display_name        = "AAF Platform Observability — ${var.environment}"
+  source_id           = lower(azurerm_log_analytics_workspace.main.id)
+  data_json           = local.workbook_json
+  tags                = var.tags
+}
+
+# ─── Outputs ─────────────────────────────────────────────────────────────────
+output "action_group_id" {
+  description = "Resource id of the alert action group (null when no alert_emails set)."
+  value       = local.alerts_enabled ? azurerm_monitor_action_group.alerts[0].id : null
+}
+
+output "alert_rule_ids" {
+  description = "Resource ids of the scheduled-query alert rules (empty when disabled)."
+  value = local.alerts_enabled ? [
+    azurerm_monitor_scheduled_query_rules_alert_v2.watchdog_critical[0].id,
+    azurerm_monitor_scheduled_query_rules_alert_v2.secret_expiry[0].id,
+    azurerm_monitor_scheduled_query_rules_alert_v2.watchdog_run_failure[0].id,
+  ] : []
+}
+
+output "workbook_id" {
+  description = "Resource id of the observability workbook (null when disabled)."
+  value       = var.enable_observability_workbook ? azurerm_application_insights_workbook.observability[0].id : null
+}

--- a/infrastructure/modules/monitoring/variables.tf
+++ b/infrastructure/modules/monitoring/variables.tf
@@ -19,3 +19,35 @@ variable "log_daily_quota_gb" {
   type        = number
   default     = 1
 }
+
+# ─── Observability: alerts + workbook (all opt-in) ───────────────────────────
+
+variable "alert_emails" {
+  description = "Email recipients for the platform alert action group. Empty (default) means no action group and no alert rules are created — the module behaves exactly as v1.0."
+  type        = list(string)
+  default     = []
+}
+
+variable "watchdog_app_name" {
+  description = "Container App (or Job) name of the watchdog, used to scope the alert/workbook log queries. Empty matches across all apps in the workspace."
+  type        = string
+  default     = ""
+}
+
+variable "alert_evaluation_frequency" {
+  description = "How often the scheduled-query alert rules run (ISO 8601 duration). Must be <= alert_window_duration."
+  type        = string
+  default     = "PT15M"
+}
+
+variable "alert_window_duration" {
+  description = "Look-back window each scheduled-query alert evaluates (ISO 8601 duration)."
+  type        = string
+  default     = "PT1H"
+}
+
+variable "enable_observability_workbook" {
+  description = "Create the Azure Monitor workbook (watchdog activity, secret expiry, gateway health). Off by default — it's a convenience surface, not a guardrail."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## What

Extends `infrastructure/modules/monitoring` with an opt-in observability layer over the platform's Container Apps console logs. This is AAF v1.2 plan item #4 (observability pass). Branches off `public/main`.

## Resources (all count-gated)

| Resource | Created when | Severity |
|---|---|---|
| `azurerm_monitor_action_group` (email) | `alert_emails` non-empty | — |
| Alert: watchdog **critical** issue filed | `alert_emails` non-empty | Sev1 |
| Alert: Key Vault **secret expiry** | `alert_emails` non-empty | Sev2 |
| Alert: watchdog **run failure** (flies blind) | `alert_emails` non-empty | Sev2 |
| `azurerm_application_insights_workbook` | `enable_observability_workbook = true` | — |

Set neither variable → the module is exactly its v1.0 form (workspace + App Insights), **no new resources**. Clean-fork safe; default deploy footprint and both cost profiles unchanged.

## The log-marker contract (no app changes)

The queries match the stable markers the services already print — no structured-logging migration needed:

| Signal | Source line | Emitter |
|---|---|---|
| Critical finding filed | `[watchdog] filed [critical] …` | `services/watchdog/watchdog.py` |
| Secret at/near expiry | `[watchdog] filed [...] Key Vault secret '…'` | `detect_expiring_secrets` → filer |
| Watchdog internal failure | `[watchdog] … failed` / `refusing to run` (stderr) | `services/watchdog/watchdog.py` |
| Gateway upstream failure | `call_failed` / `primary_failed` / `fallback_failed` / `passthrough fallback` | `services/model-router/main.py` |

Each alert fires on the first matching line in the window (`Count > 0`, `failing_periods 1/1`) — these are low-frequency, high-signal events, not noisy metrics.

## Workbook tiles

Watchdog issues/hour · findings by severity · secret-expiry findings · watchdog run failures · model-router upstream-failure & fallback rate. Deterministic name via `uuidv5` (no plan churn). Serialized via `jsonencode` so the JSON can't be malformed.

## Wiring

`alert_emails` (list, default `[]`), `watchdog_app_name` (default `""` — matches all apps on the unique `[watchdog]` markers, the safer default since Container App **Job** rows don't reliably populate `ContainerAppName_s`), `enable_observability_workbook` (default `false`), `alert_evaluation_frequency` (`PT15M`), `alert_window_duration` (`PT1H`). Exposed at the module and the dev environment.

## Verification

```
$ terraform fmt -check -recursive infrastructure      # clean
$ cd infrastructure/environments/dev
$ terraform init -backend=false && terraform validate  # Success!
```

Matches CI's terraform job exactly. Plan/apply need Azure creds + state backend (out of scope for CI, same as the rest of the repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)