### PR TITLE
feat(research): web-research routing + research-doctor + watchdog backend probe (Agent-Reach A5)

### DIFF
--- a/apps/hermes/overrides/skills/playbooks/web-research/SKILL.md
+++ b/apps/hermes/overrides/skills/playbooks/web-research/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: web-research
+description: >
+  How to do web research with the right tool and a fallback when one fails:
+  which search backend to use, how to read a page cleanly, how to get a video's
+  transcript, and how to check that the backends are healthy. Use at the start of
+  any research/lookup/"find out about X" task, or when a research tool returns
+  empty/erroring results and you need the fallback. Pulls together exa-search,
+  brave-search, web-read, video-transcript, and the research-doctor health check.
+---
+
+# Web research: pick the right backend, with fallbacks
+
+The platform exposes several research CLIs on `$PATH`. Use the one that fits the
+job; if it fails or returns empty, fall back down the chain rather than giving up
+(or fabricating).
+
+## Routing table
+
+| Need | Preferred | Fallback | Notes |
+|---|---|---|---|
+| **Search** — conceptual / "things like X" / exploratory | `exa-search` | `brave-search` → `ddgs` | Exa is semantic; finds relevant pages without exact words. |
+| **Search** — fresh / news / exact term | `brave-search` | `exa-search` → `ddgs` | Brave accepts cloud IPs (DuckDuckGo blocks them). |
+| **Read a page** — get the actual content of a URL | `web-read` | raw `curl` + strip | `web-read` returns clean Markdown; `curl` returns raw HTML. |
+| **Video** — transcript of a YouTube/Vimeo/etc. link | `video-transcript` | (Whisper, auto) | yt-dlp captions; Whisper fallback runs automatically if `GROQ_API_KEY` is set. |
+
+All search tools emit the same JSON shape (`[{title, href, body}]`), so you can
+swap one for another without changing how you parse the result. When a question
+has both an exploratory and a freshness angle, run **both** search backends and
+merge — they surface different pages.
+
+## Fallback rule
+
+If your preferred tool returns an **empty result or a non-zero exit**, try the
+fallback before concluding "nothing found". An empty result from one backend is
+not evidence that the information doesn't exist — it's often that backend being
+blocked, rate-limited, or unconfigured. Only after the preferred tool **and** its
+fallback come up empty should you treat the query as genuinely unanswerable.
+
+## Health check — `research-doctor`
+
+Before a research-heavy task (or when a tool behaves oddly), check which backends
+are actually up:
+
+```bash
+research-doctor          # human-readable: OK / SKIP / DOWN per backend
+research-doctor --json   # [{name, ok, status, detail}] for scripting
+```
+
+- **OK** — the backend responded.
+- **SKIP** — not configured here (e.g. no API key); not an error, just unavailable.
+- **DOWN** — configured but failing; route around it and, if persistent, flag it
+  to Infrastructure. `research-doctor` exits non-zero when any backend is DOWN.
+
+The watchdog runs the equivalent probe on a schedule (opt-in via
+`WATCHDOG_RESEARCH_PROBE`) and files an issue when a reachable backend goes down,
+so a degraded research capability gets surfaced even if no agent hit it yet.
+
+## Environment / keys
+
+| Tool | Key | If unset |
+|---|---|---|
+| `exa-search` | `EXA_API_KEY` | exits 1 → fall back to `brave-search` |
+| `brave-search` | `BRAVE_SEARCH_API_KEY` | exits 1 → fall back to `ddgs` |
+| `web-read` | `JINA_API_KEY` (optional) | works anonymously (lower rate limit) |
+| `video-transcript` | `GROQ_API_KEY` (optional) | captions only; no Whisper fallback |

