### PR TITLE
feat(research): web-read wrapper — clean Markdown page extraction via Jina Reader

### DIFF
--- a/agents/profiles/researcher.AGENTS.md
+++ b/agents/profiles/researcher.AGENTS.md
@@ -38,7 +38,7 @@ When in doubt about whether something is in your lane, bounce it. The cost of an
 
 You are **Researcher**, the research specialist for the platform. Your principal is the operator; your direct router is Planner. You run on a frontier model (current best for research and synthesis) with three toolsets enabled: `terminal`, `file`, and `browser`.
 
-**Heads up on the browser toolset:** in some deployed environments the browser tool (`browser_navigate`) is unavailable — neither a local browser engine nor a cloud browser provider is wired up. Don't waste turns calling `browser_navigate` repeatedly when it errors. Your fallback research tools are a **search-API CLI** (a search wrapper on `$PATH`) and `curl` (for fetching specific URLs). The browser tool is documented here for the day it's wired up; until then, treat it as a fallback path through the search API.
+**Heads up on the browser toolset:** in some deployed environments the browser tool (`browser_navigate`) is unavailable — neither a local browser engine nor a cloud browser provider is wired up. Don't waste turns calling `browser_navigate` repeatedly when it errors. Your fallback research tools are a **search-API CLI** (a search wrapper on `$PATH`) and **`web-read`** (clean-Markdown page extraction; `curl` is the lower-level fallback for fetching specific URLs). The browser tool is documented here for the day it's wired up; until then, treat it as a fallback path through the search API.
 
 **Why a search-API wrapper and not a scraping client:** some public search clients are silently blocked when they originate from cloud / datacenter IPs — they return empty results even though the CLI exits 0, which agents misread as "no results found." Prefer a search API with a proper key (the wrapper on `$PATH`); it accepts cloud IPs and emits a stable JSON shape (`[{title, href, body}]`) so the workflow below is unchanged.
 
@@ -89,9 +89,18 @@ search text -k "your query terms" -m 10 -o json
 
 Read the returned JSON. Each result has `title`, `href`, and `body` (snippet). Often the snippets answer the question directly — especially for news and well-indexed factual queries. If they do, you can stop after Stage 1 and compose your answer using those URLs as sources.
 
-### Stage 2 - fetch a specific page with curl
+### Stage 2 - fetch a specific page with web-read (clean Markdown)
 
-If search snippets are partial, ambiguous, or you need the full content of a specific page (article, official source, vendor doc), `curl` it:
+If search snippets are partial, ambiguous, or you need the full content of a specific page (article, official source, vendor doc), use **`web-read`** — a wrapper on `$PATH` that returns clean, readable **Markdown** instead of raw HTML:
+
+```bash
+web-read "https://example.com/path" > /tmp/page.md
+head -c 5000 /tmp/page.md
+```
+
+`web-read` strips tags, scripts, and nav chrome server-side (via Jina Reader), so you get the page's actual content — no HTML parsing. It exits **3** with a clear error on a non-2xx response or timeout; treat that as a failed fetch (try another URL or escalate to Stage 3). Add `--json` for structured `{title, url, content}`.
+
+**Fallback — raw `curl` + strip:** only if `web-read` is unavailable or fails on a page that should work, fetch the HTML directly and strip it:
 
 ```bash
 curl -sL -H "User-Agent: Mozilla/5.0 (compatible; PaperClipBot/1.0)" "https://example.com/path" -o /tmp/page.html
@@ -106,7 +115,7 @@ class S(HTMLParser):
 p=S(); p.feed(open('/tmp/page.html').read()); print(' '.join(' '.join(p.s).split()))" | head -c 5000
 ```
 
-This gives you the visible text content of the page (no JavaScript-rendered sections, but most authoritative news / vendor sites have static HTML for the data you need).
+Either path gives you the visible text content of the page (no JavaScript-rendered sections, but most authoritative news / vendor sites have static content for the data you need).
 
 ### Stage 3 - cancel if neither stage produced an answer
 
@@ -119,7 +128,7 @@ Then PATCH the issue to `cancelled`. **Do not** mark it `done`.
 ### Hard limits to prevent loops
 
 - `search`: at most **2** invocations per task. If reworded queries don't help, escalate to Stage 2.
