### PR TITLE
test(auth-proxy): unit suite + CI job; harden governor passthrough path (#23)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,16 @@ jobs:
           sudo apt-get update -qq && sudo apt-get install -y shellcheck
           shellcheck --severity=error scripts/*.sh
 
+  node-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: auth-proxy unit tests (no deps; node built-in runner)
+        run: node --test tests/auth-proxy/*.test.mjs
+
   python:
     runs-on: ubuntu-latest
     steps:

--- a/apps/paperclip/auth-proxy.mjs
+++ b/apps/paperclip/auth-proxy.mjs
@@ -29,7 +29,7 @@ import { createServer, request as httpRequest } from "node:http";
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { readFileSync, readdirSync, statSync, existsSync, writeFileSync,
          mkdirSync, rmSync, appendFileSync } from "node:fs";
-import { join, resolve, relative, basename, dirname, sep } from "node:path";
+import { join, resolve, relative, basename, dirname, sep, posix } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // ── Configuration ───────────────────────────────────────────────────────────
@@ -263,6 +263,27 @@ function checkScope(method, path, scopes) {
     }
   }
   return scopes.includes("*");
+}
+
+// Constrain the memory-governor passthrough to its documented surface. The
+// governor host is fixed, so this is not classic SSRF — but a crafted path like
+// "/api/memory/../admit" (raw or percent-encoded) would, once the governor
+// normalises it, reach a DIFFERENT route. Validate against the decoded +
+// normalised path and reject anything that escapes /memory or /digest. Returns
+// the original "<path><query>" to forward, or null to reject (→ 400).
+function governorTargetPath(rawUrl) {
+  const qIdx = rawUrl.indexOf("?");
+  const rawPath = qIdx === -1 ? rawUrl : rawUrl.slice(0, qIdx);
+  const query = qIdx === -1 ? "" : rawUrl.slice(qIdx);
+  const govPath = rawPath.replace(/^\/api/, "");
+  let decoded;
+  try { decoded = decodeURIComponent(govPath); } catch { return null; }
+  const norm = posix.normalize(decoded);
+  if (norm === "/memory" || norm.startsWith("/memory/") ||
+      norm === "/digest" || norm.startsWith("/digest/")) {
+    return govPath + query;
+  }
+  return null;
 }
 
 // ── Plain proxy pass-through (no auth manipulation) ─────────────────────────
@@ -1129,9 +1150,16 @@ async function handleRequest(clientReq, clientRes) {
       return;
     }
 
-    // /api/memory[...] -> governor /memory[...]
+    // /api/memory[...] -> governor /memory[...]; reject path-traversal that
+    // escapes the /memory|/digest surface (defense-in-depth: host is fixed and
+    // the route is already memory:admin + governor-key gated).
     const target = new URL(GOVERNOR_BASE_URL);
-    const govPath = clientReq.url.replace(/^\/api/, "");
+    const govPath = governorTargetPath(clientReq.url);
+    if (govPath === null) {
+      clientRes.writeHead(400, { "Content-Type": "application/json" });
+      clientRes.end(JSON.stringify({ error: "Invalid memory path" }));
+      return;
+    }
     const fwdHeaders = { ...clientReq.headers };
     delete fwdHeaders.authorization;
     fwdHeaders.host = target.hostname;
@@ -1538,6 +1566,7 @@ if (isMainModule) {
 export {
   verifyJwt,
   checkScope,
+  governorTargetPath,
   safePath,
   parseFrontmatter,
   stripBom,

--- a/tests/auth-proxy/auth-proxy.test.mjs
+++ b/tests/auth-proxy/auth-proxy.test.mjs
@@ -1,0 +1,132 @@
+// Unit tests for the auth-proxy security guards (JWT verification, scope
+// checks, path-traversal containment, frontmatter parsing). Zero dependencies —
+// Node's built-in test runner. Run: node --test tests/auth-proxy/
+//
+// auth-proxy.mjs only binds a port under isMainModule, so importing it here is
+// side-effect-free.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { resolve } from "node:path";
+
+// JWT_ISSUER / JWT_AUDIENCE are read at module-import time; pin them so token
+// fixtures are deterministic regardless of the ambient environment.
+process.env.PAPERCLIP_AUTOMATION_JWT_ISSUER = "test-issuer";
+process.env.PAPERCLIP_AUTOMATION_JWT_AUDIENCE = "test-audience";
+
+const { verifyJwt, checkScope, governorTargetPath, safePath, parseFrontmatter, stripBom } =
+  await import("../../apps/paperclip/auth-proxy.mjs");
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+const b64url = (s) => Buffer.from(s).toString("base64url");
+function makeJwt(payload, secret, { alg = "HS256" } = {}) {
+  const h = b64url(JSON.stringify({ alg, typ: "JWT" }));
+  const p = b64url(JSON.stringify(payload));
+  const sig = createHmac("sha256", secret).update(`${h}.${p}`).digest("base64url");
+  return `${h}.${p}.${sig}`;
+}
+const SECRET = "test-secret";
+const claims = { sub: "svc", iss: "test-issuer", aud: "test-audience" };
+
+// ── verifyJwt ────────────────────────────────────────────────────────────────
+test("verifyJwt accepts a valid token and returns claims", () => {
+  const p = verifyJwt(makeJwt({ ...claims, scope: ["skills:read"] }, SECRET), SECRET);
+  assert.equal(p.sub, "svc");
+  assert.deepEqual(p.scope, ["skills:read"]);
+});
+test("verifyJwt rejects a forged signature", () => {
+  assert.throws(() => verifyJwt(makeJwt(claims, SECRET), "wrong-secret"), /Invalid signature/);
+});
+test("verifyJwt rejects a non-HS256 algorithm (alg confusion)", () => {
+  assert.throws(() => verifyJwt(makeJwt(claims, SECRET, { alg: "none" }), SECRET), /Unsupported algorithm/);
+});
+test("verifyJwt rejects a malformed token", () => {
+  assert.throws(() => verifyJwt("a.b", SECRET), /Malformed JWT/);
+});
+test("verifyJwt rejects an expired token", () => {
+  assert.throws(() => verifyJwt(makeJwt({ ...claims, exp: 1 }, SECRET), SECRET), /expired/);
+});
+test("verifyJwt rejects a not-yet-valid token (nbf)", () => {
+  assert.throws(() => verifyJwt(makeJwt({ ...claims, nbf: 9999999999 }, SECRET), SECRET), /not yet valid/);
+});
+test("verifyJwt rejects the wrong issuer", () => {
+  assert.throws(() => verifyJwt(makeJwt({ ...claims, iss: "evil" }, SECRET), SECRET), /Invalid issuer/);
+});
+test("verifyJwt rejects the wrong audience", () => {
+  assert.throws(() => verifyJwt(makeJwt({ ...claims, aud: "evil" }, SECRET), SECRET), /Invalid audience/);
+});
+
+// ── checkScope ───────────────────────────────────────────────────────────────
+test("checkScope: null scopes (admin role) bypasses all checks", () => {
+  assert.equal(checkScope("POST", "/api/memory/x", null), true);
+});
+test("checkScope: a matching scope is allowed", () => {
+  assert.equal(checkScope("GET", "/api/memory", ["memory:admin"]), true);
+});
+test("checkScope: a missing scope is denied", () => {
+  assert.equal(checkScope("GET", "/api/memory", ["skills:read"]), false);
+});
+test("checkScope: the wildcard scope is allowed", () => {
+  assert.equal(checkScope("DELETE", "/api/memory/x", ["*"]), true);
+});
+test("checkScope: path wildcard matches exactly one segment", () => {
+  assert.equal(checkScope("POST", "/api/memory/abc", ["memory:admin"]), true);
+  // /api/memory/abc/def matches no pattern -> needs the "*" scope, which is absent
+  assert.equal(checkScope("POST", "/api/memory/abc/def", ["memory:admin"]), false);
+});
+
+// ── governorTargetPath (memory-governor passthrough hardening) ───────────────
+test("governorTargetPath allows the documented surface", () => {
+  assert.equal(governorTargetPath("/api/memory"), "/memory");
+  assert.equal(governorTargetPath("/api/memory/recall?q=x"), "/memory/recall?q=x");
+  assert.equal(governorTargetPath("/api/digest"), "/digest");
+  assert.equal(governorTargetPath("/api/digest/today"), "/digest/today");
+});
+test("governorTargetPath rejects raw path traversal", () => {
+  assert.equal(governorTargetPath("/api/memory/../admit"), null);
+  assert.equal(governorTargetPath("/api/memory/../../healthz"), null);
+});
+test("governorTargetPath rejects percent-encoded traversal", () => {
+  assert.equal(governorTargetPath("/api/memory/..%2fadmit"), null);
+  assert.equal(governorTargetPath("/api/memory/%2e%2e/admit"), null);
+});
+test("governorTargetPath rejects malformed percent-encoding", () => {
+  assert.equal(governorTargetPath("/api/memory/%zz"), null);
+});
+test("governorTargetPath rejects routes outside /memory and /digest", () => {
+  assert.equal(governorTargetPath("/api/memoryfoo"), null);
+  assert.equal(governorTargetPath("/api/admit"), null);
+});
+test("governorTargetPath forwards in-bounds dot-segments unchanged", () => {
+  assert.equal(governorTargetPath("/api/memory/x/../y"), "/memory/x/../y");
+});
+
+// ── safePath (path-traversal containment) ────────────────────────────────────
+test("safePath allows an in-jail path", () => {
+  assert.equal(safePath("/srv/skills", "foo", "SKILL.md"), resolve("/srv/skills/foo/SKILL.md"));
+});
+test("safePath rejects parent traversal", () => {
+  assert.equal(safePath("/srv/skills", "../etc/passwd"), null);
+});
+test("safePath rejects a sibling-prefix escape (../skills-evil)", () => {
+  assert.equal(safePath("/srv/skills", "../skills-evil"), null);
+});
+test("safePath allows the base itself", () => {
+  assert.equal(safePath("/srv/skills"), resolve("/srv/skills"));
+});
+
+// ── stripBom ─────────────────────────────────────────────────────────────────
+test("stripBom removes a leading BOM and is a no-op otherwise", () => {
+  assert.equal(stripBom("﻿hi"), "hi");
+  assert.equal(stripBom("hi"), "hi");
+});
+
+// ── parseFrontmatter ─────────────────────────────────────────────────────────
+test("parseFrontmatter parses scalars and bracket arrays", () => {
+  const fm = parseFrontmatter("---\nname: foo\ntags: [a, b, c]\n---\nbody");
+  assert.equal(fm.name, "foo");
+  assert.deepEqual(fm.tags, ["a", "b", "c"]);
+});
+test("parseFrontmatter returns {} when no frontmatter is present", () => {
+  assert.deepEqual(parseFrontmatter("just a body"), {});
+});


### PR DESCRIPTION
First slice of the post-audit security backlog (#18–23).

## What
- **New unit-test suite** `tests/auth-proxy/auth-proxy.test.mjs` (26 tests, zero deps, Node's built-in runner) for the previously-untested `auth-proxy.mjs`: JWT verification (forged sig, alg-confusion, malformed, exp/nbf/iss/aud), scope checks, `safePath` traversal containment (incl. the sibling-prefix escape), frontmatter parsing.
- **New `node-tests` CI job** so the file is gated going forward.
- **Closes #23** — `governorTargetPath()` constrains the `/api/memory`·`/api/digest` passthrough to its documented surface, rejecting raw **and** percent-encoded path traversal (`/api/memory/../admit`, `..%2f`, `%2e%2e`) that would otherwise reach other governor routes after normalization.

## Verification
- `node --test tests/auth-proxy/*.test.mjs` → **26/26 pass** (locally + the new CI job).
- The `local-stack-smoke` CI confirms the proxy still boots and serves.

## Note on the rest of the backlog
Verifying against the real code (not just the audit summary): **#21 is misdirected** — the auth-proxy intentionally normalizes Host/Origin; the CSRF guard lives in the *backend* (board-mutation-guard), so it's not an auth-proxy line-fix. I'll follow up on #18/#19/#20/#22 with that lens and comment on #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)