--- a/apps/hermes/overrides/skills/playbooks/web-research/scripts/research-doctor.sh
+++ b/apps/hermes/overrides/skills/playbooks/web-research/scripts/research-doctor.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+# research-doctor — probe each research backend wrapper and report its health.
+#
+# Borrows Agent-Reach's "doctor" idea: one command that tells you which research
+# backends are actually working right now (search, page-read, video-transcript),
+# so an agent or operator can route around a dead one instead of misreading empty
+# results as "nothing found".
+#
+# Usage:
+#   research-doctor            # human-readable per-backend status
+#   research-doctor --json     # [{name, ok, detail, status}] for machine parsing
+#
+# A backend with no configured key is reported "skip" (not in use here), not
+# "down". Exit codes: 0 = no backend is DOWN (some may be skipped) · 1 = at least
+# one configured backend is DOWN.
+
+set -u
+
+JSON=0
+[ "${1:-}" = "--json" ] && JSON=1
+
+# Accumulate "name<TAB>status<TAB>detail" rows (status: ok | down | skip).
+ROWS=""
+row() { ROWS="${ROWS}${1}	${2}	${3}
+"; }
+
+# ── web-read (Jina Reader) — anonymous, always probeable ─────────────────────
+if command -v web-read >/dev/null 2>&1; then
+  if out="$(web-read https://example.com 2>&1)" && printf '%s' "$out" | grep -qi "example domain"; then
+    row "web-read" "ok" ""
+  else
+    row "web-read" "down" "probe of example.com failed: $(printf '%s' "$out" | head -n1)"
+  fi
+else
+  row "web-read" "down" "web-read not on PATH"
+fi
+
+# ── exa-search — only when EXA_API_KEY is configured ─────────────────────────
+if [ -z "${EXA_API_KEY:-}" ]; then
+  row "exa-search" "skip" "EXA_API_KEY not set"
+elif ! command -v exa-search >/dev/null 2>&1; then
+  row "exa-search" "down" "exa-search not on PATH"
+elif exa-search "health check" >/dev/null 2>&1; then
+  row "exa-search" "ok" ""
+else
+  row "exa-search" "down" "exa-search returned non-zero (key/quota/upstream?)"
+fi
+
+# ── brave-search — only when BRAVE_SEARCH_API_KEY is configured ──────────────
+if [ -z "${BRAVE_SEARCH_API_KEY:-}" ]; then
+  row "brave-search" "skip" "BRAVE_SEARCH_API_KEY not set"
+elif ! command -v brave-search >/dev/null 2>&1; then
+  row "brave-search" "down" "brave-search not on PATH"
+elif brave-search "health" >/dev/null 2>&1; then
+  row "brave-search" "ok" ""
+else
+  row "brave-search" "down" "brave-search returned non-zero (key/quota/upstream?)"
+fi
+
+# ── video-transcript — backend is "up" if yt-dlp is installed and runnable ───
+# (A real transcript fetch is slow/flaky and YouTube-dependent; presence of a
+# working yt-dlp is the meaningful liveness signal. video-transcript also runs
+# its own per-call extraction.)
+if ! command -v video-transcript >/dev/null 2>&1; then
+  row "video-transcript" "down" "video-transcript not on PATH"
+elif command -v yt-dlp >/dev/null 2>&1 && ytver="$(yt-dlp --version 2>/dev/null)"; then
+  row "video-transcript" "ok" "yt-dlp ${ytver}"
+else
+  row "video-transcript" "down" "yt-dlp not installed or not runnable"
+fi
+
+# ── emit ─────────────────────────────────────────────────────────────────────
+down=0
+if [ "$JSON" -eq 1 ]; then
+  # python3 is in the paperclip image; use it for safe JSON encoding.
+  printf '%s' "$ROWS" | python3 -c '
+import json, sys
+out = []
+for line in sys.stdin.read().splitlines():
+    if not line.strip():
+        continue
+    name, status, detail = (line.split("\t") + ["", "", ""])[:3]
+    out.append({"name": name, "ok": status == "ok", "status": status, "detail": detail})
+print(json.dumps(out))
+'
+else
+  printf '%s' "$ROWS" | while IFS='	' read -r name status detail; do
+    [ -z "$name" ] && continue
+    case "$status" in
+      ok)   printf '  OK    %-18s %s\n' "$name" "$detail" ;;
+      skip) printf '  SKIP  %-18s %s\n' "$name" "$detail" ;;
+      *)    printf '  DOWN  %-18s %s\n' "$name" "$detail" ;;
+    esac
+  done
+fi
+
+# Exit nonzero if any backend is DOWN (skip does not count).
+printf '%s' "$ROWS" | grep -q '	down	' && down=1
+exit "$down"

