### PR TITLE
docs(model-router): document the KIMI optional tier (lands #6, closes #3)

### DIFF
--- a/services/model-router/README.md
+++ b/services/model-router/README.md
@@ -70,7 +70,7 @@ Set `PERSONA_TIERS_JSON` to a JSON object mapping agent/persona names to tier ke
 {"orchestrator": "claude-sonnet-4-6", "coder": "gpt-4o-mini"}
 ```
 
-The tier value must be a key present in `MODELS` at request time (i.e. a registered tier such as `gpt4o-mini`, `phi4`, or an optional tier you enabled — **not** the abstract `frontier`/`standard`/`economy` labels used in agent profiles). `persona-tiers.example.json` ships a working default that targets only the two always-registered tiers (`gpt4o-mini` for higher-value roles, `phi4` for economy roles), so it routes correctly on a vanilla Foundry-only stack; repoint roles at richer tiers (e.g. a `CLAUDE` tier) once you register them.
+The tier value must be a key present in `MODELS` at request time (i.e. a registered tier such as `gpt4o-mini`, `phi4`, or an optional tier you enabled — **not** the abstract `frontier`/`standard`/`economy` labels used in agent profiles). `persona-tiers.example.json` ships a working default that targets only the two always-registered tiers (`gpt4o-mini` for higher-value roles, `phi4` for economy roles), so it routes correctly on a vanilla Foundry-only stack; repoint roles at richer tiers (e.g. a `CLAUDE` or `KIMI` tier) once you register them. For Kimi: set `KIMI_BASE_URL`, `KIMI_API_KEY`, and `KIMI_MODEL=kimi-k2`, then point a role at its deployment name, e.g. `{"researcher": "kimi-k2"}`.
 
 ### Fallback chain
 


### PR DESCRIPTION
Lands @nightcityblade's #6, fixed. #6 repointed the *shipped* `persona-tiers.example.json` default (`researcher`) at `kimi-k2` — an optional tier that isn't registered on a vanilla stack, so the example would stop routing out of the box. This keeps the example on the always-registered tiers and instead **documents** how to add Kimi (register `KIMI_BASE_URL`/`KIMI_API_KEY`/`KIMI_MODEL=kimi-k2`, then map a role to `kimi-k2`). Closes #3; supersedes #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)