### PR TITLE
fix(postgres): allow-list pg_trgm + fuzzystrmatch for Paperclip migrations

### DIFF
--- a/infrastructure/modules/postgres/main.tf
+++ b/infrastructure/modules/postgres/main.tf
@@ -53,7 +53,10 @@ resource "azurerm_postgresql_flexible_server_database" "databases" {
 resource "azurerm_postgresql_flexible_server_configuration" "extensions" {
   name      = "azure.extensions"
   server_id = azurerm_postgresql_flexible_server.main.id
-  value     = "uuid-ossp,pgcrypto,vector" # Enable pgvector for embeddings if needed locally
+  # pgvector (vector) for embeddings; pg_trgm + fuzzystrmatch are required by
+  # Paperclip's company-search migrations (0079/0080) — Azure Flexible Server
+  # rejects CREATE EXTENSION unless the extension is allow-listed here.
+  value = "uuid-ossp,pgcrypto,vector,pg_trgm,fuzzystrmatch"
 }
 
 # NOTE: Row Level Security setup must be done manually or via a container in the VNet


### PR DESCRIPTION
## Problem

On the first end-to-end v1.2 Azure deploy, `ca-paperclip-dev` crash-looped (`ActivationFailed` / Unhealthy, climbing restart count). It was **not** a connection-string issue — paperclip connected fine and reached "Applying 35 pending migrations," then crashed on:

```
PostgresError: extension "pg_trgm" is not allow-listed for users in Azure Database for PostgreSQL
code: 0A000  routine: check_extension_permissions
```

Paperclip's bundled company-search migrations run unguarded `CREATE EXTENSION` statements:
- `0079_company_search_document_indexes.sql` → `pg_trgm`
- `0080_company_search_fuzzystrmatch.sql` → `fuzzystrmatch`

Azure Database for PostgreSQL **Flexible Server** rejects `CREATE EXTENSION` unless the extension is in the server's `azure.extensions` allow-list. The module only allow-listed `uuid-ossp,pgcrypto,vector`, so paperclip could never complete its migrations on a fresh Azure deployment.

## Fix

Add `pg_trgm` and `fuzzystrmatch` to the `azure.extensions` server parameter. Both are needed — allow-listing only `pg_trgm` would crash-loop again on migration `0080`.

## Verification (aaf-vault-dev)

Applied the equivalent live param, restarted the paperclip revision:
- All **35** pending migrations applied in one pass (no `PostgresError`)
- `Server listening on 0.0.0.0:3099`, `Paperclip backend ready`
- Revision health → **Healthy**, `restartCount=0`
- `scripts/smoke-test.sh` green: paperclip / hermes / honcho all `Running` / `Succeeded`

`azure.extensions` is a dynamic server parameter (no server restart required); only the consuming app needs a revision restart to re-run migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)