### PR TITLE
feat(research): exa-search + video-transcript wrappers (Agent-Reach A2 + A3)

### DIFF
--- a/agents/profiles/researcher.AGENTS.md
+++ b/agents/profiles/researcher.AGENTS.md
@@ -87,6 +87,8 @@ search text -k "your query terms" -m 10 -o json
 
 (Naive form `search "your query"` also works.)
 
+> Some deployments expose more than one search backend — a **semantic** one (best for conceptual or exploratory queries: "frameworks like X", "research on Y") and a **keyword/news** one (best for fresh, exact-term, or breaking queries). When both are available, pick the one that fits the query; the call shape above is identical for either, and you can cross-check by running both.
+
 Read the returned JSON. Each result has `title`, `href`, and `body` (snippet). Often the snippets answer the question directly — especially for news and well-indexed factual queries. If they do, you can stop after Stage 1 and compose your answer using those URLs as sources.
 
 ### Stage 2 - fetch a specific page with web-read (clean Markdown)

--- a/agents/profiles/researcher.AGENTS.md
+++ b/agents/profiles/researcher.AGENTS.md
@@ -119,6 +119,8 @@ p=S(); p.feed(open('/tmp/page.html').read()); print(' '.join(' '.join(p.s).split
 
 Either path gives you the visible text content of the page (no JavaScript-rendered sections, but most authoritative news / vendor sites have static content for the data you need).
 
+**Video sources:** if the source you need is a video (YouTube, Vimeo, etc.), use `video-transcript "<url>" > /tmp/page.md` to pull its transcript as plain text, then treat that text like any other fetched page (the same verbatim-source rules apply).
+
 ### Stage 3 - cancel if neither stage produced an answer
 
 If search returns no useful results AND your `curl` attempts fail (DNS errors, 4xx/5xx, blocked, or page structure prevents extraction), do NOT fabricate. Post EXACTLY:

--- a/apps/hermes/overrides/skills/playbooks/exa-search/SKILL.md
+++ b/apps/hermes/overrides/skills/playbooks/exa-search/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: exa-search
+description: >
+  Semantic / neural web search via the Exa API. Use for conceptual, exploratory,
+  or "find things like X" research where keyword search underperforms — e.g.
+  "papers about agent memory", "companies similar to <X>", "blog posts arguing
+  <position>". Trigger phrases: "search for", "find research/papers/articles on",
+  "what's out there about", "find similar", "semantic search". Complements
+  brave-search (use brave for fresh/news/exact-term). The `exa-search` CLI is on
+  `$PATH` and emits the same JSON shape as brave-search.
+---
+
+# Semantic web search with `exa-search`
+
+`exa-search` is a CLI on `$PATH` that queries the [Exa](https://exa.ai) neural
+search API and returns results in the **same** ddgs-compatible JSON shape as
+`brave-search` — an array of `{title, href, body}` — so it's a drop-in alongside
+the other search tools.
+
+## When to use which search backend
+
+| Backend | Best for |
+|---|---|
+| **`exa-search`** | Conceptual / semantic / exploratory queries: "frameworks like LangGraph", "research on agent memory", "find articles arguing X". Neural search finds relevant pages even when they don't contain your exact words. |
+| **`brave-search`** | Fresh / breaking / exact-term queries: news, a specific product page, a known title, anything time-sensitive. |
+
+When a question has both an exploratory and a freshness angle, run **both** and merge — they surface different pages.
+
+## Usage
+
+```bash
+# Naive form:
+exa-search "open-source agent frameworks with durable execution"
+
+# ddgs-compatible form (same flags as brave-search), e.g. 8 results:
+exa-search text -k "open-source agent frameworks" -m 8 -o json
+```
+
+Output is a JSON array; each element has `title`, `href`, and `body` (a short
+text excerpt from the page). Parse it the same way you parse `brave-search`
+output.
+
+## Behavior and exit codes
+
+| Exit | Meaning |
+|---|---|
+| `0` | Success — JSON array on stdout (may be `[]` if Exa found nothing). |
+| `1` | `EXA_API_KEY` is not set. The wrapper can't run without it. |
+| `2` | Empty query. |
+| `3` / `4` | Exa API error (non-2xx) or a transport failure — a clear message is printed to stderr. |
+
+## Environment
+
+| Variable | Purpose |
+|---|---|
+| `EXA_API_KEY` | **Required.** Exa API key (free tier ~1,000 searches/month). In Azure deploys it is mounted from the `exa-api-key` Key Vault secret when `exa_search_enabled = true`. |
+
+If `exa-search` exits `1`, Exa isn't configured in this environment — fall back to
+`brave-search`.

--- a/apps/hermes/overrides/skills/playbooks/video-transcript/SKILL.md
+++ b/apps/hermes/overrides/skills/playbooks/video-transcript/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: video-transcript
+description: >
+  Pull a plain-text transcript from a video URL (YouTube, Vimeo, Bilibili, and
+  ~1800 other sites) so you can read, summarize, quote, or research its content
+  without watching it. Use whenever a source or request is a video link.
+  Trigger phrases: "summarize this video", "what does this talk/video say",
+  "transcript of <url>", "get the captions", or any task pointing at a youtube.com
+  / youtu.be / vimeo / video URL. The `video-transcript` CLI is on `$PATH`.
+---
+
+# Get a video's transcript with `video-transcript`
+
+`video-transcript` is a CLI on `$PATH` that extracts a clean, plain-text
+transcript from a video URL using [yt-dlp](https://github.com/yt-dlp/yt-dlp).
+It fetches subtitles/captions (human or auto-generated), strips the timing markup,
+and de-duplicates the rolling caption lines into readable prose.
+
+## Usage
+
+```bash
+# Print the transcript — capture it so you can grep/quote/summarize it:
+video-transcript "https://www.youtube.com/watch?v=VIDEO_ID" > /tmp/page.md
+head -c 4000 /tmp/page.md
+
+# Prefer a subtitle language (falls back to English):
+video-transcript --lang es "https://www.youtube.com/watch?v=VIDEO_ID"
+```
+
+Only `http(s)` URLs are accepted. Output (and errors) follow the same convention
+as `web-read`: transcript on stdout, errors on stderr.
+
+## How it gets the text
+
+1. **Captions** (default, no key) — human subs first, then auto-generated. Covers
+   most YouTube videos.
+2. **Whisper fallback** (optional) — if a video has **no** captions *and*
+   `GROQ_API_KEY` is set, it downloads the audio and transcribes it with Groq
+   Whisper (needs `ffmpeg`). Without the key, a caption-less video returns exit `4`.
+
+## Behavior and exit codes
+
+| Exit | Meaning |
+|---|---|
+| `0` | Success — transcript on stdout. |
+| `2` | Usage / validation error (no URL, bad scheme, bad flag). |
+| `3` | Fetch or transcription failed (clear error on stderr). |
+| `4` | No captions and no Whisper fallback (`GROQ_API_KEY` unset). Try a different source. |
+| `5` | A required tool (`yt-dlp`, or `ffmpeg` for the fallback) is missing. |
+
+## Environment
+
+| Variable | Purpose |
+|---|---|
+| `VIDEO_TRANSCRIPT_MAX_CHARS` | Cap on transcript length (default `100000`; long videos are truncated with a marker). |
+| `VIDEO_TRANSCRIPT_LANG` | Default subtitle language (default `en`). |
+| `VIDEO_TRANSCRIPT_YT_CLIENT` | yt-dlp YouTube `player_client` (default `android,web`). YouTube gates captions behind a PO token for the web client from datacenter IPs; the android client bypasses it. Override if YouTube extraction breaks. |
+| `GROQ_API_KEY` | Optional. Enables the Whisper fallback for caption-less videos. |
+
+## Caveat
+
+YouTube extraction is a moving target (PO tokens, SABR streaming, client churn).
+If transcripts suddenly stop working, it's usually YouTube-side — the pinned
+yt-dlp may need bumping and `VIDEO_TRANSCRIPT_YT_CLIENT` may need adjusting.
+For private/internal videos, don't rely on this — it goes through public extractors.

--- a/apps/paperclip/exa-search-wrapper.sh
+++ b/apps/paperclip/exa-search-wrapper.sh
@@ -1,0 +1,114 @@
+#!/bin/sh
+# Smart wrapper around the Exa search API (https://exa.ai).
+#
+# Research-grade semantic web search, alongside brave-search. Exa is neural/
+# semantic — strong for conceptual queries ("frameworks like X", "papers about
+# Y") where keyword search underperforms. Keep brave-search for fresh/news and
+# exact-term queries; this complements it.
+#
+# Usage forms accepted (mirrors brave-search-wrapper.sh / ddgs so AGENTS.md
+# examples don't have to change beyond the binary name):
+#   exa-search "query"                       # naive form
+#   exa-search text -k "query" -m 5 -o json  # ddgs-compatible form
+#
+# Output: JSON array of {title, href, body} objects (ddgs-compatible shape) so
+# downstream parsing in agent prompts continues to work.
+#
+# Requires EXA_API_KEY in the environment (free tier ~1,000 searches/month).
+
+set -e
+
+if [ -z "${EXA_API_KEY:-}" ]; then
+  echo "ERROR: EXA_API_KEY env var not set" >&2
+  exit 1
+fi
+
+# Parse args. Default count = 5.
+QUERY=""
+COUNT=5
+
+case "$1" in
+  text|news|web|"")
+    # ddgs-compatible form: exa-search text -k "query" -m 5 -o json
+    shift
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -k|--keywords) QUERY="$2"; shift 2 ;;
+        -m|--max-results) COUNT="$2"; shift 2 ;;
+        -o|--output) shift 2 ;;  # ignore; we always emit JSON
+        *) shift ;;
+      esac
+    done
+    ;;
+  --help|-h)
+    echo "Usage: exa-search \"query\"  OR  exa-search text -k \"query\" -m 5 -o json" >&2
+    exit 0
+    ;;
+  *)
+    # Naive form: everything after the binary is the query.
+    QUERY="$*"
+    ;;
+esac
+
+if [ -z "$QUERY" ]; then
+  echo "ERROR: empty query" >&2
+  exit 2
+fi
+
+# Call Exa. python3 is in the base image.
+exec python3 - "$QUERY" "$COUNT" <<'PYEOF'
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+query = sys.argv[1]
+try:
+    count = int(sys.argv[2])
+except ValueError:
+    count = 5
+api_key = os.environ["EXA_API_KEY"]
+
+payload = json.dumps({
+    "query": query,
+    "numResults": count,
+    # Ask for a short text excerpt so each result has a usable snippet (body).
+    "contents": {"text": {"maxCharacters": 800}},
+}).encode("utf-8")
+
+req = urllib.request.Request(
+    "https://api.exa.ai/search",
+    data=payload,
+    method="POST",
+    headers={
+        "x-api-key": api_key,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "User-Agent": "azureagentforge-exa-search/1.0",
+    },
+)
+
+try:
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        data = json.loads(resp.read())
+except urllib.error.HTTPError as e:
+    print(f"ERROR: Exa API returned HTTP {e.code}: {e.read().decode('utf-8', 'ignore')}", file=sys.stderr)
+    sys.exit(3)
+except Exception as e:
+    print(f"ERROR: Exa API call failed: {e}", file=sys.stderr)
+    sys.exit(4)
+
+results = []
+for item in (data.get("results") or [])[:count]:
+    body = (item.get("text") or item.get("summary") or "").strip()
+    # Collapse whitespace and cap the snippet so output stays compact.
+    body = " ".join(body.split())[:500]
+    results.append({
+        "title": item.get("title") or "",
+        "href": item.get("url") or "",
+        "body": body,
+    })
+
+print(json.dumps(results, ensure_ascii=False))
+PYEOF

