### PR TITLE
One-command full local stack (docker compose --profile full)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,17 @@
 # Copy this file to .env and fill in real values for local development.
 # In production, all secrets are injected from Azure Key Vault via
 # Container App secret volume mounts. Never commit real values.
+#
+# ── LOCAL FULL STACK (no Azure) ──────────────────────────────────────────────
+# `docker compose --profile full up` (or scripts/local-stack.sh up) runs the
+# whole platform locally. It comes up healthy with NO credentials — every value
+# has a working local default baked into docker-compose.yml, so copying this
+# file to .env unchanged is enough to boot. To actually DRIVE agents, set ONE
+# OpenAI-compatible endpoint (OPENAI_COMPAT_* below):
+#   OpenAI:    OPENAI_COMPAT_BASE_URL=https://api.openai.com/v1   OPENAI_COMPAT_API_KEY=sk-...
+#   Ollama:    OPENAI_COMPAT_BASE_URL=http://host.docker.internal:11434/v1  OPENAI_COMPAT_API_KEY=ollama
+#   LM Studio: OPENAI_COMPAT_BASE_URL=http://host.docker.internal:1234/v1   OPENAI_COMPAT_API_KEY=lm-studio
+# See docs/local-development.md.
 
 # ── LLM Provider ─────────────────────────────────────────────────────────────
 LLM_PROVIDER=azure_foundry

--- a/.github/workflows/local-stack-smoke.yml
+++ b/.github/workflows/local-stack-smoke.yml
@@ -1,0 +1,53 @@
+name: local-stack-smoke
+
+# Heavy (~5 image builds), so scoped to paths that affect the local stack.
+on:
+  push:
+    paths:
+      - 'docker-compose.yml'
+      - 'services/**'
+      - 'apps/**'
+      - 'infrastructure/migrations/**'
+      - 'scripts/smoke-local.sh'
+      - 'scripts/local-stack.sh'
+      - '.env.example'
+      - '.github/workflows/local-stack-smoke.yml'
+  pull_request:
+    paths:
+      - 'docker-compose.yml'
+      - 'services/**'
+      - 'apps/**'
+      - 'infrastructure/migrations/**'
+      - 'scripts/smoke-local.sh'
+      - 'scripts/local-stack.sh'
+      - '.env.example'
+      - '.github/workflows/local-stack-smoke.yml'
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - name: Bring up full stack (no model creds)
+        run: docker compose --profile full up -d --build
+      - name: Wait for healthy
+        run: |
+          deadline=$(( $(date +%s) + 600 ))
+          while :; do
+            unhealthy="$(docker compose ps --format '{{.Service}} {{.Health}}' | awk '$2!="" && $2!="healthy"{print $1}')"
+            [ -z "$unhealthy" ] && break
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "timeout; unhealthy: $unhealthy"; docker compose ps; docker compose logs; exit 1
+            fi
+            sleep 10
+          done
+      - name: Smoke
+        run: bash scripts/smoke-local.sh
+      - name: Logs on failure
+        if: failure()
+        run: docker compose logs
+      - name: Teardown
+        if: always()
+        run: docker compose --profile full down -v

--- a/.github/workflows/local-stack-smoke.yml
+++ b/.github/workflows/local-stack-smoke.yml
@@ -47,7 +47,9 @@ jobs:
         run: bash scripts/smoke-local.sh
       - name: Logs on failure
         if: failure()
-        run: docker compose logs
+        run: |
+          docker compose --profile full ps -a
+          docker compose --profile full logs --no-color
       - name: Teardown
         if: always()
         run: docker compose --profile full down -v

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ As of v1.1, AzureAgentForge includes:
 - Governed memory: governor service, retrieval planner, background loops, hybrid vector retrieval, and self-improvement watchdog (shipped, flag-gated off)
 - Multi-tenant architecture design and early scaffolding
 
-The current local quickstart brings up PostgreSQL and the model router. The full one-command local stack and full end-to-end Azure installer are planned for v1.2.
+The current local quickstart brings up PostgreSQL and the model router; the full platform runs locally with one command (`scripts/local-stack.sh up`, or `docker compose --profile full up`). The full end-to-end Azure installer is planned for v1.2.
 
 ---
 
@@ -374,7 +374,7 @@ docker compose --profile full up
 
 plus upstream sources.
 
-A one-command full local stack is planned for v1.2.
+A one-command full local stack is available: `scripts/local-stack.sh up` (see [`docs/local-development.md`](docs/local-development.md)).
 
 See [`docs/getting-started.md`](docs/getting-started.md) for the full local walkthrough.
 
@@ -468,7 +468,7 @@ See [`docs/getting-started.md`](docs/getting-started.md) for the full Azure walk
 - ⬜ Key Vault secret seeding
 - ⬜ Full service deployment automation
 - ⬜ Smoke tests after deployment
-- ⬜ One-command full local stack (`docker compose --profile full up`)
+- ✅ One-command full local stack (`docker compose --profile full up`)
 - ⬜ Full Microsoft Teams integration
 - ⬜ First fully validated end-to-end Azure deployment from a clean subscription
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,12 +39,18 @@ services:
 
   # ── full profile ───────────────────────────────────────────────────────────
   # One-shot: applies the governor migrations (agent_events, feature_flags,
-  # memory_classes, …) to Postgres, then exits. Idempotent.
+  # memory_classes, …) to Postgres, then exits. Idempotent. Runs AFTER Honcho so
+  # the `documents` table exists (0002 ALTERs it) — Honcho owns that table.
   migrate:
     profiles: ["full"]
     image: pgvector/pgvector:pg16
     depends_on:
       postgres:
+        condition: service_healthy
+      # Honcho's entrypoint runs `alembic upgrade head` (creating `documents`)
+      # before it serves /openapi.json, so honcho-healthy ⟹ the table exists.
+      # (In Azure these migrations run as a later, post-deploy pipeline stage.)
+      honcho:
         condition: service_healthy
     volumes: ["./infrastructure/migrations:/migrations:ro"]
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,13 @@ services:
       # psycopg3 scheme — NOT DATABASE_URL. Wrong/unset → it falls back to its
       # localhost default and exits 1.
       DB_CONNECTION_URI: postgresql+psycopg://${POSTGRES_USER:-aaf}:${POSTGRES_PASSWORD:-localdev}@postgres:5432/${POSTGRES_DB:-aaf}
+      # Honcho constructs an LLM client per specialist AT IMPORT (deriver/summary
+      # default to google, dream to anthropic) and raises "Missing client" if the
+      # key is absent. Placeholder keys let it BOOT with no creds; the deriver's
+      # actual memory processing needs real keys (override to drive it).
+      LLM_ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-localdev-honcho-placeholder}
+      LLM_OPENAI_API_KEY: ${OPENAI_API_KEY:-localdev-honcho-placeholder}
+      LLM_GEMINI_API_KEY: ${GEMINI_API_KEY:-localdev-honcho-placeholder}
     ports: ["${HONCHO_PORT:-8000}:8000"]
 
   # Bundles the Hermes runtime (the adapter spawns it per task in-container).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
-# Default `docker compose up` starts the working slice: Postgres + model-router.
-# To additionally build PaperClip + Honcho (requires their upstream project
-# sources — see ROADMAP / docs): docker compose --profile full up
+# Default `docker compose up` = working slice: Postgres + model-router.
+# Full platform locally (no Azure):  docker compose --profile full up
+# Or use the wrapper:                scripts/local-stack.sh up
+# See .env.example and docs/local-development.md.
 
 services:
   postgres:
@@ -9,8 +10,13 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-aaf}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-localdev}
       POSTGRES_DB: ${POSTGRES_DB:-aaf}
-    ports: ["5432:5432"]
+    ports: ["${POSTGRES_PORT:-5432}:5432"]
     volumes: ["pgdata:/var/lib/postgresql/data"]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-aaf} -d ${POSTGRES_DB:-aaf}"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
 
   model-router:
     build: ./services/model-router