--- a/services/paperclip/Dockerfile
+++ b/services/paperclip/Dockerfile
@@ -303,7 +303,9 @@ COPY apps/hermes/overrides/skills /opt/hermes-skills
 RUN chmod +x /opt/hermes-skills/playbooks/agent-delegate/scripts/pc-delegate.sh \
  && ln -sf /opt/hermes-skills/playbooks/agent-delegate/scripts/pc-delegate.sh /usr/local/bin/pc-delegate \
  && chmod +x /opt/hermes-skills/playbooks/honcho-memory/scripts/pc-honcho.sh \
- && ln -sf /opt/hermes-skills/playbooks/honcho-memory/scripts/pc-honcho.sh /usr/local/bin/pc-honcho
+ && ln -sf /opt/hermes-skills/playbooks/honcho-memory/scripts/pc-honcho.sh /usr/local/bin/pc-honcho \
+ && chmod +x /opt/hermes-skills/playbooks/web-research/scripts/research-doctor.sh \
+ && ln -sf /opt/hermes-skills/playbooks/web-research/scripts/research-doctor.sh /usr/local/bin/research-doctor
 
 # Optional skills: staged by Stage-Skills.ps1, copied alongside built-in ones.
 # Kept in a separate image directory so the entrypoint can distinguish

--- a/services/watchdog/detectors.py
+++ b/services/watchdog/detectors.py
@@ -266,6 +266,34 @@ def detect_expiring_secrets(secrets: Iterable[dict], *, now: datetime,
     return out
 
 
+def detect_research_backends(probes: Iterable[dict]) -> list[Finding]:
+    """Research backends (web search / page-read / video-transcript) that failed
+    their health probe.
+
+    `probes` is [{name, ok, detail}] -- ok is a bool, detail a short reason
+    string. Each not-ok backend becomes one `high` finding: when a researcher
+    agent loses a backend it usually fails INDIRECTLY (empty results misread as
+    'nothing found', or a silent fallback/cancel) rather than with an obvious
+    error, so surfacing it to an operator is the point. Pure: the caller runs the
+    probes (watchdog.py) and supplies the results."""
+    out = []
+    for p in probes:
+        if p.get("ok"):
+            continue
+        name = p.get("name", "?")
+        detail = (p.get("detail") or "").strip()
+        out.append(_ev(
+            "high", f"research-backend-down:{name}",
+            f"Research backend '{name}' is unavailable",
+            f"The '{name}' research backend failed its health probe"
+            + (f": {detail}" if detail else "") + ". Researcher agents lose this "
+            "capability until it's restored, and it tends to surface as empty "
+            "results or a silent fallback rather than an obvious error. Check the "
+            "API key/quota and the upstream service.",
+            {"backend": name, "detail": detail}, "Infrastructure"))
+    return out
+
+
 ALL_DETECTORS = (
     detect_adapter_failures,
     detect_stuck_wakes,

--- a/services/watchdog/tests/test_research_backends.py
+++ b/services/watchdog/tests/test_research_backends.py
@@ -1,0 +1,53 @@
+"""Tests for the research-backend health detector (detect_research_backends).
+
+Researcher agents depend on a set of web backends (search, page-read,
+video-transcript). When one goes down they fail indirectly — empty results read
+as "nothing found", or a silent fallback/cancel. Pure function: the caller runs
+the probes and supplies [{name, ok, detail}], so every branch is offline-testable.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from services.watchdog import detectors  # noqa: E402
+
+
+def test_down_backend_is_high_with_stable_signature():
+    out = detectors.detect_research_backends(
+        [{"name": "exa-search", "ok": False, "detail": "HTTP 401 (bad key)"}])
+    assert len(out) == 1
+    f = out[0]
+    assert f.severity == "high"
+    assert f.signature == "research-backend-down:exa-search"
+    assert f.recommended_owner == "Infrastructure"
+    assert f.evidence["backend"] == "exa-search"
+    assert "401" in f.evidence["detail"]
+    assert "exa-search" in f.title
+
+
+def test_healthy_backend_produces_nothing():
+    assert detectors.detect_research_backends(
+        [{"name": "web-read", "ok": True, "detail": ""}]) == []
+
+
+def test_only_down_backends_are_reported():
+    probes = [
+        {"name": "web-read", "ok": True},
+        {"name": "exa-search", "ok": False, "detail": "timeout"},
+        {"name": "video-transcript", "ok": False, "detail": "yt-dlp missing"},
+    ]
+    out = detectors.detect_research_backends(probes)
+    assert {f.evidence["backend"] for f in out} == {"exa-search", "video-transcript"}
+    assert all(f.severity == "high" for f in out)
+
+
+def test_missing_detail_does_not_crash():
+    out = detectors.detect_research_backends([{"name": "brave-search", "ok": False}])
+    assert len(out) == 1
+    assert out[0].evidence["backend"] == "brave-search"
+
+
+def test_empty_probe_list_is_no_findings():
+    assert detectors.detect_research_backends([]) == []

--- a/services/watchdog/watchdog.py
+++ b/services/watchdog/watchdog.py
@@ -33,6 +33,7 @@ import json
 import os
 import sys
 import time
+import urllib.error
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
@@ -91,6 +92,50 @@ def _fetch_kv_secret_expiries(vault_uri: str) -> list[dict]:
         print(f"[watchdog] Key Vault secret list failed: {e}", file=sys.stderr)
         return []
     return out
+
+
+def _probe_research_backends() -> list[dict]:
+    """Best-effort reachability/auth probes of the HTTP research backends the
+    watchdog container can reach. Only CONFIGURED backends are probed -- an unset
+    key means the backend isn't in use in this deployment, not that it's down, so
+    it's skipped (no false alarm). Returns [{name, ok, detail}]. yt-dlp /
+    video-transcript runs only inside the paperclip image, so it's covered by
+    research-doctor.sh there, not here."""
+    probes: list[dict] = []
+
+    def _probe(name: str, req: "urllib.request.Request") -> None:
+        try:
+            with urllib.request.urlopen(req, timeout=15) as r:
+                code = r.getcode()
+            ok = 200 <= code < 300
+            probes.append({"name": name, "ok": ok,
+                           "detail": "" if ok else f"HTTP {code}"})
+        except urllib.error.HTTPError as e:
+            probes.append({"name": name, "ok": False, "detail": f"HTTP {e.code}"})
+        except Exception as e:  # noqa: BLE001 -- network probe is best-effort
+            probes.append({"name": name, "ok": False, "detail": str(e)[:120]})
+
+    # web-read (Jina Reader) -- anonymous, always checkable.
+    _probe("web-read", urllib.request.Request(
+        "https://r.jina.ai/https://example.com",
+        headers={"User-Agent": "azureagentforge-watchdog/1.0"}))
+
+    # exa-search -- only when a key is configured.
+    exa_key = os.getenv("EXA_API_KEY", "").strip()
+    if exa_key:
+        body = json.dumps({"query": "health check", "numResults": 1}).encode("utf-8")
+        _probe("exa-search", urllib.request.Request(
+            "https://api.exa.ai/search", data=body, method="POST",
+            headers={"x-api-key": exa_key, "Content-Type": "application/json"}))
+
+    # brave-search -- only when a key is configured.
+    brave_key = os.getenv("BRAVE_SEARCH_API_KEY", "").strip()
+    if brave_key:
+        _probe("brave-search", urllib.request.Request(
+            "https://api.search.brave.com/res/v1/web/search?q=health&count=1",
+            headers={"X-Subscription-Token": brave_key, "Accept": "application/json"}))
+
+    return probes
 
 DEFAULT_BASE = "https://app.example.com"
 # Per-agent monthly caps in dollars (illustrative defaults).
@@ -263,6 +308,15 @@ def main() -> int:
         secrets = _fetch_kv_secret_expiries(vault_uri)
         findings += detectors.detect_expiring_secrets(secrets, now=datetime.now(timezone.utc))
         print(f"[watchdog] key-vault secrets checked={len(secrets)}")
+
+    # Research-backend health (opt-in via WATCHDOG_RESEARCH_PROBE). A down
+    # search/page-read backend makes researcher agents fail indirectly (empty
+    # results, silent fallback), so probe the reachable ones and flag any down.
+    if os.getenv("WATCHDOG_RESEARCH_PROBE", "").lower() in ("1", "true", "yes"):
+        probes = _probe_research_backends()
+        findings += detectors.detect_research_backends(probes)
+        print(f"[watchdog] research backends probed={len(probes)} "
+              f"down={sum(1 for p in probes if not p['ok'])}")
 
     seen = _load_seen(state)
     fresh = detectors.dedup(findings, seen)


### PR DESCRIPTION
Closes out Agent-Reach **Track A**. Borrows Agent-Reach's "doctor" idea: an ordered preferred→fallback routing skill plus a health check, so researcher agents route around a dead backend instead of misreading empty results as "nothing found".

Builds on the wrappers from #39 (web-read), #40 (exa-search, video-transcript).

## What's added

**Routing skill** — `playbooks/web-research/SKILL.md`
A routing table (exa→brave→ddgs for search; web-read→curl for pages; video-transcript for video), the fallback rule (empty/erroring → try the fallback before concluding "nothing found"), and how to read `research-doctor`.

**Health check** — `research-doctor` (`playbooks/web-research/scripts/research-doctor.sh` → `/usr/local/bin/research-doctor`, symlinked like `pc-delegate`)
Probes every backend: `web-read` live, `exa-search`/`brave-search` when keyed, `yt-dlp` presence for `video-transcript`. Human-readable **OK / SKIP / DOWN** output and a `--json` mode (`{name, ok, status, detail}`). Unconfigured backends are **SKIP** (no false alarm); exits non-zero only when a *configured* backend is **DOWN**.

**Watchdog detector** — `services/watchdog/`
- `detect_research_backends(probes)` — pure detector, one `high` finding per down backend, mirrors `detect_expiring_secrets`.
- `_probe_research_backends()` — best-effort `urllib` probes of the HTTP backends the watchdog container can reach (Jina anonymously; Exa/Brave only when keyed), wired **opt-in behind `WATCHDOG_RESEARCH_PROBE`** (default off).

## Design note
The watchdog runs as its own container without the wrappers or yt-dlp, so it can only probe the reachable HTTP backends — `research-doctor` (in the paperclip image) covers the full set including yt-dlp. Both share the same `{name, ok, detail}` shape.

## Verification
- **TDD**: 5 new detector tests (watched red → green); full watchdog suite **69/69**.
- `python -m compileall services` clean (the CI gate).
- `research-doctor`: shellcheck clean; **live-tested both paths** — down/skip → exit 1; with web-read + yt-dlp on PATH → web-read OK (real Jina probe) + video-transcript OK (yt-dlp 2025.10.14) → exit 0; `--json` validates.
- build-context COPY sources resolve; image build + boot verified by the `smoke` gate on this PR.

> Track A is now complete (A1 web-read, A2 exa-search, A3 video-transcript, A5 doctor/health). Follow-on (separate): the MRTek/Gandalf port of all of this (private repo, ADO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)