--- a/apps/paperclip/video-transcript-wrapper.sh
+++ b/apps/paperclip/video-transcript-wrapper.sh
@@ -1,0 +1,178 @@
+#!/bin/sh
+# Pull a transcript from a video URL (YouTube, Bilibili, Vimeo, and ~1800 other
+# sites yt-dlp supports) for summarization/research.
+#
+# Strategy:
+#   1. Captions — fetch human or auto-generated subtitles via yt-dlp (no API key,
+#      covers the vast majority of YouTube videos), strip the VTT to clean,
+#      de-duplicated plain text.
+#   2. Whisper fallback (optional) — if there are NO captions AND GROQ_API_KEY is
+#      set, download the audio and transcribe it with Groq Whisper. Needs ffmpeg.
+#
+# Usage:
+#   video-transcript https://www.youtube.com/watch?v=...        # plain-text transcript
+#   video-transcript --lang es https://...                       # prefer a subtitle language
+#
+# Env:
+#   VIDEO_TRANSCRIPT_MAX_CHARS  cap on output length (default 100000)
+#   VIDEO_TRANSCRIPT_LANG       default subtitle language (default "en")
+#   GROQ_API_KEY                optional; enables the Whisper fallback for
+#                               caption-less videos (requires ffmpeg)
+#
+# Exit codes: 0 ok · 2 usage/validation · 3 fetch/transcribe failed ·
+#             4 no captions and no Whisper fallback available · 5 missing tool.
+#
+# Requires yt-dlp (and ffmpeg for the Whisper fallback) in the image.
+
+set -eu
+
+MAX_CHARS="${VIDEO_TRANSCRIPT_MAX_CHARS:-100000}"
+LANG_PREF="${VIDEO_TRANSCRIPT_LANG:-en}"
+# YouTube increasingly gates caption/format access behind a "PO token" for the
+# default web client (worse from datacenter IPs), silently yielding no subtitles.
+# The android client currently bypasses this. Passed only to the YouTube
+# extractor; ignored for the other ~1800 sites. Overridable as YouTube churns.
+YT_CLIENT="${VIDEO_TRANSCRIPT_YT_CLIENT:-android,web}"
+URL=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --lang)
+      [ $# -ge 2 ] || { echo "ERROR: --lang needs a value" >&2; exit 2; }
+      LANG_PREF="$2"
+      shift 2
+      ;;
+    -h|--help)
+      echo "Usage: video-transcript [--lang xx] <url>" >&2
+      echo "  Extract a plain-text transcript from a video URL via yt-dlp captions" >&2
+      echo "  (Whisper fallback for caption-less videos when GROQ_API_KEY is set)." >&2
+      exit 0
+      ;;
+    -*)
+      echo "ERROR: unknown option: $1" >&2
+      echo "Usage: video-transcript [--lang xx] <url>" >&2
+      exit 2
+      ;;
+    *)
+      if [ -n "$URL" ]; then
+        echo "ERROR: more than one URL given. Quote the URL." >&2
+        exit 2
+      fi
+      URL="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$URL" ]; then
+  echo "ERROR: no URL provided. Usage: video-transcript [--lang xx] <url>" >&2
+  exit 2
+fi
+
+case "$URL" in
+  http://*|https://*) ;;
+  *)
+    echo "ERROR: URL must start with http:// or https:// (got: $URL)" >&2
+    exit 2
+    ;;
+esac
+
+if ! command -v yt-dlp >/dev/null 2>&1; then
+  echo "ERROR: yt-dlp is not installed in this environment." >&2
+  exit 5
+fi
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT INT TERM
+
+# ── Stage 1: captions (human subs first, then auto-subs) ─────────────────────
+# `|| true`: a video with no subs makes yt-dlp exit non-zero; that's not fatal —
+# we detect "no .vtt produced" below and decide on the fallback.
+yt-dlp --quiet --no-warnings --skip-download \
+  --write-subs --write-auto-subs \
+  --sub-langs "${LANG_PREF}.*,${LANG_PREF},en" --sub-format vtt \
+  --extractor-args "youtube:player_client=${YT_CLIENT}" \
+  --output "${workdir}/sub.%(ext)s" "$URL" >/dev/null 2>&1 || true
+
+vtt="$(find "$workdir" -name '*.vtt' 2>/dev/null | head -n1)"
+
+if [ -n "$vtt" ]; then
+  python3 - "$vtt" "$MAX_CHARS" <<'PYEOF'
+import re, sys
+vtt_path = sys.argv[1]
+max_chars = int(sys.argv[2]) if len(sys.argv) > 2 else 100000
+out, last = [], None
+with open(vtt_path, encoding="utf-8", errors="ignore") as f:
+    for raw in f:
+        line = raw.rstrip("\n")
+        s = line.strip()
+        if not s:
+            continue
+        if s.startswith("WEBVTT") or s.startswith("Kind:") or s.startswith("Language:"):
+            continue
+        if "-->" in s:
+            continue
+        if re.fullmatch(r"\d+", s):        # bare cue index
+            continue
+        line = re.sub(r"<[^>]+>", "", line)  # inline timing/markup tags
+        line = line.replace("&nbsp;", " ")
+        line = re.sub(r"\s+", " ", line).strip()
+        if not line or line == last:        # drop rolling duplicates
+            continue
+        out.append(line)
+        last = line
+text = "\n".join(out)
+if len(text) > max_chars:
+    text = text[:max_chars].rstrip() + "\n...[transcript truncated]"
+print(text)
+PYEOF
+  exit 0
+fi
+
+# ── Stage 2: Whisper fallback (optional, gated on GROQ_API_KEY) ───────────────
+if [ -n "${GROQ_API_KEY:-}" ]; then
+  if ! command -v ffmpeg >/dev/null 2>&1; then
+    echo "ERROR: no captions for ${URL}; the Whisper fallback needs ffmpeg, which is not installed." >&2
+    exit 5
+  fi
+  yt-dlp --quiet --no-warnings -x --audio-format mp3 --audio-quality 5 \
+    --extractor-args "youtube:player_client=${YT_CLIENT}" \
+    --output "${workdir}/audio.%(ext)s" "$URL" >/dev/null 2>&1 \
+    || { echo "ERROR: no captions and audio download failed for ${URL}." >&2; exit 3; }
+  audio="$(find "$workdir" -name 'audio.*' 2>/dev/null | head -n1)"
+  if [ -z "$audio" ]; then
+    echo "ERROR: no captions and no audio could be extracted for ${URL}." >&2
+    exit 3
+  fi
+  resp_file="$(mktemp)"
+  trap 'rm -rf "$workdir" "$resp_file"' EXIT INT TERM
+  http_code="$(curl --silent --show-error --max-time 180 \
+    --output "$resp_file" --write-out '%{http_code}' \
+    --header "Authorization: Bearer ${GROQ_API_KEY}" \
+    --form "model=whisper-large-v3" \
+    --form "response_format=text" \
+    --form "file=@${audio}" \
+    https://api.groq.com/openai/v1/audio/transcriptions || true)"
+  case "$http_code" in
+    2??)
+      python3 - "$resp_file" "$MAX_CHARS" <<'PYEOF'
+import sys
+text = open(sys.argv[1], encoding="utf-8", errors="ignore").read().strip()
+max_chars = int(sys.argv[2]) if len(sys.argv) > 2 else 100000
+if len(text) > max_chars:
+    text = text[:max_chars].rstrip() + "\n...[transcript truncated]"
+print(text)
+PYEOF
+      exit 0
+      ;;
+    *)
+      echo "ERROR: Whisper transcription failed for ${URL} (Groq HTTP ${http_code:-000})." >&2
+      head -c 300 "$resp_file" 1>&2 || true
+      echo "" >&2
+      exit 3
+      ;;
+  esac
+fi
+
+echo "ERROR: no captions available for ${URL}. Set GROQ_API_KEY to enable the Whisper fallback for caption-less videos." >&2
+exit 4