@@ -24,34 +30,124 @@ services:
       GPT4O_API_KEY: ${GPT4O_API_KEY:-${AZURE_FOUNDRY_API_KEY:-}}
       OPENAI_COMPAT_BASE_URL: ${OPENAI_COMPAT_BASE_URL:-}
       OPENAI_COMPAT_API_KEY: ${OPENAI_COMPAT_API_KEY:-}
-    ports: ["8080:8080"]
+    ports: ["${ROUTER_PORT:-8080}:8080"]
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8080/health').status==200 else 1)\""]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  # ── full profile ───────────────────────────────────────────────────────────
+  # One-shot: applies the governor migrations (agent_events, feature_flags,
+  # memory_classes, …) to Postgres, then exits. Idempotent.
+  migrate:
+    profiles: ["full"]
+    image: pgvector/pgvector:pg16
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes: ["./infrastructure/migrations:/migrations:ro"]
+    environment:
+      PGHOST: postgres
+      PGUSER: ${POSTGRES_USER:-aaf}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-localdev}
+      PGDATABASE: ${POSTGRES_DB:-aaf}
+    entrypoint:
+      - sh
+      - -c
+      - |
+        set -e
+        for f in /migrations/*.sql; do
+          echo "[migrate] applying $${f}"
+          psql -v ON_ERROR_STOP=1 -f "$${f}"
+        done
+        echo "[migrate] all migrations applied"
+    restart: "no"
 
   honcho:
     profiles: ["full"]
-    build: ./services/honcho
-    depends_on: [postgres]
+    build:
+      context: .
+      dockerfile: services/honcho/Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-aaf}:${POSTGRES_PASSWORD:-localdev}@postgres:5432/${POSTGRES_DB:-aaf}
+    ports: ["${HONCHO_PORT:-8000}:8000"]
 
-  # Governed-memory sidecar. Every behavior is flag-gated OFF (the migrations
-  # under infrastructure/migrations/ seed every flag false), so with a fresh DB
-  # this is an idle app and /admit returns "disabled" until you flip a flag.
+  # Bundles the Hermes runtime (the adapter spawns it per task in-container).
+  paperclip:
+    profiles: ["full"]
+    build:
+      context: .
+      dockerfile: services/paperclip/Dockerfile
+      args:
+        PAPERCLIP_VERSION: ${PAPERCLIP_VERSION:-v2026.517.0}
+        PAPERCLIP_EXPECTED_SHA: ${PAPERCLIP_EXPECTED_SHA:-3e6610fb938d04638fa578a1fc0d119b434fa2e4}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+      model-router:
+        condition: service_healthy
+      honcho:
+        condition: service_started
+    environment:
+      PORT: "3100"
+      OPENAI_BASE_URL: http://model-router:8080/v1
+      HONCHO_BASE_URL: http://honcho:8000
+      GOVERNOR_BASE_URL: http://memory-governor:8090
+      PAPERCLIP_AUTOMATION_JWT_SECRET: ${PAPERCLIP_AUTOMATION_JWT_SECRET:-localdev-automation-secret-change-me}
+      PAPERCLIP_AGENT_JWT_SECRET: ${PAPERCLIP_AGENT_JWT_SECRET:-localdev-agent-secret-change-me}
+      PAPERCLIP_ADMIN_EMAIL: ${PAPERCLIP_ADMIN_EMAIL:-admin@localhost}
+      PAPERCLIP_ADMIN_PASSWORD: ${PAPERCLIP_ADMIN_PASSWORD:-localdev-admin-change-me}
+    ports: ["${PAPERCLIP_PORT:-3100}:3100"]
+    volumes: ["paperclip-data:/paperclip"]
+
+  # Governed-memory sidecar. Every behavior is flag-gated OFF (migrations seed
+  # all flags false), so it idles and /admit returns "disabled" with a fresh DB.
   memory-governor:
     profiles: ["full"]
     build: ./services/memory-governor
-    depends_on: [postgres, model-router, honcho]
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+      model-router:
+        condition: service_healthy
+      honcho:
+        condition: service_started
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-aaf}:${POSTGRES_PASSWORD:-localdev}@postgres:5432/${POSTGRES_DB:-aaf}
       ROUTER_BASE_URL: http://model-router:8080/v1
       HONCHO_BASE_URL: http://honcho:8000
       GOVERNOR_API_KEY: ${GOVERNOR_API_KEY:-localdev}
-    ports: ["8090:8090"]
+    ports: ["${GOVERNOR_PORT:-8090}:8090"]
 
-  paperclip:
+  # Self-improvement watchdog. A one-shot: it self-mints a JWT from the secret,
+  # checks AGENT_EVENTS_ENABLED in the DB (seeded false), prints "nothing to do"
+  # and exits 0. Present so the full platform is complete; inert until flags flip.
+  watchdog:
     profiles: ["full"]
-    build: ./services/paperclip
-    depends_on: [postgres, model-router, honcho]
-    ports: ["3099:3099"]
+    build: ./services/watchdog
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    environment:
+      AGENT_EVENTS_DSN: postgresql://${POSTGRES_USER:-aaf}:${POSTGRES_PASSWORD:-localdev}@postgres:5432/${POSTGRES_DB:-aaf}
+      WATCHDOG_COMPANY_ID: local
+      WATCHDOG_BASE_URL: http://paperclip:3100
+      PAPERCLIP_AUTOMATION_JWT_SECRET: ${PAPERCLIP_AUTOMATION_JWT_SECRET:-localdev-automation-secret-change-me}
+      GOVERNOR_BASE_URL: http://memory-governor:8090
+      GOVERNOR_API_KEY: ${GOVERNOR_API_KEY:-localdev}
+      GOVERNOR_WORKSPACE: local
+    restart: "no"
 
 volumes:
   pgdata:
+  paperclip-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,10 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-aaf}:${POSTGRES_PASSWORD:-localdev}@postgres:5432/${POSTGRES_DB:-aaf}
+      # Honcho reads DB_CONNECTION_URI (pydantic env_prefix DB_) with the
+      # psycopg3 scheme — NOT DATABASE_URL. Wrong/unset → it falls back to its
+      # localhost default and exits 1.
+      DB_CONNECTION_URI: postgresql+psycopg://${POSTGRES_USER:-aaf}:${POSTGRES_PASSWORD:-localdev}@postgres:5432/${POSTGRES_DB:-aaf}
     ports: ["${HONCHO_PORT:-8000}:8000"]
 
   # Bundles the Hermes runtime (the adapter spawns it per task in-container).

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -7,11 +7,12 @@
 
 # Local development
 
-`docker compose up` starts two services: Postgres and the model-router. That is
-the v1.0 working slice, enough to develop and test LLM routing without the
-rest of the stack. PaperClip and Honcho need `docker compose --profile full up`
-plus upstream project sources; that becomes one-command in v1.1. You need Docker
-Desktop and an LLM endpoint: Azure AI Foundry or anything OpenAI-compatible.
+`docker compose up` starts two services: Postgres and the model-router — the
+working slice, enough to develop and test LLM routing. The **whole platform**
+runs locally with one command: `scripts/local-stack.sh up` (or
+`docker compose --profile full up`). It comes up healthy with **no credentials**;
+to drive agents, point it at any OpenAI-compatible endpoint. You need Docker
+Desktop; an LLM endpoint is optional until you want to run agents.
 
 ---
 
@@ -58,6 +59,42 @@ Postgres data persists in the `pgdata` named volume between restarts.
 
 ---
 
+## Full local stack (no Azure)
+
+```bash
+scripts/local-stack.sh up
+```
+
+This initializes the upstream submodules if needed, creates `.env` from
+`.env.example`, builds and starts the `full` profile, waits for health, runs the
+smoke gate, and prints the URLs:
+
+| Service | URL | Notes |
+|---|---|---|
+| PaperClip UI / API | http://localhost:3100 | bundles the Hermes runtime |
+| Model router | http://localhost:8080 | |
+| Honcho (memory) | http://localhost:8000 | |
+| Memory governor | http://localhost:8090 | flag-off / idle (`/admit` → `disabled`) |
+
+The stack comes up **healthy with no credentials**. The watchdog runs once, sees
+its flag off, and exits cleanly. To actually **drive agents**, set ONE
+OpenAI-compatible endpoint in `.env` and restart:
+
+```bash
+# .env  (Ollama / LM Studio run on your host → use host.docker.internal)
+OPENAI_COMPAT_BASE_URL=https://api.openai.com/v1
+OPENAI_COMPAT_API_KEY=sk-...
+```
+
+```bash
+scripts/local-stack.sh down && scripts/local-stack.sh up
+```
+
+Other wrapper commands: `scripts/local-stack.sh smoke` (re-run the health gate),
+`logs [service]`, and `down -v` (drop volumes). Ports are overridable in `.env`.
+
+---
+
 ## Iterating on a service
 
 To rebuild a single service after editing its code:
@@ -85,14 +122,16 @@ They build from upstream base images. If an upstream image changes its
 interface, the build may break. Check `services/<name>/Dockerfile` for the
 exact base and pin if you need reproducibility.
 
-PaperClip and Honcho are behind the `full` Compose profile
-(`docker compose --profile full up`). Their Dockerfiles reference upstream
-projects (paperclipai/paperclip, plastic-labs/honcho) not vendored in this
-repo; you need to clone those sources before building. The one-command full
-local stack is v1.1.
+PaperClip, Honcho, the memory-governor, and the watchdog are behind the `full`
+Compose profile (`docker compose --profile full up`). The Hermes and Honcho
+upstream sources are vendored as git submodules under `apps/*/src` and the
+wrapper auto-initializes them; PaperClip is pulled at build time from the pinned
+upstream. No manual cloning is needed.
 
-The `agent-runtime` service has a Dockerfile in `services/agent-runtime/`
-but no entry in `docker-compose.yml`. It is not part of the local stack.
+The `agent-runtime` service (the standalone Hermes / Telegram gateway) has a
+Dockerfile in `services/agent-runtime/` but is **not** part of the local stack:
+the PaperClip image already bundles the Hermes runtime it spawns per task, and
+the gateway needs a bot token.
 
 There is no hot-reload. After changing source files in a service, you need
 to rebuild that container (`docker compose up --build <service>`).

--- a/docs/superpowers/plans/2026-06-19-full-local-stack.md
+++ b/docs/superpowers/plans/2026-06-19-full-local-stack.md
@@ -1,0 +1,574 @@
+# Full Local Stack Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `docker compose --profile full up` bring up the whole AzureAgentForge platform locally with no Azure account, verified by a no-creds smoke gate.
+
+**Architecture:** Repair and complete the single-file `full` compose profile (correct build contexts, a one-shot migration runner, service env + dev-only secrets, healthchecks and ordering), add `.env.example`, a `smoke-local.sh` no-creds health gate, a `local-stack.sh` wrapper, and a path-scoped CI smoke workflow. Builds on PR #17 (which made all 7 images buildable).
+
+**Tech Stack:** Docker Compose v2, Postgres (pgvector), bash, GitHub Actions. Spec: `docs/superpowers/specs/2026-06-19-full-local-stack-design.md`.
+
+**Verification note:** the authoring machine has **no Docker daemon**, so per-task verification is static (`python3` YAML parse, `bash -n`, `shellcheck` if present). The live `up`+smoke integration runs in **CI / on the operator's machine** (Task 8). Confirm-during-implementation items are flagged inline.
+
+---
+
+### Task 1: `.env.example`
+
+**Files:**
+- Create: `.env.example`
+- Verify: `.gitignore` already ignores `.env` and un-ignores `.env.example` (lines `.env`, `.env.*`, `!.env.example`).
+
+- [ ] **Step 1: Write `.env.example`**
+
+```bash
+# AzureAgentForge — local full-stack config. Copy to .env (gitignored) and edit.
+#   docker compose --profile full up      (or: scripts/local-stack.sh up)
+
+# ── Model backend — the ONE thing to set to DRIVE agents ─────────────────────
+# The stack comes up healthy WITHOUT this; model calls return a clear error
+# until you point it at any OpenAI-compatible endpoint. Pick one:
+#   OpenAI:    OPENAI_COMPAT_BASE_URL=https://api.openai.com/v1   OPENAI_COMPAT_API_KEY=sk-...
+#   Ollama:    OPENAI_COMPAT_BASE_URL=http://host.docker.internal:11434/v1  OPENAI_COMPAT_API_KEY=ollama
+#   LM Studio: OPENAI_COMPAT_BASE_URL=http://host.docker.internal:1234/v1   OPENAI_COMPAT_API_KEY=lm-studio
+OPENAI_COMPAT_BASE_URL=
+OPENAI_COMPAT_API_KEY=
+
+# ── Postgres (local dev defaults) ────────────────────────────────────────────
+POSTGRES_USER=aaf
+POSTGRES_PASSWORD=localdev
+POSTGRES_DB=aaf
+
+# ── DEV ONLY — DO NOT USE IN PRODUCTION ──────────────────────────────────────
+# Well-known placeholders so the stack runs with zero setup. A real deploy
+# injects these from Key Vault.
+PAPERCLIP_AUTOMATION_JWT_SECRET=localdev-automation-secret-change-me
+PAPERCLIP_AGENT_JWT_SECRET=localdev-agent-secret-change-me
+PAPERCLIP_ADMIN_EMAIL=admin@localhost
+PAPERCLIP_ADMIN_PASSWORD=localdev-admin-change-me
+GOVERNOR_API_KEY=localdev
+
+# ── Host port overrides (change if a port is already in use) ──────────────────
+POSTGRES_PORT=5432
+ROUTER_PORT=8080
+PAPERCLIP_PORT=3100
+HONCHO_PORT=8000
+GOVERNOR_PORT=8090
+
+# ── PaperClip upstream pin (matches scripts/build-and-push.sh) ────────────────
+PAPERCLIP_VERSION=v2026.517.0
+PAPERCLIP_EXPECTED_SHA=3e6610fb938d04638fa578a1fc0d119b434fa2e4
+```
+
+- [ ] **Step 2: Verify gitignore + no real secrets**
+
+Run: `git check-ignore .env && echo ok; grep -nE 'sk-[A-Za-z0-9]{20,}|BEGIN .*PRIVATE KEY' .env.example && echo LEAK || echo clean`
+Expected: `ok` then `clean`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .env.example
+git commit -m "feat(local): .env.example for the full local stack"
+```
+
+---
+
+### Task 2: Rewrite `docker-compose.yml` (build contexts, healthchecks, ports, full services)
+
+**Files:**
+- Modify: `docker-compose.yml` (replace whole file)
+
+This replaces the broken skeleton. Key fixes: `honcho`/`paperclip` build with `context: .` + `dockerfile:`; add `migrate`; add `watchdog`; wire env; add healthchecks + ordering; port overrides; named `paperclip-data` volume.
+
+- [ ] **Step 1: Write the full `docker-compose.yml`**
+
+```yaml
+# Default `docker compose up` = working slice: Postgres + model-router.
+# Full platform locally (no Azure):  docker compose --profile full up
+# Or use the wrapper:                scripts/local-stack.sh up
+# See .env.example and docs/local-development.md.
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-aaf}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-localdev}
+      POSTGRES_DB: ${POSTGRES_DB:-aaf}
+    ports: ["${POSTGRES_PORT:-5432}:5432"]
+    volumes: ["pgdata:/var/lib/postgresql/data"]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-aaf} -d ${POSTGRES_DB:-aaf}"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  model-router:
+    build: ./services/model-router
+    environment:
+      LLM_PROVIDER: ${LLM_PROVIDER:-azure_foundry}
+      AZURE_FOUNDRY_ENDPOINT: ${AZURE_FOUNDRY_ENDPOINT:-}
+      AZURE_FOUNDRY_API_KEY: ${AZURE_FOUNDRY_API_KEY:-}
+      GPT4O_BASE_URL: ${GPT4O_BASE_URL:-${AZURE_FOUNDRY_ENDPOINT:-}}
+      GPT4O_API_KEY: ${GPT4O_API_KEY:-${AZURE_FOUNDRY_API_KEY:-}}
+      OPENAI_COMPAT_BASE_URL: ${OPENAI_COMPAT_BASE_URL:-}
+      OPENAI_COMPAT_API_KEY: ${OPENAI_COMPAT_API_KEY:-}
+    ports: ["${ROUTER_PORT:-8080}:8080"]
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8080/health').status==200 else 1)\""]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  # ── full profile ───────────────────────────────────────────────────────────
+  migrate:
+    profiles: ["full"]
+    image: pgvector/pgvector:pg16
+    depends_on:
+      postgres: { condition: service_healthy }
+    volumes: ["./infrastructure/migrations:/migrations:ro"]
+    environment:
+      PGHOST: postgres
+      PGUSER: ${POSTGRES_USER:-aaf}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-localdev}
+      PGDATABASE: ${POSTGRES_DB:-aaf}
+    entrypoint:
+      - sh
+      - -c
+      - |
+        set -e
+        for f in /migrations/*.sql; do
+          echo "[migrate] applying $${f}"
+          psql -v ON_ERROR_STOP=1 -f "$${f}"
+        done
+        echo "[migrate] all migrations applied"
+    restart: "no"
+
+  honcho:
+    profiles: ["full"]
+    build:
+      context: .
+      dockerfile: services/honcho/Dockerfile
+    depends_on:
+      postgres: { condition: service_healthy }
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-aaf}:${POSTGRES_PASSWORD:-localdev}@postgres:5432/${POSTGRES_DB:-aaf}
+    ports: ["${HONCHO_PORT:-8000}:8000"]
+
+  paperclip:
+    profiles: ["full"]
+    build:
+      context: .
+      dockerfile: services/paperclip/Dockerfile
+      args:
+        PAPERCLIP_VERSION: ${PAPERCLIP_VERSION:-v2026.517.0}
+        PAPERCLIP_EXPECTED_SHA: ${PAPERCLIP_EXPECTED_SHA:-3e6610fb938d04638fa578a1fc0d119b434fa2e4}
+    depends_on:
+      postgres: { condition: service_healthy }
+      migrate: { condition: service_completed_successfully }
+      model-router: { condition: service_healthy }
+      honcho: { condition: service_started }
+    environment:
+      PORT: "3100"
+      OPENAI_BASE_URL: http://model-router:8080/v1
+      HONCHO_BASE_URL: http://honcho:8000
+      GOVERNOR_BASE_URL: http://memory-governor:8090
+      PAPERCLIP_AUTOMATION_JWT_SECRET: ${PAPERCLIP_AUTOMATION_JWT_SECRET:-localdev-automation-secret-change-me}
+      PAPERCLIP_AGENT_JWT_SECRET: ${PAPERCLIP_AGENT_JWT_SECRET:-localdev-agent-secret-change-me}
+      PAPERCLIP_ADMIN_EMAIL: ${PAPERCLIP_ADMIN_EMAIL:-admin@localhost}
+      PAPERCLIP_ADMIN_PASSWORD: ${PAPERCLIP_ADMIN_PASSWORD:-localdev-admin-change-me}
+    ports: ["${PAPERCLIP_PORT:-3100}:3100"]
+    volumes: ["paperclip-data:/paperclip"]
+
+  memory-governor:
+    profiles: ["full"]
+    build: ./services/memory-governor
+    depends_on:
+      postgres: { condition: service_healthy }
+      migrate: { condition: service_completed_successfully }
+      model-router: { condition: service_healthy }
+      honcho: { condition: service_started }
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-aaf}:${POSTGRES_PASSWORD:-localdev}@postgres:5432/${POSTGRES_DB:-aaf}
+      ROUTER_BASE_URL: http://model-router:8080/v1
+      HONCHO_BASE_URL: http://honcho:8000
+      GOVERNOR_API_KEY: ${GOVERNOR_API_KEY:-localdev}
+    ports: ["${GOVERNOR_PORT:-8090}:8090"]
+
+  watchdog:
+    profiles: ["full"]
+    build: ./services/watchdog
+    depends_on:
+      postgres: { condition: service_healthy }
+      migrate: { condition: service_completed_successfully }
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-aaf}:${POSTGRES_PASSWORD:-localdev}@postgres:5432/${POSTGRES_DB:-aaf}
+      ROUTER_BASE_URL: http://model-router:8080/v1
+      GOVERNOR_BASE_URL: http://memory-governor:8090
+      GOVERNOR_API_KEY: ${GOVERNOR_API_KEY:-localdev}
+
+volumes:
+  pgdata:
+  paperclip-data:
+```
+
+**Confirm during implementation:**
+- model-router `GET /health` returns 200 **without** provider creds (liveness, not provider check). Grep `services/model-router/main.py:1387` region. If it depends on creds, switch the healthcheck to a TCP/port liveness probe.
+- `watchdog` required env — read `services/watchdog/src/watchdog/watchdog.py`; add any missing required vars (it reads governance flags from the DB, which seed off, so it idles).
+
+- [ ] **Step 2: Validate YAML parses**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('docker-compose.yml')); print('yaml ok')"`
+Expected: `yaml ok`
+
+- [ ] **Step 3: Assert structure**
+
+Run:
+```bash
+python3 - <<'PY'
+import yaml
+c=yaml.safe_load(open('docker-compose.yml'))['services']
+default=[s for s,v in c.items() if 'profiles' not in v]
+full=[s for s,v in c.items() if v.get('profiles')==['full']]
+assert set(default)=={'postgres','model-router'}, default
+assert set(full)=={'migrate','honcho','paperclip','memory-governor','watchdog'}, full
+assert c['paperclip']['build']['dockerfile']=='services/paperclip/Dockerfile'
+assert c['honcho']['build']['dockerfile']=='services/honcho/Dockerfile'
+print('structure ok')
+PY
+```
+Expected: `structure ok`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docker-compose.yml
+git commit -m "feat(local): full compose profile — contexts, migrate, healthchecks, watchdog"
+```
+
+---
+
+### Task 3: `scripts/smoke-local.sh` — no-creds health gate
+
+**Files:**
+- Create: `scripts/smoke-local.sh` (chmod +x)
+
+- [ ] **Step 1: Write the script**
+
+```bash
+#!/usr/bin/env bash
+# No-credentials health gate for the local full stack. Makes NO model calls, so
+# it passes without any model key. Exits non-zero on first failure.
+set -uo pipefail
+
+ROUTER_PORT="${ROUTER_PORT:-8080}"
+PAPERCLIP_PORT="${PAPERCLIP_PORT:-3100}"
+HONCHO_PORT="${HONCHO_PORT:-8000}"
+GOVERNOR_PORT="${GOVERNOR_PORT:-8090}"
+GOVERNOR_API_KEY="${GOVERNOR_API_KEY:-localdev}"
+POSTGRES_USER="${POSTGRES_USER:-aaf}"
+POSTGRES_DB="${POSTGRES_DB:-aaf}"
+COMPOSE="${COMPOSE:-docker compose}"
+
+fail=0
+pass() { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+bad()  { printf '  \033[31m✗\033[0m %s\n' "$1"; fail=1; }
+
+http_is() { # url expected label
+  local code; code="$(curl -s -o /dev/null -w '%{http_code}' "$1" 2>/dev/null || echo 000)"
+  [ "$code" = "$2" ] && pass "$3 ($code)" || bad "$3 (got $code, want $2)"
+}
+
+echo "smoke-local: checking the full stack (no model key required)…"
+
+# 1. migrations applied — feature_flags seeded
+if $COMPOSE exec -T postgres psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
+     'select count(*) from feature_flags;' >/tmp/aaf_ff 2>/dev/null \
+   && [ "$(tr -d '[:space:]' </tmp/aaf_ff)" -ge 1 ] 2>/dev/null; then
+  pass "migrations applied (feature_flags rows: $(tr -d '[:space:]' </tmp/aaf_ff))"
+else
+  bad "migrations applied (feature_flags missing/empty)"
+fi
+
+# 2. model-router liveness (no creds)
+http_is "http://localhost:${ROUTER_PORT}/health" 200 "model-router /health"
+# 3. honcho
+http_is "http://localhost:${HONCHO_PORT}/openapi.json" 200 "honcho /openapi.json"
+# 4. paperclip UI
+http_is "http://localhost:${PAPERCLIP_PORT}/" 200 "paperclip UI /"
+# 5. governor healthy + idle
+http_is "http://localhost:${GOVERNOR_PORT}/healthz" 200 "memory-governor /healthz"
+admit="$(curl -s -X POST "http://localhost:${GOVERNOR_PORT}/admit" \
+  -H "Authorization: Bearer ${GOVERNOR_API_KEY}" -H 'Content-Type: application/json' \
+  -d '{"content":"smoke","agent_id":"smoke","scope_kind":"task","scope_id":"smoke"}' 2>/dev/null || echo '')"
+if printf '%s' "$admit" | grep -q '"status"[[:space:]]*:[[:space:]]*"disabled"'; then
+  pass "memory-governor /admit → disabled (flags off)"
+else
+  bad "memory-governor /admit → expected disabled, got: ${admit:-<none>}"
+fi
+
+echo
+[ "$fail" -eq 0 ] && { echo "smoke-local: PASS"; exit 0; } || { echo "smoke-local: FAIL"; exit 1; }
+```
+
+**Confirm during implementation:** the `/admit` request body shape against `services/memory-governor/src/governor/main.py:115` (the admission model). If the schema differs and returns 422 before the disabled short-circuit, either adjust the body to match or replace check 5b with a DB assertion (`select enabled from feature_flags where flag='MEMORY_CLASSES_ENABLED'` → `f`).
+
+- [ ] **Step 2: Make executable + syntax check**
+
+Run: `chmod +x scripts/smoke-local.sh && bash -n scripts/smoke-local.sh && echo "bash ok"; command -v shellcheck >/dev/null && shellcheck scripts/smoke-local.sh || echo "(shellcheck not installed — skipped)"`
+Expected: `bash ok` (and shellcheck clean or skipped)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/smoke-local.sh
+git commit -m "feat(local): smoke-local.sh no-creds health gate"
+```
+
+---
+
+### Task 4: `scripts/local-stack.sh` — wrapper
+
+**Files:**
+- Create: `scripts/local-stack.sh` (chmod +x)
+
+- [ ] **Step 1: Write the script**
+
+```bash
+#!/usr/bin/env bash
+# One-command local full stack.
+#   scripts/local-stack.sh up           preflight, .env bootstrap, build, wait, smoke, print URLs
+#   scripts/local-stack.sh down [args]  stop and remove (pass -v to drop volumes)
+#   scripts/local-stack.sh smoke        run the health gate against a running stack
+#   scripts/local-stack.sh logs [svc]   follow logs
+set -euo pipefail
+cd "$(dirname "$0")/.."
+COMPOSE="docker compose"
+
+up() {
+  for s in apps/hermes/src apps/honcho/src; do
+    if [ -z "$(ls -A "$s" 2>/dev/null || true)" ]; then
+      echo "[local-stack] initializing submodule $s…"; git submodule update --init "$s"
+    fi
+  done
+  if [ ! -f .env ]; then
+    cp .env.example .env
+    echo "[local-stack] created .env from .env.example — edit it to add a model key to drive agents."
+  fi
+  $COMPOSE --profile full up -d --build
+  echo "[local-stack] waiting for services to become healthy (up to 5 min)…"
+  deadline=$(( $(date +%s) + 300 ))
+  while :; do
+    unhealthy="$($COMPOSE ps --format '{{.Service}} {{.Health}}' 2>/dev/null | awk '$2!="" && $2!="healthy"{print $1}')"
+    [ -z "$unhealthy" ] && break
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "[local-stack] timeout; still unhealthy: $unhealthy"; $COMPOSE ps; exit 1
+    fi
+    sleep 5
+  done
+  scripts/smoke-local.sh
+  cat <<EOF
+
+[local-stack] up. URLs:
+  PaperClip UI/API : http://localhost:${PAPERCLIP_PORT:-3100}
+  Model router     : http://localhost:${ROUTER_PORT:-8080}
+  Honcho           : http://localhost:${HONCHO_PORT:-8000}
+  Memory governor  : http://localhost:${GOVERNOR_PORT:-8090}
+
+Set OPENAI_COMPAT_BASE_URL + OPENAI_COMPAT_API_KEY in .env to drive agents.
+EOF
+}
+
+case "${1:-up}" in
+  up)    up ;;
+  down)  shift; $COMPOSE --profile full down "$@" ;;
+  smoke) scripts/smoke-local.sh ;;
+  logs)  $COMPOSE --profile full logs -f "${2:-}" ;;
+  *)     echo "usage: $0 {up|down [-v]|smoke|logs [service]}"; exit 2 ;;
+esac
+```
+
+- [ ] **Step 2: Make executable + syntax check**
+
+Run: `chmod +x scripts/local-stack.sh && bash -n scripts/local-stack.sh && echo "bash ok"; command -v shellcheck >/dev/null && shellcheck scripts/local-stack.sh || echo "(shellcheck skipped)"`
+Expected: `bash ok`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/local-stack.sh
+git commit -m "feat(local): local-stack.sh one-command wrapper"
+```
+
+---
+
+### Task 5: CI — path-scoped full-stack smoke
+
+**Files:**
+- Create: `.github/workflows/local-stack-smoke.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+```yaml
+name: local-stack-smoke
+on:
+  push:
+    paths: &paths
+      - 'docker-compose.yml'
+      - 'services/**'
+      - 'apps/**'
+      - 'infrastructure/migrations/**'
+      - 'scripts/smoke-local.sh'
+      - 'scripts/local-stack.sh'
+      - '.env.example'
+      - '.github/workflows/local-stack-smoke.yml'
+  pull_request:
+    paths: *paths
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with: { submodules: recursive }
+      - name: Bring up full stack (no model creds)
+        run: docker compose --profile full up -d --build
+      - name: Wait for healthy
+        run: |
+          deadline=$(( $(date +%s) + 600 ))
+          while :; do
+            unhealthy="$(docker compose ps --format '{{.Service}} {{.Health}}' | awk '$2!="" && $2!="healthy"{print $1}')"
+            [ -z "$unhealthy" ] && break
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "timeout; unhealthy: $unhealthy"; docker compose ps; docker compose logs; exit 1
+            fi
+            sleep 10
+          done
+      - name: Smoke
+        run: bash scripts/smoke-local.sh
+      - name: Logs on failure
+        if: failure()
+        run: docker compose logs
+      - name: Teardown
+        if: always()
+        run: docker compose --profile full down -v
+```
+
+- [ ] **Step 2: Validate YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/local-stack-smoke.yml')); print('yaml ok')"`
+Expected: `yaml ok`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/local-stack-smoke.yml
+git commit -m "ci(local): path-scoped full-stack smoke workflow"
+```
+
+---
+
+### Task 6: Docs — reflect that the full local stack shipped
+
+**Files:**
+- Modify: `README.md` (the "planned for v1.2" local-stack lines + the roadmap checkbox)
+- Create: `docs/local-development.md` (usage)
+
+- [ ] **Step 1: Update README local-stack references**
+
+In `README.md`, update the three local-stack mentions (text match, line numbers approximate):
+- `~303`: "The current local quickstart brings up PostgreSQL and the model router. The full one-command local stack and full end-to-end Azure installer are planned for v1.2." → "`docker compose --profile full up` (or `scripts/local-stack.sh up`) brings up the whole platform locally with no Azure account; the full end-to-end Azure installer is planned for v1.2."
+- `~377`: "A one-command full local stack is planned for v1.2." → "A one-command full local stack is available: `scripts/local-stack.sh up`. See [docs/local-development.md](docs/local-development.md)."
+- Roadmap (`~471`): change `⬜ One-command full local stack (`docker compose --profile full up`)` to `✅`.
+
+- [ ] **Step 2: Write `docs/local-development.md`**
+
+```markdown
+# Local development — full stack, no Azure
+
+Bring up the whole AzureAgentForge platform on your machine, no Azure account needed.
+
+## Quickstart
+
+```bash
+scripts/local-stack.sh up
+```
+
+This initializes the upstream submodules if needed, creates `.env` from `.env.example`,
+builds and starts the full profile, waits for health, runs the smoke gate, and prints URLs:
+
+| Service | URL |
+|---|---|
+| PaperClip UI / API | http://localhost:3100 |
+| Model router | http://localhost:8080 |
+| Honcho (memory) | http://localhost:8000 |
+| Memory governor | http://localhost:8090 |
+
+The stack comes up **healthy with no credentials**. The governed-memory governor and watchdog
+are present but **flag-off / idle**.
+
+## Driving agents
+
+To actually run agents, set ONE OpenAI-compatible endpoint in `.env`:
+
+```bash
+OPENAI_COMPAT_BASE_URL=https://api.openai.com/v1   # or Ollama / LM Studio
+OPENAI_COMPAT_API_KEY=sk-...
+```
+
+Then `scripts/local-stack.sh down && scripts/local-stack.sh up`.
+
+## Plain compose
+
+```bash
+docker compose up                  # working slice: Postgres + model-router
+docker compose --profile full up   # full platform
+```
+
+## Verify / teardown
+
+```bash
+scripts/local-stack.sh smoke       # re-run the health gate
+scripts/local-stack.sh logs paperclip
+scripts/local-stack.sh down -v     # stop and drop volumes
+```
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md docs/local-development.md
+git commit -m "docs(local): document the one-command full local stack"
+```
+
+---
+
+### Task 7: Static end-to-end self-check (no daemon)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Re-validate everything statically**
+
+Run:
+```bash
+python3 -c "import yaml; yaml.safe_load(open('docker-compose.yml')); yaml.safe_load(open('.github/workflows/local-stack-smoke.yml')); print('yaml ok')"
+bash -n scripts/smoke-local.sh && bash -n scripts/local-stack.sh && echo "bash ok"
+git check-ignore .env >/dev/null && echo ".env ignored"
+```
+Expected: `yaml ok`, `bash ok`, `.env ignored`
+
+---
+
+### Task 8: Live integration verification (CI / operator — has Docker)
+
+**Files:** none (gated; cannot run on the authoring machine — no Docker daemon)
+
+- [ ] **Step 1:** Push the branch; the `local-stack-smoke` workflow builds the full profile, waits for healthy, runs `scripts/smoke-local.sh`, and tears down. This is the authoritative end-to-end check.
+- [ ] **Step 2 (optional, operator local):** `scripts/local-stack.sh up` on a machine with Docker; confirm all-healthy + smoke PASS + the printed URLs load.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §4 topology → Task 2; §5 contexts → Task 2; §6 `.env.example`/secrets → Task 1 + Task 2 env; §7 migrate → Task 2 (`migrate` service); §8 smoke → Task 3; §9 wrapper → Task 4; §11 CI → Task 5; docs/§roadmap → Task 6; §13 no-daemon constraint → Tasks 7–8. All covered.
+- **Open confirmations (resolve in-task, not placeholders):** router `/health` creds-independence (Task 2); watchdog required env (Task 2); governor `/admit` body schema (Task 3). Each has a concrete fallback.
+- **Type/name consistency:** port vars (`ROUTER_PORT`/`PAPERCLIP_PORT`/`HONCHO_PORT`/`GOVERNOR_PORT`), `GOVERNOR_API_KEY`, service names (`model-router`, `memory-governor`), and URLs (`http://model-router:8080/v1`, `http://honcho:8000`, `http://memory-governor:8090`) are consistent across compose, smoke, wrapper, and docs.

