### PR TITLE
fix(auth-proxy): fail-closed CSRF Origin guard + bounded admin-session TTL

### DIFF
--- a/apps/paperclip/auth-proxy.mjs
+++ b/apps/paperclip/auth-proxy.mjs
@@ -79,7 +79,20 @@ const BACKEND_PORT = parseInt(process.env.PAPERCLIP_INTERNAL_PORT || "3099", 10)
 const BACKEND_HOST = "127.0.0.1";
 const ADMIN_EMAIL = process.env.PAPERCLIP_ADMIN_EMAIL || "";
 const ADMIN_PASSWORD = process.env.PAPERCLIP_ADMIN_PASSWORD || "";
+const PUBLIC_URL_CONFIGURED = !!process.env.PAPERCLIP_PUBLIC_URL;
 const PUBLIC_URL = process.env.PAPERCLIP_PUBLIC_URL || `http://localhost:${PROXY_PORT}`;
+// Hostnames the browser pass-through path will accept as the request Origin, in
+// addition to PUBLIC_URL's host (issue #21). Mirrors PAPERCLIP_ALLOWED_HOSTNAMES
+// that PaperClip's own CSRF guard uses; comma-separated.
+const ALLOWED_HOSTNAMES = process.env.PAPERCLIP_ALLOWED_HOSTNAMES || "";
+// Bootstrapped admin-session cache lifetime (issue #18). A flat 23h was far too
+// long for a single shared admin cookie; cap it (default 1h, overridable) and
+// honor the cookie's own Max-Age when shorter. Held in memory only, never logged.
+const SESSION_TTL_CAP_MS =
+  Math.max(1, parseInt(process.env.PAPERCLIP_SESSION_TTL_SECONDS || "3600", 10) || 3600) * 1000;
+const SESSION_REFRESH_SKEW_MS = 60 * 1000;
+// HTTP methods that mutate state and therefore require the CSRF Origin check.
+const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 // ── Skills API Configuration ───────────────────────────────────────────────
 const HERMES_HOME = process.env.HERMES_HOME || "/paperclip/.hermes";