--- a/infrastructure/modules/container-apps/paperclip.tf
+++ b/infrastructure/modules/container-apps/paperclip.tf
@@ -147,6 +147,20 @@ resource "azurerm_container_app" "paperclip" {
     }
   }
 
+  # Exa API key — feeds the exa-search wrapper (semantic web search alongside
+  # brave-search). Free tier ~1,000 searches/month. Provision the KV secret
+  # before flipping exa_search_enabled = true:
+  #   az keyvault secret set --vault-name aaf-dev-kv \
+  #     --name exa-api-key --value "<api key>"
+  dynamic "secret" {
+    for_each = var.exa_search_enabled ? [1] : []
+    content {
+      name                = "exa-api-key"
+      key_vault_secret_id = "${var.key_vault_uri}secrets/exa-api-key"
+      identity            = azurerm_user_assigned_identity.paperclip.id
+    }
+  }
+
   # Discord plugin bot token — injected as DISCORD_BOT_TOKEN env var so the
   # paperclip-plugin-discord worker can read it directly without going through
   # ctx.secrets.resolve() (which is gated behind PaperClip's secret-bindings
@@ -384,6 +398,18 @@ resource "azurerm_container_app" "paperclip" {
         content {
           name        = "BRAVE_SEARCH_API_KEY"
           secret_name = "brave-search-api-key"
+        }
+      }
+
+      # ── Exa Search ──────────────────────────────────────────────────────
+      # Feeds /usr/local/bin/exa-search. When exa_search_enabled = false the
+      # wrapper is still on disk (baked into the image) but exits with a clear
+      # error if invoked, since EXA_API_KEY will be unset.
+      dynamic "env" {
+        for_each = var.exa_search_enabled ? [1] : []
+        content {
+          name        = "EXA_API_KEY"
+          secret_name = "exa-api-key"
         }
       }
 