--- a/docs/superpowers/specs/2026-06-19-full-local-stack-design.md
+++ b/docs/superpowers/specs/2026-06-19-full-local-stack-design.md
@@ -1,0 +1,203 @@
+# One-Command Full Local Stack — Design Spec
+
+**Date:** 2026-06-19
+**Status:** Approved (brainstorming) → ready for implementation plan
+**Branch:** `feat/full-local-stack` (builds on `feat/vendoring-buildability` / PR #17)
+**Roadmap:** v1.2 — "One-command full local stack (`docker compose --profile full up`)"
+
+## 1. Problem
+
+`docker compose --profile full up` is promised in the README/ROADMAP (v1.2) but the current `full`
+profile is a non-working skeleton:
+
+- **Wrong build context.** `paperclip` and `honcho` build with `build: ./services/<n>`, but their
+  Dockerfiles COPY from `apps/` and require **repo-root** context (`context: .`, `dockerfile:
+  services/<n>/Dockerfile`). As written, the build fails.
+- **No migration runner.** The governor tables (`infrastructure/migrations/0001…0008.sql`) are never
+  applied locally — there is no existing runner for them (in Azure they run via a pipeline stage).
+- **No service config.** `paperclip`, `honcho`, `memory-governor` have no env wiring (model routing,
+  Honcho URL, dev secrets, admin bootstrap), so even if they built they would not run together.
+- **No boot ordering / healthchecks**, no `.env.example`, no local smoke test.
+
+PR #17 made all 7 images **buildable** from a clean clone; this spec makes the full stack **run**
+from a clean clone, with **no Azure account**.
+
+## 2. Goal & success criteria
+
+A developer with **no Azure account** runs one command and gets the whole platform up and
+explorable. To *drive* an agent they add a single model endpoint to `.env`; to merely look around
+(PaperClip UI, agent roster, governed-memory wiring) they need **zero credentials**.
+
+Success = the no-creds **`smoke-local.sh`** gate passes:
+
+1. Migrations applied (the `feature_flags` table exists and is seeded).
+2. `model-router` reachable (`GET /health` → 200); a model call with no provider returns a **clear error**, not a crash.
+3. `honcho` healthy (`GET /openapi.json` → 200).
+4. `paperclip` UI reachable (`GET /` → 200; there is no dedicated health endpoint).
+5. `memory-governor` healthy (`GET /healthz` → 200) and `POST /admit` (with the dev `GOVERNOR_API_KEY`) returns `"disabled"`.
+
+## 3. Chosen approach — A: fix & complete the single `--profile full` in place
+
+Keep one `docker-compose.yml`; repair and complete the `full` profile. Rejected alternative B
+(split base + `docker-compose.full.yml`) because it changes the documented `--profile full` UX for
+no real gain. Add a thin `scripts/local-stack.sh` wrapper for the nicest one-command first run.
+
+## 4. Service topology
+
+```
+postgres ──(healthy)──┬─► migrate (one-shot; applies SQL; exits 0)
+                      ├─► honcho            (:8000, manages own schema)
+model-router ─────────┤
+   (:8080)            ├─► paperclip         (:3100, bundles the Hermes runtime)
+                      ├─► memory-governor   (:8090, flag-OFF / idle)
+                      └─► watchdog          (loops, flag-OFF / inert)
+```
+
+**No separate Hermes/Telegram container.** The PaperClip image already bundles the Hermes runtime
+(Dockerfile `hermes-cli` stage installs `apps/hermes/src` to `/opt/hermes`; the
+`hermes-paperclip-adapter` spawns it per task inside the paperclip container). The standalone
+`agent-runtime` image is the Telegram **gateway** (needs a bot token) and is **out of scope** here.
+
+**Default profile (unchanged):** `postgres`, `model-router`.
+**`full` profile adds:** `migrate`, `honcho`, `paperclip`, `memory-governor`, `watchdog`.
+
+### Boot ordering (healthchecks + depends_on conditions)
+
+| Service | Healthcheck | depends_on |
+|---|---|---|
+| postgres | `pg_isready` | — |
+| model-router | `GET /health` | — |
+| migrate | (one-shot; no healthcheck) | postgres: `service_healthy` |
+| honcho | `GET /openapi.json` | postgres: `service_healthy` |
+| paperclip | `GET /` (UI root; no dedicated health endpoint) | postgres healthy, migrate `service_completed_successfully`, model-router healthy |
+| memory-governor | `GET /healthz` | postgres healthy, migrate completed, honcho healthy, model-router healthy |
+| watchdog | (long-running loop; minimal/no healthcheck) | postgres healthy, migrate completed |
+
+## 5. Build-context fix
+
+- **Self-contained** (context = service dir; already correct): `model-router`, `memory-governor`,
+  `watchdog`.
+- **Upstream** (context = repo root; COPY from `apps/`): `honcho`, `paperclip`:
+  ```yaml
+  build:
+    context: .
+    dockerfile: services/paperclip/Dockerfile
+    args:
+      PAPERCLIP_VERSION: ${PAPERCLIP_VERSION:-latest}
+      PAPERCLIP_EXPECTED_SHA: ${PAPERCLIP_EXPECTED_SHA:-}
+  ```
+
+## 6. Configuration & secrets — `.env.example` → `.env`
+
+A committed `.env.example` (copied to `.env`, which is gitignored). Contents:
+
+- **Model backend (the one knob), empty by default**, with inline examples:
+  - OpenAI: `OPENAI_COMPAT_BASE_URL=https://api.openai.com/v1` + `OPENAI_COMPAT_API_KEY=sk-...`
+  - Ollama: `OPENAI_COMPAT_BASE_URL=http://host.docker.internal:11434/v1`
+  - LM Studio: `OPENAI_COMPAT_BASE_URL=http://host.docker.internal:1234/v1`
+- **Postgres** dev defaults (`aaf` / `localdev` / `aaf`).
+- **Dev-only secrets** under a loud `# DEV ONLY — DO NOT USE IN PRODUCTION` banner:
+  `PAPERCLIP_AUTOMATION_JWT_SECRET`, `PAPERCLIP_AGENT_JWT_SECRET`, `PAPERCLIP_ADMIN_EMAIL`,
+  `PAPERCLIP_ADMIN_PASSWORD`, `GOVERNOR_API_KEY` — all obvious `localdev-*` placeholders.
+- **Optional port overrides:** `POSTGRES_PORT`, `ROUTER_PORT`, `PAPERCLIP_PORT`, `HONCHO_PORT`,
+  `GOVERNOR_PORT` (each `${X_PORT:-default}`).
+
+Per-service env (key items):
+
+- **paperclip:** `OPENAI_BASE_URL=http://model-router:8080/v1` (the bundled Hermes routes through the
+  local router), `HONCHO_BASE_URL=http://honcho:8000`, the dev JWT secrets + admin bootstrap. The
+  **auth-proxy is enabled** (dev JWT secret present) so the full UI + skills/automation API are
+  reachable on a single host port (`:3100`).
+- **memory-governor:** `DATABASE_URL`, `ROUTER_BASE_URL=http://model-router:8080/v1`,
+  `HONCHO_BASE_URL`, `GOVERNOR_API_KEY`. All feature flags seed **false** (DB), so it idles.
+- **honcho:** `DATABASE_URL` to the shared Postgres.
+- **watchdog:** `DATABASE_URL` (+ router/governor URLs); all detector/loop flags **off**.
+
+## 7. Migration runner (new)
+
+One-shot `migrate` service:
+
+```yaml
+migrate:
+  profiles: ["full"]
+  image: postgres:16            # for psql
+  depends_on: { postgres: { condition: service_healthy } }
+  volumes: ["./infrastructure/migrations:/migrations:ro"]
+  environment: { PGHOST: postgres, PGUSER: ..., PGPASSWORD: ..., PGDATABASE: ... }
+  entrypoint: ["sh","-c","set -e; for f in /migrations/*.sql; do echo \"applying $f\"; psql -v ON_ERROR_STOP=1 -f \"$f\"; done"]
+  restart: "no"
+```
+
+- Files apply in lexical order (`0001, 0002, 0004, 0006, 0007, 0008`); they are already idempotent.
+- `0004_pg_trgm.sql`'s `CREATE EXTENSION pg_trgm` **works on the local `pgvector/pgvector:pg16`
+  image** (the Azure Flexible-Server rejection gotcha does not apply locally).
+- Honcho continues to manage its own schema (its entrypoint), independent of this runner.
+
+## 8. `scripts/smoke-local.sh` — no-creds health gate
+
+Bash; asserts the five success criteria in §2 against the running stack **without any model key**.
+The governor check (`POST /admit`) sends the dev `GOVERNOR_API_KEY` (the route is key-gated) and
+expects `{"status":"disabled"}`. Non-zero exit + a clear message on first failure. Used by humans and
+by CI.
+
+## 9. `scripts/local-stack.sh` — wrapper (`up | down | smoke | logs`)
+
+`up`:
+1. Preflight: if `apps/hermes/src` / `apps/honcho/src` are empty, run `git submodule update --init`.
+2. If `.env` is missing, copy `.env.example` → `.env` and print "edit `.env` to add a model key".
+3. `docker compose --profile full up -d --build`.
+4. Wait for all healthchecks to go healthy (poll, with a timeout).
+5. Run `scripts/smoke-local.sh`.
+6. Print URLs (PaperClip `http://localhost:3100`, router `:8080`, honcho `:8000`, governor `:8090`)
+   and "set `OPENAI_COMPAT_*` in `.env` to drive agents."
+
+`down`: `docker compose --profile full down` (`-v` optional). `smoke`: run the gate. `logs`: tail.
+
+## 10. Error handling / failure modes
+
+- **No model creds:** stack healthy; router returns an explicit "no provider configured" on model
+  calls; agent runs fail with a clear message in PaperClip. Smoke passes (it makes no model calls).
+- **Port collisions:** ports overridable via `${X_PORT:-default}` in `.env`.
+- **Empty submodules:** wrapper auto-inits before build.
+- **Slow first build:** multi-stage build of ~5 images is slow on first run; documented. Cached after.
+
+## 11. Testing / CI
+
+- **Local:** `scripts/smoke-local.sh` is the verification.
+- **CI:** a GitHub Actions workflow builds the `full` profile, runs `smoke-local.sh`, tears down.
+  Because building ~5 images is heavy, the workflow is **path-scoped** (triggers only on changes to
+  `docker-compose.yml`, `services/**`, `apps/**`, `infrastructure/migrations/**`,
+  `scripts/{smoke-local,local-stack}.sh`, `.env.example`) rather than on every PR.
+
+## 12. Resolved decisions
+
+1. **Model backend:** stack comes up with zero creds; agents driven by a user-supplied
+   OpenAI-compatible endpoint (OpenAI / Ollama / LM Studio) via `.env`. *(No bundled local model.)*
+2. **Scope:** full platform incl. governed memory — `postgres + model-router + honcho + paperclip +
+   memory-governor + watchdog + migrate`. Governor + watchdog **present but flag-OFF/idle**.
+3. **Success bar:** no-creds health smoke (not a full agent round-trip).
+4. **Structure:** single-file `--profile full` (Approach A) + `local-stack.sh` wrapper.
+5. **Watchdog:** included in `full`, idle (flags off).
+6. **CI:** path-scoped full-stack smoke workflow.
+
+## 13. Constraints & out-of-scope
+
+- **No Docker daemon on the authoring machine.** Implementation produces all files + static
+  validation (YAML parse, `bash -n`/shellcheck, and `docker compose config` where a CLI is
+  available). The **live `up` + smoke run is gated to the operator or CI** — it cannot be executed
+  during implementation.
+- **Out of scope (YAGNI):** Telegram/Discord/Teams surfaces, the standalone `agent-runtime` gateway,
+  a bundled local model, and production secret management.
+
+## 14. Acceptance criteria (testable)
+
+- [ ] `docker compose config --profile full` parses with no errors and resolves all build contexts.
+- [ ] `migrate` applies all `infrastructure/migrations/*.sql` against the local Postgres and exits 0.
+- [ ] With an empty `.env` (no model key), `docker compose --profile full up` reaches all-healthy and
+      `scripts/smoke-local.sh` exits 0.
+- [ ] `scripts/local-stack.sh up` performs submodule preflight, `.env` bootstrap, build, wait, smoke,
+      and prints the service URLs.
+- [ ] `.env.example` documents the model-backend knob (OpenAI / Ollama / LM Studio) and dev-only
+      secrets with a production warning; `.env` is gitignored.
+- [ ] The path-scoped CI workflow builds the full profile, runs the smoke gate, and tears down.
+- [ ] No Telegram/Teams/agent-runtime services appear in the `full` profile.

--- a/scripts/local-stack.sh
+++ b/scripts/local-stack.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# One-command local full stack.
+#   scripts/local-stack.sh up           preflight, .env bootstrap, build, wait, smoke, print URLs
+#   scripts/local-stack.sh down [args]  stop and remove (pass -v to drop volumes)
+#   scripts/local-stack.sh smoke        run the health gate against a running stack
+#   scripts/local-stack.sh logs [svc]   follow logs
+set -euo pipefail
+cd "$(dirname "$0")/.."
+COMPOSE="docker compose"
+
+up() {
+  for s in apps/hermes/src apps/honcho/src; do
+    if [ -z "$(ls -A "$s" 2>/dev/null || true)" ]; then
+      echo "[local-stack] initializing submodule $s…"; git submodule update --init "$s"
+    fi
+  done
+  if [ ! -f .env ]; then
+    cp .env.example .env
+    echo "[local-stack] created .env from .env.example — edit it to add a model key to drive agents."
+  fi
+  $COMPOSE --profile full up -d --build
+  echo "[local-stack] waiting for services to become healthy (up to 5 min)…"
+  deadline=$(( $(date +%s) + 300 ))
+  while :; do
+    unhealthy="$($COMPOSE ps --format '{{.Service}} {{.Health}}' 2>/dev/null | awk '$2!="" && $2!="healthy"{print $1}')"
+    [ -z "$unhealthy" ] && break
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "[local-stack] timeout; still unhealthy: $unhealthy"; $COMPOSE ps; exit 1
+    fi
+    sleep 5
+  done
+  scripts/smoke-local.sh
+  cat <<EOF
+
+[local-stack] up. URLs:
+  PaperClip UI/API : http://localhost:${PAPERCLIP_PORT:-3100}
+  Model router     : http://localhost:${ROUTER_PORT:-8080}
+  Honcho           : http://localhost:${HONCHO_PORT:-8000}
+  Memory governor  : http://localhost:${GOVERNOR_PORT:-8090}
+
+Set OPENAI_COMPAT_BASE_URL + OPENAI_COMPAT_API_KEY in .env to drive agents.
+EOF
+}
+
+case "${1:-up}" in
+  up)    up ;;
+  down)  shift; $COMPOSE --profile full down "$@" ;;
+  smoke) scripts/smoke-local.sh ;;
+  logs)  $COMPOSE --profile full logs -f "${2:-}" ;;
+  *)     echo "usage: $0 {up|down [-v]|smoke|logs [service]}"; exit 2 ;;
+esac