-- `curl`: at most **3** distinct URLs per task. If three different sites don't yield content, escalate to Stage 3.
+- page fetches (`web-read`/`curl`): at most **3** distinct URLs per task. If three different sites don't yield content, escalate to Stage 3.
 - Total tool calls (excluding the initial issue list / fetch): cap at **8** per task. If you've used 8 and don't have an answer yet, cancel.
 
 ## Mandatory output format
@@ -141,14 +150,14 @@ Example structure:
 
 ## Verbatim-source rule (anti-fabrication, MANDATORY)
 
-**Every named entity in your final comment — every proper name, organization not already in the question, figure, version number, date, price, statistic — MUST appear verbatim in the printed output of one of your `search` calls or one of the `/tmp/*.html` files you fetched and parsed this session.**
+**Every named entity in your final comment — every proper name, organization not already in the question, figure, version number, date, price, statistic — MUST appear verbatim in the printed output of one of your `search` calls or one of the `/tmp` page files you fetched this session (`.md` from `web-read`, `.html` from `curl`).**
 
 Before posting, do this concrete check:
 
 ```bash
 # Substitute each name/number you're about to claim:
-grep -F "<entity you're about to claim>" /tmp/*.html
-grep -F "<figure you're about to claim>" /tmp/*.html
+grep -F "<entity you're about to claim>" /tmp/*.md /tmp/*.html 2>/dev/null
+grep -F "<figure you're about to claim>" /tmp/*.md /tmp/*.html 2>/dev/null
 # If grep returns NOTHING for any claim → that claim is fabricated. Remove it.
 ```
 
@@ -199,7 +208,7 @@ These map to real failure modes already observed:
 - ❌ **DO NOT lift facts from this prompt.** If a name or figure appears here, that's an *example* or a *routing rule* — not your source. Your sources are pages you actually visited.
 - ❌ **DO NOT pad an answer with training-data context.** If you research a vendor's pricing and find three tiers, post three tiers. Don't add background filler the question didn't ask for — that's chatbot padding, not research.
 - ❌ **DO NOT end a session without executing the POST + PATCH curls.** A composed-but-uncommitted answer is invisible to the user. See § Session-end requirement.
-- ❌ **DO NOT trust your own composition step.** Right before posting, run the `grep -F "<entity>" /tmp/*.html` check from § Verbatim-source rule for every name in your draft. If grep is empty, the name is fabricated.
+- ❌ **DO NOT trust your own composition step.** Right before posting, run the `grep -F "<entity>" /tmp/*.md /tmp/*.html` check from § Verbatim-source rule for every name in your draft. If grep is empty, the name is fabricated.
 
 # One-shot principle
 

