### PR TITLE
fix(model-router): treat the Key Vault __unset__ placeholder as unconfigured

### DIFF
--- a/services/model-router/main.py
+++ b/services/model-router/main.py
@@ -107,18 +107,34 @@ def _validate_request(body: dict) -> None:
     if max_tokens is not None and (not isinstance(max_tokens, int) or max_tokens < 1):
         raise HTTPException(status_code=400, detail="max_tokens must be a positive integer")
 
+# ─── Key Vault unset-secret sentinel ─────────────────────────────────────────
+# scripts/seed-keyvault.sh seeds this non-empty placeholder for any external
+# secret you did not provide — `az keyvault secret set` rejects an empty value,
+# so an unconfigured tier's *_BASE_URL / *_API_KEY arrives here as "__unset__"
+# rather than "". Treat it (and blank/whitespace) as "not configured" so the
+# tier is skipped, not registered against a bogus endpoint that 5xxs at request
+# time. Keep in sync with PLACEHOLDER_VALUE in scripts/seed-keyvault.sh.
+_KV_UNSET_SENTINEL = "__unset__"
+
+
+def _tier_env(name: str, default: str = "") -> str:
+    """Read a tier-config env var, normalizing the Key Vault unset-placeholder
+    and blank/whitespace to "" so the truthy tier-gating below skips it."""
+    val = os.environ.get(name, default)
+    if val is None:
+        return ""
+    val = val.strip()
+    return "" if val == _KV_UNSET_SENTINEL else val
+
+
 # ─── GPT-4o-mini Configuration (primary) ─────────────────────────────────────
 # Primary tier activates when either GPT4O_BASE_URL/GPT4O_API_KEY or
 # AZURE_FOUNDRY_ENDPOINT/AZURE_FOUNDRY_API_KEY are set (the latter are the
 # compose-level vars so `docker compose up` with Foundry creds brings it up).
-_GPT4O_BASE_URL = os.environ.get(
-    "GPT4O_BASE_URL",
-    os.environ.get("AZURE_FOUNDRY_ENDPOINT", ""),  # set AZURE_FOUNDRY_ENDPOINT or GPT4O_BASE_URL
-)
-_GPT4O_API_KEY = os.environ.get(
-    "GPT4O_API_KEY",
-    os.environ.get("AZURE_FOUNDRY_API_KEY", ""),   # alias: AZURE_FOUNDRY_API_KEY activates primary tier
-)
+# A placeholder/blank in the GPT4O_* pair falls through to AZURE_FOUNDRY_* via
+# the `or` chain (and the two are aliased in docker-compose.yml).
+_GPT4O_BASE_URL = _tier_env("GPT4O_BASE_URL") or _tier_env("AZURE_FOUNDRY_ENDPOINT")
+_GPT4O_API_KEY = _tier_env("GPT4O_API_KEY") or _tier_env("AZURE_FOUNDRY_API_KEY")
 
 MODELS: dict[str, dict[str, Any]] = {}
 
@@ -136,8 +152,8 @@ if _GPT4O_BASE_URL and _GPT4O_API_KEY:
 else:
     log.info("tier gpt4o-mini not configured (GPT4O_BASE_URL/GPT4O_API_KEY or AZURE_FOUNDRY_ENDPOINT/AZURE_FOUNDRY_API_KEY); skipping")
 