--- a/scripts/smoke-local.sh
+++ b/scripts/smoke-local.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# No-credentials health gate for the local full stack. Makes NO model calls, so
+# it passes without any model key. Exits non-zero on first failure.
+set -uo pipefail
+
+ROUTER_PORT="${ROUTER_PORT:-8080}"
+PAPERCLIP_PORT="${PAPERCLIP_PORT:-3100}"
+HONCHO_PORT="${HONCHO_PORT:-8000}"
+GOVERNOR_PORT="${GOVERNOR_PORT:-8090}"
+GOVERNOR_API_KEY="${GOVERNOR_API_KEY:-localdev}"
+POSTGRES_USER="${POSTGRES_USER:-aaf}"
+POSTGRES_DB="${POSTGRES_DB:-aaf}"
+COMPOSE="${COMPOSE:-docker compose}"
+
+fail=0
+pass() { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+bad()  { printf '  \033[31m✗\033[0m %s\n' "$1"; fail=1; }
+
+http_is() { # url expected label
+  local code; code="$(curl -s -o /dev/null -w '%{http_code}' "$1" 2>/dev/null || echo 000)"
+  [ "$code" = "$2" ] && pass "$3 ($code)" || bad "$3 (got $code, want $2)"
+}
+
+echo "smoke-local: checking the full stack (no model key required)…"
+
+# 1. migrations applied — feature_flags seeded
+if $COMPOSE exec -T postgres psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
+     'select count(*) from feature_flags;' >/tmp/aaf_ff 2>/dev/null \
+   && [ "$(tr -d '[:space:]' </tmp/aaf_ff)" -ge 1 ] 2>/dev/null; then
+  pass "migrations applied (feature_flags rows: $(tr -d '[:space:]' </tmp/aaf_ff))"
+else
+  bad "migrations applied (feature_flags missing/empty)"
+fi
+
+# 2. model-router liveness (no creds)
+http_is "http://localhost:${ROUTER_PORT}/health" 200 "model-router /health"
+# 3. honcho
+http_is "http://localhost:${HONCHO_PORT}/openapi.json" 200 "honcho /openapi.json"
+# 4. paperclip UI
+http_is "http://localhost:${PAPERCLIP_PORT}/" 200 "paperclip UI /"
+# 5. governor healthy + idle. /admit is key-gated (X-Governor-Key) and pydantic-
+#    validates the body before the disabled short-circuit, so send a valid body.
+http_is "http://localhost:${GOVERNOR_PORT}/healthz" 200 "memory-governor /healthz"
+admit="$(curl -s -X POST "http://localhost:${GOVERNOR_PORT}/admit" \
+  -H "X-Governor-Key: ${GOVERNOR_API_KEY}" -H 'Content-Type: application/json' \
+  -d '{"content":"smoke","workspace_name":"smoke","observer":"smoke","created_by_peer":"smoke"}' \
+  2>/dev/null || echo '')"
+if printf '%s' "$admit" | grep -q '"status"[[:space:]]*:[[:space:]]*"disabled"'; then
+  pass "memory-governor /admit → disabled (flags off)"
+else
+  bad "memory-governor /admit → expected disabled, got: ${admit:-<none>}"
+fi
+
+echo
+[ "$fail" -eq 0 ] && { echo "smoke-local: PASS"; exit 0; } || { echo "smoke-local: FAIL"; exit 1; }