@@ -146,6 +159,25 @@ function verifyJwt(token, secret) {
 
 // ── Session Cookie Cache ────────────────────────────────────────────────────
 
+// Parse a Set-Cookie line's Max-Age (in ms) when present and numeric, else null.
+function cookieMaxAgeMs(setCookieLine) {
+  const m = /(?:^|;)\s*max-age\s*=\s*(-?\d+)/i.exec(String(setCookieLine || ""));
+  if (!m) return null;
+  const secs = parseInt(m[1], 10);
+  return Number.isFinite(secs) ? secs * 1000 : null;
+}
+
+// Cache-expiry timestamp for the bootstrapped admin session (issue #18): the
+// sooner of (now + TTL cap) and the cookie's own Max-Age, minus a refresh skew
+// so the proxy re-auths before the upstream session lapses. Floored to now+1s so
+// a short or negative Max-Age never yields an already-expired cache entry.
+function sessionCacheExpiry(now, setCookieLine, { ttlCapMs, skewMs }) {
+  let horizon = now + ttlCapMs;
+  const maxAge = cookieMaxAgeMs(setCookieLine);
+  if (maxAge != null) horizon = Math.min(horizon, now + maxAge);
+  return Math.max(now + 1000, horizon - skewMs);
+}
+
 let cachedSession = null; // { cookie, expiresAt }
 
 async function getSessionCookie() {
@@ -163,7 +195,7 @@ async function getSessionCookie() {
 
   const loginBody = JSON.stringify({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
 
-  const cookie = await new Promise((resolve, reject) => {
+  const setCookieLine = await new Promise((resolve, reject) => {
     const req = httpRequest(
       {
         hostname: BACKEND_HOST,
@@ -190,15 +222,16 @@ async function getSessionCookie() {
           // `paperclip-dev`, yielding `__Secure-paperclip-dev.session_token`;
           // older PaperClip versions used the default `better-auth` prefix).
           // Matching on the suffix keeps the proxy resilient to prefix changes.
-          const sessionCookie = setCookies
-            .map((c) => c.split(";")[0])
-            .find((c) => /\.session_token=/.test(c));
-          if (!sessionCookie) {
+          // Keep the FULL Set-Cookie line (not just `name=value`) so we can read
+          // its Max-Age when capping the cache TTL below (issue #18).
+          const sessionSetCookie = setCookies
+            .find((c) => /\.session_token=/.test(c.split(";")[0]));
+          if (!sessionSetCookie) {
             const names = setCookies.map((c) => c.split("=")[0]).join(", ");
             reject(new Error(`No session_token cookie in login response (set-cookie names: ${names || "<none>"})`));
             return;
           }
-          resolve(sessionCookie);
+          resolve(sessionSetCookie);
         });
       }
     );
@@ -207,12 +240,18 @@ async function getSessionCookie() {
     req.end();
   });
 
+  const cookie = setCookieLine.split(";")[0]; // forward only `name=value`
+  const now = Date.now();
   cachedSession = {
     cookie,
-    expiresAt: Date.now() + 23 * 60 * 60 * 1000, // 23 hours
+    expiresAt: sessionCacheExpiry(now, setCookieLine, {
+      ttlCapMs: SESSION_TTL_CAP_MS,
+      skewMs: SESSION_REFRESH_SKEW_MS,
+    }),
   };
 
-  console.log("[auth-proxy] Session cookie obtained and cached (23h TTL)");
+  const ttlMin = Math.round((cachedSession.expiresAt - now) / 60000);
+  console.log(`[auth-proxy] Session cookie obtained and cached (~${ttlMin}m TTL, in-memory only)`);
   return cookie;
 }
 
@@ -307,7 +346,41 @@ function fenceUntrustedContent(text, source = "external") {
 
 // ── Plain proxy pass-through (no auth manipulation) ─────────────────────────
 
+// CSRF fail-closed Origin guard (issue #21). The pass-through path below rewrites
+// Host/Origin to PUBLIC_URL so PaperClip's board-mutation guard accepts legit
+// cloudflared traffic — but rewriting Origin UNCONDITIONALLY also launders a
+// cross-site attacker's Origin into a trusted value, defeating CSRF protection.
+// Validate the INCOMING Origin against the public host + PAPERCLIP_ALLOWED_HOSTNAMES
+// before any rewrite. A missing Origin (same-origin or non-browser client) is
+// allowed; a present-but-mismatched or malformed Origin is rejected. With no
+// allow-list configured, only the public host passes — fail closed.
+function isOriginAllowed(origin, { publicUrl, allowedHostnames }) {
+  if (!origin) return true;
+  let host;
+  try { host = new URL(origin).hostname.toLowerCase(); } catch { return false; }
+  const allowed = new Set();
+  try { allowed.add(new URL(publicUrl).hostname.toLowerCase()); } catch { /* unparseable publicUrl */ }
+  for (const h of String(allowedHostnames || "").split(",")) {
+    const t = h.trim().toLowerCase();
+    if (t) allowed.add(t);
+  }
+  return allowed.has(host);
+}
+
 function proxyPassThrough(clientReq, clientRes) {
+  // Reject cross-origin state-changing requests BEFORE laundering Origin/Host to
+  // the public URL (issue #21) — otherwise the rewrite would hand PaperClip's
+  // CSRF guard a forged-but-trusted Origin.
+  if (STATE_CHANGING_METHODS.has(clientReq.method) &&
+      !isOriginAllowed(clientReq.headers.origin, { publicUrl: PUBLIC_URL, allowedHostnames: ALLOWED_HOSTNAMES })) {
+    console.warn(`[auth-proxy] CSRF: rejected ${clientReq.method} ${clientReq.url} from origin '${clientReq.headers.origin}'`);
+    clientRes.writeHead(403, { "Content-Type": "application/json" });
+    clientRes.end(JSON.stringify({
+      error: "Forbidden",
+      message: "Cross-origin request rejected (CSRF protection)",
+    }));
+    return;
+  }
   // Strip both automation identity headers so pass-through callers can't spoof
   // the values the auth-proxy injects after JWT validation.
   const headers = { ...clientReq.headers };
@@ -1569,6 +1642,12 @@ if (isMainModule) {
     console.warn("[auth-proxy] JWT bearer auth disabled — browser session auth still works");
   }
 
+  if (!PUBLIC_URL_CONFIGURED) {
+    console.warn("[auth-proxy] WARNING: PAPERCLIP_PUBLIC_URL not set — using localhost fallback. " +
+      "Browser CSRF enforcement trusts only the localhost origin plus any PAPERCLIP_ALLOWED_HOSTNAMES; " +
+      "set PAPERCLIP_PUBLIC_URL to your public hostname in any real deploy.");
+  }
+
   server.listen(PROXY_PORT, "0.0.0.0", () => {
     console.log(`[auth-proxy] Listening on :${PROXY_PORT} → Paperclip :${BACKEND_PORT}`);
     console.log(`[auth-proxy] Browser traffic: pass-through (session cookies)`);
@@ -1590,6 +1669,9 @@ export {
   safePath,
   parseFrontmatter,
   stripBom,
+  isOriginAllowed,
+  cookieMaxAgeMs,
+  sessionCacheExpiry,
   handleRequest,
   guardedHandler,
   server,

--- a/tests/auth-proxy/auth-proxy.test.mjs
+++ b/tests/auth-proxy/auth-proxy.test.mjs
@@ -14,7 +14,8 @@ import { resolve } from "node:path";
 process.env.PAPERCLIP_AUTOMATION_JWT_ISSUER = "test-issuer";
 process.env.PAPERCLIP_AUTOMATION_JWT_AUDIENCE = "test-audience";
 
-const { verifyJwt, checkScope, governorTargetPath, fenceUntrustedContent, safePath, parseFrontmatter, stripBom } =
+const { verifyJwt, checkScope, governorTargetPath, fenceUntrustedContent, safePath, parseFrontmatter, stripBom,
+        isOriginAllowed, cookieMaxAgeMs, sessionCacheExpiry } =
   await import("../../apps/paperclip/auth-proxy.mjs");
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -140,6 +141,69 @@ test("safePath allows the base itself", () => {
 test("stripBom removes a leading BOM and is a no-op otherwise", () => {
   assert.equal(stripBom("﻿hi"), "hi");
   assert.equal(stripBom("hi"), "hi");
+});
+
+// ── isOriginAllowed (CSRF fail-closed Origin guard, issue #21) ───────────────
+// The pass-through (browser cookie) path used to launder Origin -> PUBLIC_URL
+// unconditionally, defeating PaperClip's CSRF guard. isOriginAllowed validates
+// the *incoming* Origin against the public host + PAPERCLIP_ALLOWED_HOSTNAMES
+// before any rewrite, and fails CLOSED when the allow-list is unset.
+const ORIGIN_CFG = { publicUrl: "https://forge.example.com", allowedHostnames: "forge.example.com, admin.example.com" };
+
+test("isOriginAllowed: no Origin header is allowed (not a tagged cross-origin request)", () => {
+  assert.equal(isOriginAllowed(undefined, ORIGIN_CFG), true);
+  assert.equal(isOriginAllowed("", ORIGIN_CFG), true);
+  assert.equal(isOriginAllowed(null, ORIGIN_CFG), true);
+});
+test("isOriginAllowed: an Origin matching the public URL host is allowed", () => {
+  assert.equal(isOriginAllowed("https://forge.example.com", ORIGIN_CFG), true);
+});
+test("isOriginAllowed: an Origin in PAPERCLIP_ALLOWED_HOSTNAMES is allowed", () => {
+  assert.equal(isOriginAllowed("https://admin.example.com", ORIGIN_CFG), true);
+});
+test("isOriginAllowed: a cross-origin request is rejected", () => {
+  assert.equal(isOriginAllowed("https://evil.com", ORIGIN_CFG), false);
+});
+test("isOriginAllowed: host match is case-insensitive and ignores port/path", () => {
+  assert.equal(isOriginAllowed("https://FORGE.example.com:443", ORIGIN_CFG), true);
+});
+test("isOriginAllowed: a malformed Origin is rejected (fail-closed)", () => {
+  assert.equal(isOriginAllowed("not a url", ORIGIN_CFG), false);
+});
+test("isOriginAllowed: fails CLOSED when allowedHostnames is unset — only the public host passes", () => {
+  const cfg = { publicUrl: "https://forge.example.com", allowedHostnames: "" };
+  assert.equal(isOriginAllowed("https://forge.example.com", cfg), true);
+  assert.equal(isOriginAllowed("https://evil.com", cfg), false);
+});
+
+// ── cookieMaxAgeMs / sessionCacheExpiry (session TTL hardening, issue #18) ────
+// The bootstrapped admin session was cached for a flat 23h. These helpers cap
+// the cache TTL, honor the cookie's own Max-Age when shorter, and subtract a
+// refresh skew so the proxy re-auths before the upstream session lapses.
+test("cookieMaxAgeMs parses Max-Age (case-insensitive) and returns null when absent", () => {
+  assert.equal(cookieMaxAgeMs("__Secure-x.session_token=abc; Path=/; Max-Age=3600; HttpOnly"), 3600 * 1000);
+  assert.equal(cookieMaxAgeMs("x.session_token=abc; path=/; max-age=120"), 120 * 1000);
+  assert.equal(cookieMaxAgeMs("x.session_token=abc; Path=/; HttpOnly"), null);
+});
+test("sessionCacheExpiry: no Max-Age falls back to the TTL cap minus skew", () => {
+  const now = 1_000_000;
+  const exp = sessionCacheExpiry(now, "x.session_token=abc", { ttlCapMs: 3600_000, skewMs: 60_000 });
+  assert.equal(exp, now + 3600_000 - 60_000);
+});
+test("sessionCacheExpiry: a shorter cookie Max-Age wins over the cap", () => {
+  const now = 1_000_000;
+  const exp = sessionCacheExpiry(now, "x.session_token=abc; Max-Age=600", { ttlCapMs: 3600_000, skewMs: 60_000 });
+  assert.equal(exp, now + 600_000 - 60_000);
+});
+test("sessionCacheExpiry: a longer cookie Max-Age is capped by the configured TTL", () => {
+  const now = 1_000_000;
+  const exp = sessionCacheExpiry(now, "x.session_token=abc; Max-Age=86400", { ttlCapMs: 3600_000, skewMs: 60_000 });
+  assert.equal(exp, now + 3600_000 - 60_000);
+});
+test("sessionCacheExpiry: never returns a past timestamp (1s floor)", () => {
+  const now = 1_000_000;
+  const exp = sessionCacheExpiry(now, "x.session_token=abc; Max-Age=5", { ttlCapMs: 3600_000, skewMs: 60_000 });
+  assert.equal(exp, now + 1000);
 });
 
 // ── parseFrontmatter ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #21 and #18 — the two open auth-proxy findings from the post-publication security audit of #17.

## #21 — CSRF/Origin guard fails open (Low)
The browser pass-through path rewrote `headers.origin = PUBLIC_URL` **unconditionally** before forwarding (`auth-proxy.mjs:321`). That launders a cross-site attacker's `Origin` into a trusted value, defeating PaperClip's board-mutation CSRF guard entirely — and `PUBLIC_URL` silently falls back to `localhost` when `PAPERCLIP_PUBLIC_URL` is unset.

**Fix:** validate the *incoming* `Origin` against the public host + `PAPERCLIP_ALLOWED_HOSTNAMES` **before** any rewrite, for state-changing methods (`POST/PUT/PATCH/DELETE`) only:
- Missing `Origin` (same-origin / non-browser client) → allowed.
- Present-but-mismatched or malformed `Origin` → `403`.
- **No allow-list configured → only the public host passes (fail closed).**
- Startup warning when `PAPERCLIP_PUBLIC_URL` is unset, so the weakened posture is visible in deploys.

GET/whoami, the iMessage/Lacy webhooks (own handlers, shared-secret auth), and the JWT automation path all bypass this guard correctly.

## #18 — 23h admin-session TTL (Medium)
The bootstrapped admin session cookie was cached for a flat **23h** (`auth-proxy.mjs:212`).

**Fix:** cap the cache TTL (default **1h** via `PAPERCLIP_SESSION_TTL_SECONDS`), honor the cookie's own `Max-Age` when shorter, and subtract a 60s refresh skew so the proxy re-auths before the upstream session lapses. Cookie remains in-memory only and is never logged (confirmed — no disk persistence).

## Tests
Three new pure, exported helpers — `isOriginAllowed`, `cookieMaxAgeMs`, `sessionCacheExpiry` — built TDD-first (12 new tests, watched fail → implemented). Full suite **41/41 green** via `node --test tests/auth-proxy/*.test.mjs`. No behavior change to existing helpers.

> Security-sensitive change — opening green for operator review/merge rather than auto-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)