-_PHI_BASE_URL = os.environ.get("PHI_BASE_URL", "")
-_PHI_API_KEY = os.environ.get("PHI_API_KEY", "")
+_PHI_BASE_URL = _tier_env("PHI_BASE_URL")
+_PHI_API_KEY = _tier_env("PHI_API_KEY")
 if _PHI_BASE_URL and _PHI_API_KEY:
     MODELS["phi4"] = {
         "litellm_model": f"openai/{os.environ.get('PHI_MODEL', 'Phi-4')}",
@@ -190,9 +206,9 @@ def _register_foundry_tier(
     KV-secret format across providers), we rewrite to `/anthropic` for the
     Anthropic prefix automatically.
     """
-    base_url = os.environ.get(f"{env_prefix}_BASE_URL")
-    api_key = os.environ.get(f"{env_prefix}_API_KEY")
-    deployment = os.environ.get(f"{env_prefix}_MODEL")
+    base_url = _tier_env(f"{env_prefix}_BASE_URL")
+    api_key = _tier_env(f"{env_prefix}_API_KEY")
+    deployment = _tier_env(f"{env_prefix}_MODEL")
     if not (base_url and api_key and deployment):
         log.info(
             "Foundry tier %s_* not configured — env vars missing, skipping",
@@ -1331,7 +1347,7 @@ async def messages(request: Request):
 # Disabled (503) unless an embedding key is set. EMBEDDING_BASE_URL unset ->
 # OpenAI.com; set it to point at an Azure/Foundry deployment of the same model.
 _EMBED_MODEL = os.environ.get("EMBEDDING_MODEL", "text-embedding-3-small")
-_EMBED_API_KEY = os.environ.get("EMBEDDING_API_KEY") or os.environ.get("OPENAI_API_KEY")
+_EMBED_API_KEY = _tier_env("EMBEDDING_API_KEY") or _tier_env("OPENAI_API_KEY")
 _EMBED_API_BASE = os.environ.get("EMBEDDING_BASE_URL") or None
 _EMBED_TIMEOUT_S = int(os.environ.get("EMBEDDING_TIMEOUT_SECONDS", "20"))
 _EMBED_MAX_INPUTS = int(os.environ.get("EMBEDDING_MAX_INPUTS", "256"))

--- a/services/model-router/tests/test_foundry_tiers.py
+++ b/services/model-router/tests/test_foundry_tiers.py
@@ -93,3 +93,61 @@ class TestRegisterFoundryTier:
             "NOTOOLS", default_budget=0.25, supports_tools=False
         )
         assert router.MODELS["notools-test"]["supports_tools"] is False
+
+    def test_noop_when_base_url_is_kv_placeholder(self, router, monkeypatch):
+        # seed-keyvault.sh seeds "__unset__" for unprovided externals; an
+        # unconfigured tier must be skipped, not registered against the
+        # placeholder (which would 5xx at request time).
+        monkeypatch.setenv("PHURL_BASE_URL", "__unset__")
+        monkeypatch.setenv("PHURL_API_KEY", "real-key")
+        monkeypatch.setenv("PHURL_MODEL", "phurl-test")
+        before = set(router.MODELS.keys())
+        router._register_foundry_tier("PHURL", default_budget=0.25)
+        assert set(router.MODELS.keys()) == before
+
+    def test_noop_when_api_key_is_kv_placeholder(self, router, monkeypatch):
+        monkeypatch.setenv("PHKEY_BASE_URL", "https://host/openai/v1/")
+        monkeypatch.setenv("PHKEY_API_KEY", "__unset__")
+        monkeypatch.setenv("PHKEY_MODEL", "phkey-test")
+        before = set(router.MODELS.keys())
+        router._register_foundry_tier("PHKEY", default_budget=0.25)
+        assert set(router.MODELS.keys()) == before
+
+    def test_noop_when_placeholder_has_surrounding_whitespace(self, router, monkeypatch):
+        # The sentinel matches after strip(), so "  __unset__  " also skips.
+        monkeypatch.setenv("PHWS_BASE_URL", "  __unset__  ")
+        monkeypatch.setenv("PHWS_API_KEY", "k")
+        monkeypatch.setenv("PHWS_MODEL", "phws-test")
+        before = set(router.MODELS.keys())
+        router._register_foundry_tier("PHWS", default_budget=0.25)
+        assert set(router.MODELS.keys()) == before
+
+
+class TestTierEnv:
+    """`_tier_env` normalizes the Key Vault unset-placeholder and blank/
+    whitespace values to "" so the truthy tier-gating skips an unconfigured
+    tier instead of registering it against a bogus endpoint."""
+
+    def test_real_value_passes_through(self, router, monkeypatch):
+        monkeypatch.setenv("TE_BASE_URL", "https://real.example/v1")
+        assert router._tier_env("TE_BASE_URL") == "https://real.example/v1"
+
+    def test_real_value_is_stripped(self, router, monkeypatch):
+        monkeypatch.setenv("TE_KEY", "  sk-abc  ")
+        assert router._tier_env("TE_KEY") == "sk-abc"
+
+    def test_kv_placeholder_normalizes_to_empty(self, router, monkeypatch):
+        monkeypatch.setenv("TE_KEY", "__unset__")
+        assert router._tier_env("TE_KEY") == ""
+
+    def test_whitespace_padded_placeholder_normalizes_to_empty(self, router, monkeypatch):
+        monkeypatch.setenv("TE_KEY", "  __unset__ ")
+        assert router._tier_env("TE_KEY") == ""
+
+    def test_blank_normalizes_to_empty(self, router, monkeypatch):
+        monkeypatch.setenv("TE_KEY", "   ")
+        assert router._tier_env("TE_KEY") == ""
+
+    def test_absent_returns_empty_default(self, router, monkeypatch):
+        monkeypatch.delenv("TE_MISSING", raising=False)
+        assert router._tier_env("TE_MISSING") == ""


### PR DESCRIPTION
Follow-up to #31. That PR made `seed-keyvault.sh` seed a non-empty `__unset__` placeholder for unset external secrets (because `az keyvault secret set` rejects an empty value). This teaches the router to treat that placeholder as **unconfigured**.

## Problem
The router gates tiers on plain truthiness (`if BASE_URL and API_KEY`). With the `__unset__` placeholder (truthy), an unconfigured **optional** tier (claude/grok/kimi/phi) — and the primary / embeddings paths — would **register against a bogus endpoint and 5xx at request time** instead of fail-soft skipping. Nothing in the router recognized the sentinel.

## Fix
Add `_tier_env()`, which normalizes the `__unset__` placeholder (and blank/whitespace) to `""` so the existing truthy gating skips the tier. Applied at every tier-config read:
- `gpt4o-mini` primary — `AZURE_FOUNDRY_*` fallback restructured to an `or` chain so a placeholder in **either** pair falls through to the other
- `phi4`
- `_register_foundry_tier` (claude / kimi / grok)
- the embeddings key (falls back to the placeholder-seeded `OPENAI_API_KEY`)

**Intentionally not normalized** (not KV-placeholder-seeded): `ROUTER_API_KEY`, `OLLAMA_*`, `FOUNDRY_API_KEY`.

## Tests
+9 (`TestTierEnv` + `_register_foundry_tier` placeholder no-op cases). Full model-router suite **155 passed** locally (146 prior + 9 new).

Resolves the follow-up flagged in #31's description and the in-code note in `seed-keyvault.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)