### PR DESCRIPTION
Makes `docker compose --profile full up` (or `scripts/local-stack.sh up`) bring up the **whole platform locally with no Azure account**. Implements the v1.2 roadmap item.

> **Stacked on #17** (`feat/vendoring-buildability`). Base will retarget to `main` once #17 merges; review the [3 local-stack commits](https://github.com/mrobinson2/AzureAgentForge/compare/feat/vendoring-buildability...feat/full-local-stack) only.

## What it does
- **Fixes the broken `full` profile**: `honcho`/`paperclip` now build from repo root (`context: .`, `dockerfile: services/<n>/Dockerfile`) — they COPY from `apps/`.
- **Adds a one-shot `migrate`** service that applies `infrastructure/migrations/*.sql` (governor tables) and exits.
- **Wires service env + dev-only secrets**, healthchecks + `depends_on` ordering, port overrides, and a `paperclip-data` volume.
- **`scripts/smoke-local.sh`** — no-creds health gate (DB migrated, router `/health`, honcho, paperclip UI, governor `/healthz` + `/admit`→`disabled`).
- **`scripts/local-stack.sh`** — submodule preflight + `.env` bootstrap + build + wait-healthy + smoke + prints URLs.
- **Path-scoped CI** (`local-stack-smoke.yml`) builds the full profile, runs the smoke gate, tears down.
- Hermes runs **bundled inside the paperclip image** (no separate container); watchdog is a one-shot that idles (flags off) and exits clean.

## Design
- Comes up healthy with **zero credentials**; BYO any OpenAI-compatible endpoint (OpenAI / Ollama / LM Studio) in `.env` to drive agents.
- Spec: `docs/superpowers/specs/2026-06-19-full-local-stack-design.md` · Plan: `docs/superpowers/plans/2026-06-19-full-local-stack.md`

## Testing
- Static (authoring machine has no Docker): YAML parse, compose structure assertions, `bash -n`, shellcheck — all green.
- **Live `up`+smoke runs in CI** (`local-stack-smoke`) — the authoritative end-to-end check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)