--- a/infrastructure/modules/container-apps/variables.tf
+++ b/infrastructure/modules/container-apps/variables.tf
@@ -336,6 +336,12 @@ variable "brave_search_enabled" {
   default     = true
 }
 
+variable "exa_search_enabled" {
+  description = "Enable the exa-search wrapper inside paperclip (mounts EXA_API_KEY from the KV secret exa-api-key). Semantic web search alongside brave-search; opt-in because it needs an Exa key seeded into Key Vault first. Default off."
+  type        = bool
+  default     = false
+}
+
 variable "telegram_enabled" {
   type        = bool
   description = "Enable the Telegram chat surface (agent-runtime Telegram gateway)."

--- a/services/paperclip/Dockerfile
+++ b/services/paperclip/Dockerfile
@@ -270,6 +270,20 @@ RUN chmod +x /usr/local/bin/web-read
 COPY apps/paperclip/exa-search-wrapper.sh /usr/local/bin/exa-search
 RUN chmod +x /usr/local/bin/exa-search
 
+# video-transcript wrapper — pulls transcripts from YouTube/Vimeo/~1800 sites for
+# summarization. Needs yt-dlp (pinned standalone binary; runs on the base image's
+# python3) and ffmpeg (only for the optional Whisper-fallback audio extraction).
+# Pin yt-dlp and let the watchdog health-check it, since YouTube extraction churns.
+ARG YT_DLP_VERSION=2025.10.14
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ffmpeg \
+ && rm -rf /var/lib/apt/lists/* \
+ && curl -fsSL "https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/yt-dlp" -o /usr/local/bin/yt-dlp \
+ && chmod +x /usr/local/bin/yt-dlp \
+ && yt-dlp --version
+COPY apps/paperclip/video-transcript-wrapper.sh /usr/local/bin/video-transcript
+RUN chmod +x /usr/local/bin/video-transcript
+
 # Hermes skills: pip install doesn't include skills/, copy them separately.
 # Placed at /opt/hermes-skills so they're baked into the image. The entrypoint
 # syncs these to ~/.hermes/skills on the persistent volume.

--- a/services/paperclip/Dockerfile
+++ b/services/paperclip/Dockerfile
@@ -263,6 +263,13 @@ RUN chmod +x /usr/local/bin/brave-search
 COPY apps/paperclip/web-read-wrapper.sh /usr/local/bin/web-read
 RUN chmod +x /usr/local/bin/web-read
 
+# Exa search wrapper — research-grade semantic web search alongside brave-search
+# (exa for conceptual/semantic, brave for fresh/news). Same call shape as
+# brave-search; emits ddgs-compatible JSON. Requires EXA_API_KEY in the container
+# env (KV-backed); the wrapper exits with a clear error if unset.
+COPY apps/paperclip/exa-search-wrapper.sh /usr/local/bin/exa-search
+RUN chmod +x /usr/local/bin/exa-search
+
 # Hermes skills: pip install doesn't include skills/, copy them separately.
 # Placed at /opt/hermes-skills so they're baked into the image. The entrypoint
 # syncs these to ~/.hermes/skills on the persistent volume.


### PR DESCRIPTION
Finishes the rest of Agent-Reach **Track A** research skills — two independent CLI wrappers, same pattern as `web-read` (#39). They share the Dockerfile and researcher profile, so they're bundled here as two clean commits.

## A2 — `exa-search` (semantic web search)
- `apps/paperclip/exa-search-wrapper.sh` → `/usr/local/bin/exa-search`. Mirrors `brave-search` exactly (naive + `-k/-m` forms; ddgs-compatible `[{title, href, body}]`); calls the Exa REST API directly (`POST api.exa.ai/search`, `x-api-key`) via python3.
- Terraform: `exa_search_enabled` flag (**default off**) + `exa-api-key` KV secret + `EXA_API_KEY` env, mirroring the brave wiring — **inert until** the operator seeds the key and flips the flag.
- `playbooks/exa-search/SKILL.md`: routing — exa for semantic/conceptual, brave for fresh/news.

## A3 — `video-transcript` (YouTube/Vimeo/~1800 sites)
- `apps/paperclip/video-transcript-wrapper.sh` → `/usr/local/bin/video-transcript`. Captions via yt-dlp → VTT stripped, rolling-duplicate deduped, length-capped. Optional Groq-Whisper fallback gated on `GROQ_API_KEY` (+ffmpeg).
- **YouTube PO-token note:** the default web client now returns *no* captions from datacenter IPs (PO-token/SABR gating). The wrapper defaults `player_client=android,web` (overridable via `VIDEO_TRANSCRIPT_YT_CLIENT`), which bypasses it — confirmed live.
- Dockerfile: ffmpeg (apt) + pinned yt-dlp standalone binary (`ARG YT_DLP_VERSION=2025.10.14`, runs on base python3) in the production stage.
- `playbooks/video-transcript/SKILL.md`: usage, exit codes, env, churn caveat.

## Researcher profile
Generic backend-choice note for search (profile stays platform-agnostic); concrete `video-transcript` usage for video sources; verbatim-source/limit rules already cover `/tmp/*.md`.

## Verification
- `exa-search`: offline behavior matches brave-search (no key→exit 1, empty→exit 2); shellcheck/`bash -n` clean. Live Exa call **not** exercised (no `EXA_API_KEY`).
- `video-transcript`: VTT stripper unit-tested against a rolling-caption fixture; **live end-to-end caption extraction returns a clean transcript** (android client bypassed YouTube's gate); offline checks + shellcheck clean. Whisper fallback **not** live-exercised (no `GROQ_API_KEY`).
- `validate_profiles.py` → 14/14; `terraform fmt`/`validate` clean; build-context COPY sources resolve.
- Image build + boot (with ffmpeg + yt-dlp) verified by the `smoke` gate on this PR.

> Follow-on (separate): MRTek/Gandalf port of all three wrappers (private repo, ADO + `Deploy-AgentsMd.ps1`); A5 watchdog backend health-check (covers the yt-dlp churn risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)