--- a/apps/hermes/overrides/skills/playbooks/web-read/SKILL.md
+++ b/apps/hermes/overrides/skills/playbooks/web-read/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: web-read
+description: >
+  Read a web page as clean Markdown instead of raw HTML. Use whenever you need
+  the actual content of a specific URL — an article, vendor/pricing page,
+  changelog, docs page, or any link a search result pointed you to. Trigger
+  phrases: "read this page", "what does <url> say", "fetch/open this link",
+  "get the article", "extract the content", or any time you would otherwise
+  `curl` a URL to read it. The `web-read` CLI is on `$PATH`.
+---
+
+# Read a web page as clean Markdown with `web-read`
+
+`web-read` is a CLI on `$PATH` that fetches a URL through [Jina Reader](https://r.jina.ai)
+and returns clean, readable **Markdown** — the page's actual content with the
+HTML tags, scripts, and navigation chrome stripped server-side.
+
+> Prefer `web-read` over raw `curl` when your goal is to **read** a page. Raw
+> `curl` returns the HTML source (tags and all), which buries the content and
+> wastes context. Use `curl` only for API calls or when `web-read` can't reach a page.
+
+## Usage
+
+```bash
+# Clean Markdown to stdout — capture it so you can grep/quote it later:
+web-read "https://example.com/article" > /tmp/page.md
+head -c 5000 /tmp/page.md
+
+# Structured JSON ({title, url, content, ...}) instead of Markdown:
+web-read --json "https://example.com/article"
+```
+
+Only `http://` and `https://` URLs are accepted. Quote the URL.
+
+## Behavior and exit codes
+
+| Exit | Meaning |
+|---|---|
+| `0` | Success — page content is on stdout. |
+| `2` | Usage / validation error (no URL, bad scheme, unknown flag). Fix the call. |
+| `3` | Fetch failed — non-2xx from Jina or a timeout. A clear error is printed to **stderr**. Treat as a failed fetch: try another URL or stop; **do not** fabricate content. |
+
+All errors go to **stderr**, so `web-read "$url" > /tmp/page.md` leaves `/tmp/page.md`
+holding clean content (or empty on failure) — never an error string mixed into the text.
+
+## Environment
+
+| Variable | Purpose |
+|---|---|
+| `JINA_API_KEY` | Optional. Sent as a Bearer token for a higher rate limit. Anonymous (no key) still works. |
+| `WEB_READ_TIMEOUT` | Optional. Per-request timeout in seconds (default `20`). |
+
+## Privacy note
+
+The target URL transits `r.jina.ai`, a third-party reader service. That is fine
+for **public** research. Do **not** point `web-read` at private, internal, or
+regulated content — fetch those with `curl` directly instead.

--- a/apps/paperclip/web-read-wrapper.sh
+++ b/apps/paperclip/web-read-wrapper.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+# Smart wrapper around Jina Reader (https://r.jina.ai) for clean Markdown
+# extraction of any web page.
+#
+# Why: an agent that `curl`s a page gets raw HTML — tags, scripts, nav chrome —
+# which buries the actual content and wastes context. Jina Reader fetches the
+# URL server-side and returns clean, readable Markdown (the content a human
+# would read). This is the "for page content, use web-read, not raw curl" path.
+#
+# Usage forms:
+#   web-read https://example.com/article          # clean Markdown to stdout
+#   web-read --json https://example.com/article    # JSON {title, url, content, ...}
+#
+# Anonymous by default (no key needed). Set JINA_API_KEY in the container env for
+# a higher rate limit — the wrapper sends it as a Bearer token; without it the
+# request is still served anonymously.
+#
+# Output: page content on stdout; all errors on stderr so a caller capturing
+# stdout (e.g. `web-read "$url" > /tmp/page.md`) gets clean content or nothing.
+#
+# Exit codes: 0 ok · 2 usage/validation error · 3 fetch failed (non-2xx or timeout).
+#
+# Privacy note: the target URL transits r.jina.ai (a third-party reader). Fine
+# for public research; flag before pointing it at regulated/private content.
+#
+# Requires curl (present in the paperclip base image). No API key required.
+
+set -eu
+
+TIMEOUT="${WEB_READ_TIMEOUT:-20}"
+JSON=0
+URL=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --json)
+      JSON=1
+      shift
+      ;;
+    -h|--help)
+      echo "Usage: web-read [--json] <url>" >&2
+      echo "  Clean Markdown extraction of a web page via Jina Reader." >&2
+      echo "  --json   return structured JSON instead of Markdown." >&2
+      echo "  Env: JINA_API_KEY (optional, higher rate limit); WEB_READ_TIMEOUT (default 20s)." >&2
+      exit 0
+      ;;
+    -*)
+      echo "ERROR: unknown option: $1" >&2
+      echo "Usage: web-read [--json] <url>" >&2
+      exit 2
+      ;;
+    *)
+      if [ -n "$URL" ]; then
+        echo "ERROR: more than one URL given. Quote the URL if it contains spaces." >&2
+        echo "Usage: web-read [--json] <url>" >&2
+        exit 2
+      fi
+      URL="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$URL" ]; then
+  echo "ERROR: no URL provided. Usage: web-read [--json] <url>" >&2
+  exit 2
+fi
+
+# Only http(s): Jina won't read file://, and we don't forward odd schemes.
+case "$URL" in
+  http://*|https://*) ;;
+  *)
+    echo "ERROR: URL must start with http:// or https:// (got: $URL)" >&2
+    exit 2
+    ;;
+esac
+
+# Build curl args. Anonymous unless JINA_API_KEY is set.
+set -- \
+  --silent --show-error --location \
+  --max-time "$TIMEOUT" \
+  --header "User-Agent: azureagentforge-web-read/1.0"
+if [ "$JSON" -eq 1 ]; then
+  set -- "$@" --header "Accept: application/json"
+fi
+if [ -n "${JINA_API_KEY:-}" ]; then
+  set -- "$@" --header "Authorization: Bearer ${JINA_API_KEY}"
+fi
+
+# r.jina.ai takes the target URL verbatim as a path suffix:
+#   https://r.jina.ai/https://example.com/article
+body_file="$(mktemp)"
+trap 'rm -f "$body_file"' EXIT INT TERM
+
+# `|| true` so a curl transport failure (e.g. timeout, exit 28) doesn't trip
+# `set -e` before we can read the HTTP status and emit a clear message.
+http_code="$(curl "$@" --output "$body_file" --write-out '%{http_code}' "https://r.jina.ai/${URL}" || true)"
+
+case "$http_code" in
+  2??)
+    cat "$body_file"
+    ;;
+  000|"")
+    echo "ERROR: web-read could not reach r.jina.ai for ${URL} (timed out after ${TIMEOUT}s or a network error)." >&2
+    exit 3
+    ;;
+  *)
+    echo "ERROR: web-read got HTTP ${http_code} reading ${URL} via r.jina.ai." >&2
+    head -c 400 "$body_file" 1>&2 || true
+    echo "" >&2
+    exit 3
+    ;;
+esac

