### PR TITLE
feat(forge): default deployment id to gpt-4o-mini + add image-tag field

### DIFF
--- a/infrastructure/environments/dev/variables.tf
+++ b/infrastructure/environments/dev/variables.tf
@@ -123,7 +123,7 @@ variable "ai_foundry_endpoint" {
 variable "ai_foundry_deployment_id" {
   description = "Azure AI Foundry model deployment ID (used by Honcho for memory ops)"
   type        = string
-  default     = "Phi-4"
+  default     = "gpt-4o-mini"
 }
 
 # Container Image Tags

--- a/installer/app.py
+++ b/installer/app.py
@@ -83,6 +83,7 @@ class ConfigBody(BaseModel):
     discord_enabled: bool = False
     ai_foundry_endpoint: str = ""
     ai_foundry_deployment_id: str = ""
+    image_tag: str = ""
     owner_email: str = ""
     keyvault_admin_object_ids: list[str] = []
     preview_only: bool = False

--- a/installer/core.py
+++ b/installer/core.py
@@ -30,6 +30,8 @@ VALID_PROFILES = ("cost-optimized", "hardened")
 _LOCATION_RE = re.compile(r"^[a-z0-9]{3,30}$")
 _ENVIRONMENT_RE = re.compile(r"^[a-z][a-z0-9]{1,11}$")
 _SUBSCRIPTION_RE = re.compile(r"^[0-9a-fA-F-]{36}$")
+# Docker image tag / git SHA: alnum-or-underscore start, then alnum . _ - (<=128).
+_IMAGE_TAG_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$")
 
 
 # ---------------------------------------------------------------------------
@@ -135,6 +137,9 @@ class DeployConfig:
     discord_enabled: bool = False
     ai_foundry_endpoint: str = ""
     ai_foundry_deployment_id: str = ""
+    # A single container image tag applied to all four service images
+    # (hermes/honcho/router/paperclip). Empty -> terraform's "latest" default.
+    image_tag: str = ""
     owner_email: str = ""
     # Azure AD object IDs granted Key Vault Secrets Officer, so the operator (and
     # any CI principal) can seed secrets into the RBAC-authorized vault. Without
@@ -155,6 +160,8 @@ class DeployConfig:
             errs.append("ai_foundry_endpoint must be an https:// URL")
         if self.owner_email and ("@" not in self.owner_email or '"' in self.owner_email):
             errs.append("owner_email doesn't look like an email address")
+        if self.image_tag and not _IMAGE_TAG_RE.match(self.image_tag):
+            errs.append("image_tag must be a valid container tag (alphanumerics, '.', '_', '-')")
         for oid in self.keyvault_admin_object_ids:
             if not _SUBSCRIPTION_RE.match(oid or ""):
                 errs.append(f"keyvault_admin_object_ids entry {oid!r} must be a GUID")
@@ -182,6 +189,9 @@ def render_tfvars(cfg: DeployConfig) -> str:
         pairs.append(("ai_foundry_endpoint", _hcl_str(cfg.ai_foundry_endpoint)))
     if cfg.ai_foundry_deployment_id:
         pairs.append(("ai_foundry_deployment_id", _hcl_str(cfg.ai_foundry_deployment_id)))
+    if cfg.image_tag:
+        for svc in ("hermes", "honcho", "router", "paperclip"):
+            pairs.append((f"{svc}_image_tag", _hcl_str(cfg.image_tag)))
     if cfg.owner_email:
         pairs.append(("owner_email", _hcl_str(cfg.owner_email)))
     if cfg.keyvault_admin_object_ids:

--- a/installer/static/index.html
+++ b/installer/static/index.html
@@ -124,7 +124,9 @@
         <label>Azure AI Foundry endpoint <span class="dim">(optional — can set later)</span></label>
         <input type="text" id="foundry" placeholder="https://your-project.openai.azure.com/">
         <label>Foundry deployment id <span class="dim">(optional)</span></label>
-        <input type="text" id="foundryDeployment" placeholder="grok-4-fast-reasoning">
+        <input type="text" id="foundryDeployment" value="gpt-4o-mini" placeholder="gpt-4o-mini">
+        <label>Container image tag <span class="dim">(optional — applies to all services; blank = "latest")</span></label>
+        <input type="text" id="imageTag" placeholder="e.g. a git SHA like 9bf1a51, or latest">
         <label>Key Vault admin object IDs <span class="dim">(your Azure AD object ID; comma-separated for more — needed to seed secrets)</span></label>
         <input type="text" id="kvAdmins" placeholder="az ad signed-in-user show --query id -o tsv">
         <div class="chk"><input type="checkbox" id="telegram"><label for="telegram" style="margin:0">Enable Telegram surface</label></div>
@@ -272,6 +274,7 @@ function configBody(previewOnly) {
     discord_enabled: $('discord').checked,
     ai_foundry_endpoint: $('foundry').value.trim(),
     ai_foundry_deployment_id: $('foundryDeployment').value.trim(),
+    image_tag: $('imageTag').value.trim(),
     keyvault_admin_object_ids: $('kvAdmins').value.split(',').map(s => s.trim()).filter(Boolean),
     preview_only: previewOnly,
   });

--- a/installer/tests/test_core.py
+++ b/installer/tests/test_core.py
@@ -88,6 +88,27 @@ def test_render_tfvars_omits_empty_keyvault_admin_object_ids():
     assert "keyvault_admin_object_ids" not in _kv(core.render_tfvars(core.DeployConfig(**GOOD)))
 
 
+def test_render_tfvars_image_tag_fans_out_to_all_services():
+    cfg = core.DeployConfig(**GOOD, image_tag="9bf1a51")
+    kv = _kv(core.render_tfvars(cfg))
+    for svc in ("hermes", "honcho", "router", "paperclip"):
+        assert kv[f"{svc}_image_tag"] == '"9bf1a51"'
+
+
+def test_render_tfvars_omits_image_tag_when_blank():
+    kv = _kv(core.render_tfvars(core.DeployConfig(**GOOD)))
+    assert not any(k.endswith("_image_tag") for k in kv)
+
+
+def test_invalid_image_tag_rejected():
+    errs = core.DeployConfig(**GOOD, image_tag="bad tag!").validate()
+    assert errs and any("image_tag" in e for e in errs)
+
+
+def test_valid_image_tag_passes():
+    assert core.DeployConfig(**GOOD, image_tag="v1.2.3-rc1").validate() == []
+
+
 def test_render_tfvars_is_fmt_aligned():
     out = core.render_tfvars(core.DeployConfig(**GOOD))
     eq_cols = {line.index("=") for line in out.splitlines()


### PR DESCRIPTION
Fixes two Forge Console gaps that forced manual `terraform.tfvars` edits during the first v1.2 deploy.

## 1. Deployment id defaults to gpt-4o-mini
The form hinted `grok-4-fast-reasoning` and the `ai_foundry_deployment_id` terraform default was `Phi-4` — neither matches the dev backend (gpt-4o-mini). Now the form pre-fills `gpt-4o-mini` and the terraform default matches.

## 2. Image-tag field
The wizard had no way to set container image tags, so they had to be hand-added after it wrote tfvars. Adds an optional **Container image tag** field that fans a single tag out to all four service vars (`hermes/honcho/router/paperclip_image_tag`); blank keeps terraform's `"latest"`. Tag input is validated (alnum + `.` `_` `-`).

## Tests
+4 (`render_tfvars` fan-out, omit-when-blank, reject-invalid, accept-valid). Installer suite **46 passed**; `terraform fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)