### PR TITLE
fix(deploy): reconcile data.tf KV secret names + seed non-empty placeholders

### DIFF
--- a/infrastructure/environments/dev/data.tf
+++ b/infrastructure/environments/dev/data.tf
@@ -1,23 +1,26 @@
-# Data sources for Key Vault secrets
-# Naming convention: platform-<platform>-<purpose>
+# Data sources for Key Vault secrets.
+# Names match what scripts/seed-keyvault.sh seeds and what the container-apps
+# modules reference (bare kebab-case, no platform- prefix). The previous
+# platform-<platform>-<purpose> names were never created by the seed script, so
+# `terraform plan` failed reading these data sources on a fresh deploy.
 
 data "azurerm_key_vault_secret" "auth_password" {
-  name         = "platform-azureagentforge-auth-password"
+  name         = "auth-password"
   key_vault_id = module.keyvault.id
 }
 
 data "azurerm_key_vault_secret" "gateway_token" {
-  name         = "platform-azureagentforge-gateway-token"
+  name         = "gateway-token"
   key_vault_id = module.keyvault.id
 }
 
 data "azurerm_key_vault_secret" "telegram" {
   count        = var.telegram_enabled ? 1 : 0
-  name         = "platform-telegram-bot-token"
+  name         = "telegram-bot-token"
   key_vault_id = module.keyvault.id
 }
 
 data "azurerm_key_vault_secret" "cf_tunnel_token" {
-  name         = "platform-cloudflared-token"
+  name         = "cf-tunnel-token"
   key_vault_id = module.keyvault.id
 }

--- a/scripts/seed-keyvault.sh
+++ b/scripts/seed-keyvault.sh
@@ -32,17 +32,27 @@ DRY_RUN=0
 # Internal secrets generated locally if missing.
 GENERATE="postgres-admin-password governor-api-key paperclip-admin-password \
 paperclip-agent-jwt-secret paperclip-auth-secret paperclip-automation-jwt-secret \
-paperclip-automation-token"
+paperclip-automation-token auth-password gateway-token"
 
 # Secrets sourced from the environment. Every name here is referenced by a
 # container app's Key Vault secret mount (infrastructure/modules/container-apps),
 # so each must EXIST in the vault for `terraform apply` to succeed — see the
-# external loop below, which seeds an empty placeholder for any you don't set.
+# external loop below, which seeds a non-empty placeholder for any you don't set.
 EXTERNAL="ai-foundry-api-key brave-search-api-key cf-tunnel-token claude-api-key \
 claude-base-url discord-bot-token gpt4o-api-key grok-api-key grok-base-url \
 gws-credentials kimi-api-key kimi-base-url openai-api-key paperclip-admin-email \
 phi-api-key phi-base-url telegram-bot-token postgres-connection-string \
 paperclip-db-url"
+
+# Non-empty sentinel seeded for any unset external. `az keyvault secret set`
+# REJECTS an empty --value, so we cannot seed "" — yet every external above is
+# referenced by a container's Key Vault mount and must EXIST for `terraform apply`
+# to succeed. CAVEAT: consumers do not yet treat this value as "unconfigured"
+# (the model-router registers a tier whenever its *_BASE_URL / *_API_KEY are
+# truthy), so an unset OPTIONAL tier registers against this placeholder and fails
+# at request time rather than fail-soft skipping. Follow-up: teach the router (and
+# other readers) to treat PLACEHOLDER_VALUE as empty.
+PLACEHOLDER_VALUE="__unset__"
 
 die() { echo "error: $*" >&2; exit 2; }
 
@@ -140,15 +150,16 @@ for s in $EXTERNAL; do
     # with an empty placeholder.
     echo "    keep: $s (exists)"; kept=$((kept + 1)); continue
   fi
-  # Unset and absent — seed an EMPTY placeholder. Every external is referenced by
-  # a container's Key Vault secret mount, and ACA fails the deploy if a referenced
-  # secret does not exist; an empty value lets `terraform apply` succeed while the
-  # unconfigured feature/tier stays inert (the router treats an empty base-url or
-  # key as "tier not configured" and fail-soft skips it). Fill it in later and
-  # re-run to enable.
-  set_secret "$s" ""; placeheld=$((placeheld + 1)); missing="$missing $s"
+  # Unset and absent — seed a non-empty placeholder ($PLACEHOLDER_VALUE). Every
+  # external is referenced by a container's Key Vault secret mount, and ACA fails
+  # the deploy if a referenced secret does not exist. We cannot seed "" because
+  # `az keyvault secret set` rejects an empty --value and aborts the whole run on
+  # the first unset external. The placeholder lets `terraform apply` succeed; fill
+  # the real value in later and re-run to enable. See PLACEHOLDER_VALUE above for
+  # the consumer-side caveat.
+  set_secret "$s" "$PLACEHOLDER_VALUE"; placeheld=$((placeheld + 1)); missing="$missing $s"
 done
 
 echo
 echo "summary: generated=$generated provided=$provided kept=$kept placeholders=$placeheld"
-[ -z "$missing" ] || echo "seeded EMPTY (set the matching env var + re-run to enable):$missing"
+[ -z "$missing" ] || echo "seeded placeholder '$PLACEHOLDER_VALUE' (set the matching env var + re-run to enable):$missing"


### PR DESCRIPTION
Lands the two still-needed fixes from #16 on top of **current** `main` (PR #16 itself is unmergeably stale — it predates the vendoring work, an ~8.5k-line delta). Both were hit and hand-patched during the first end-to-end Azure deploy.

## Fix 1 — `data.tf` Key Vault secret names
`infrastructure/environments/dev/data.tf` read four secrets by `platform-<platform>-<purpose>` names that `scripts/seed-keyvault.sh` never creates, so `terraform plan` failed reading those data sources on a fresh deploy. Renamed to the bare kebab-case names the seed script + container-apps modules already use (`auth-password`, `gateway-token`, `telegram-bot-token`, `cf-tunnel-token`), and added `auth-password` + `gateway-token` to the seed **GENERATE** list so they exist.

## Fix 2 — seed non-empty placeholders
`seed-keyvault.sh` seeded unset externals with `--value ""`, but `az keyvault secret set` **rejects an empty value** and aborted the whole run on the first unset external — so no externals seeded and ACA couldn't resolve their KV references (paperclip's "Invalid URL" boot crash). Seeds a non-empty sentinel (`__unset__`) instead.

## Verified
- `bash -n scripts/seed-keyvault.sh` → clean
- dry-run: `generated=9` (incl. `auth-password`, `gateway-token`) + `19` placeholders
- `terraform fmt` → clean

## ⚠️ Known limitation (follow-up, intentionally out of scope)
Consumers don't yet treat `__unset__` as *unconfigured*. The model-router registers a tier whenever its `*_BASE_URL`/`*_API_KEY` are truthy (`main.py`), so an unset **optional** tier (claude/grok/kimi/phi) now registers against the placeholder and **fails at request time instead of fail-soft skipping**. Recommend a follow-up to normalize the sentinel to empty in the router (and other readers). The unused `auth_password`/`gateway_token` data sources could also be deleted rather than generated.

Closes #16 (superseded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)