--- a/services/paperclip/Dockerfile
+++ b/services/paperclip/Dockerfile
@@ -256,6 +256,13 @@ RUN chmod +x /usr/local/bin/ddgs
 COPY apps/paperclip/brave-search-wrapper.sh /usr/local/bin/brave-search
 RUN chmod +x /usr/local/bin/brave-search
 
+# web-read wrapper — clean Markdown extraction of any URL via Jina Reader
+# (r.jina.ai). Agents that raw-curl a page get HTML tags; web-read returns the
+# readable content instead. Anonymous by default; JINA_API_KEY (optional, KV-
+# backed) raises the rate limit.
+COPY apps/paperclip/web-read-wrapper.sh /usr/local/bin/web-read
+RUN chmod +x /usr/local/bin/web-read
+
 # Hermes skills: pip install doesn't include skills/, copy them separately.
 # Placed at /opt/hermes-skills so they're baked into the image. The entrypoint
 # syncs these to ~/.hermes/skills on the persistent volume.


### PR DESCRIPTION
**Agent-Reach Track A, item A1** — the highest-ROI research-skill win. Gives researcher agents a `web-read` CLI that returns clean Markdown for any URL instead of raw HTML.

## Problem
The researcher workflow's Stage 2 was "`curl` the page → strip HTML with a Python `HTMLParser` one-liner." Agents get tag soup, scripts, and nav chrome — content buried, context wasted.

## What's added
- **`apps/paperclip/web-read-wrapper.sh`** → `/usr/local/bin/web-read`. POSIX `sh`, curl-based, mirrors `brave-search-wrapper.sh` conventions:
  - `web-read <url>` → clean Markdown to stdout; `--json` → `{title, url, content, ...}`
  - http(s)-only validation; errors to **stderr** (so `> /tmp/page.md` stays clean)
  - exit `0` ok / `2` usage / `3` fetch-failed (non-2xx or timeout, with a clear message)
  - anonymous by default; optional `JINA_API_KEY` (Bearer, higher rate limit); `WEB_READ_TIMEOUT` (default 20s)
- **`services/paperclip/Dockerfile`** — COPY + chmod next to brave-search.
- **`agents/profiles/researcher.AGENTS.md`** — Stage 2 now leads with `web-read`; raw-`curl`+strip kept as the explicit fallback. The verbatim-source anti-fabrication check and the page-fetch limit are generalized to cover `/tmp/*.md` (web-read) and `/tmp/*.html` (curl).
- **`apps/hermes/overrides/skills/playbooks/web-read/SKILL.md`** — discoverable playbook (un-manifested, like `tagore`).

## Verification
- Offline arg/validation checks **8/8**; `shellcheck --severity=error` clean; `bash -n` clean.
- **Live** fetch of `example.com` returns Markdown and (`--json`) structured JSON; fetch-error path exits `3` with a clear stderr message.
- `python agents/validate_profiles.py` → **14/14 valid**; `scripts/validate-build-context.sh` → COPY sources resolve.
- Boot-in-image verified by the `smoke` gate on this PR.

> Privacy note (in the wrapper + SKILL.md): target URLs transit `r.jina.ai`. Fine for public research; not for private/regulated content. The follow-on MRTek/Gandalf port (private repo, ADO) is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)