### PR TITLE
Forge Console: robust first-time deploy (env visibility, bootstrap callout, inline help, next steps)

### DIFF
--- a/installer/static/index.html
+++ b/installer/static/index.html
@@ -324,9 +324,10 @@ async function run(step, confirm = '', approve_destroy = '') {
 }
 
 async function confirmRun(step) {
-  // Keep the displayed/typed name in sync with what's configured, so you always
-  // know what to type (the server checks it against the written environment).
-  ENV_NAME = ($('environment').value.trim() || ENV_NAME || 'dev');
+  // ENV_NAME is set when you Write configuration, and matches the environment the
+  // server validates the typed token against (_last_config.environment). Don't
+  // re-read the live field here — an edit that wasn't re-written would show a name
+  // the server doesn't expect.
   $('confirmTitle').textContent = 'Confirm ' + step;
   $('confirmText').innerHTML = (step === 'apply'
     ? 'Apply creates real, billable Azure resources from the saved plan. '

--- a/installer/static/index.html
+++ b/installer/static/index.html
@@ -123,10 +123,13 @@
         </select>
         <label>Azure AI Foundry endpoint <span class="dim">(optional — can set later)</span></label>
         <input type="text" id="foundry" placeholder="https://your-project.openai.azure.com/">
+        <div class="note">Your Foundry / AI-Services resource's endpoint: Azure Portal → the resource → <b>Endpoint</b>. Leave blank to wire a model later.</div>
         <label>Foundry deployment id <span class="dim">(optional)</span></label>
         <input type="text" id="foundryDeployment" value="gpt-4o-mini" placeholder="gpt-4o-mini">
+        <div class="note">The <b>name of a model deployment</b> you created in Foundry (e.g. <code>gpt-4o-mini</code>) — a deployment name, not a GUID. List yours: <code>az cognitiveservices account deployment list -n &lt;foundry&gt; -g &lt;rg&gt; -o table</code></div>
         <label>Container image tag <span class="dim">(optional — applies to all services; blank = "latest")</span></label>
         <input type="text" id="imageTag" placeholder="e.g. a git SHA like 9bf1a51, or latest">
+        <div class="note">The short git SHA <code>scripts/build-and-push.sh</code> prints after pushing images (e.g. <code>9bf1a51</code>). Blank uses <code>latest</code>.</div>
         <label>Key Vault admin object IDs <span class="dim">(your Azure AD object ID; comma-separated for more — needed to seed secrets)</span></label>
         <input type="text" id="kvAdmins" placeholder="az ad signed-in-user show --query id -o tsv">
         <div class="chk"><input type="checkbox" id="telegram"><label for="telegram" style="margin:0">Enable Telegram surface</label></div>
@@ -145,6 +148,8 @@
       <div class="head" onclick="open_('deploy')"><div class="num">3</div>
         <div class="title">Deploy to Azure</div></div>
       <div class="body">
+        <div class="note" style="margin:0 0 10px">Target environment:
+        <b id="deployEnvName">dev</b> <span class="dim">— set in step 2 (Configure)</span></div>
         <div class="btns">
           <button class="secondary" onclick="run('init')">init</button>
           <button class="secondary" onclick="run('validate')">validate</button>
@@ -153,6 +158,12 @@
         </div>
         <div class="note">Run <b>plan</b> and read it before <b>apply</b>. Apply creates real,
         billable Azure resources (see docs/cost.md for what to expect).</div>
+        <div class="note"><b>First deploy?</b> The Key Vault module reads
+        <code>postgres-admin-password</code> as a data source, so the very first
+        <code>plan</code> fails until the vault is seeded. Run the one-time bootstrap from a
+        terminal first: <code>scripts/bootstrap.sh --apply</code> (creates the vault + seeds the
+        secret), then come back and <code>plan</code>/<code>apply</code> here. See
+        docs/deploy-pipeline.md.</div>
         <div class="btns" style="margin-top:18px">
           <button class="secondary" onclick="run('output')">show outputs</button>
           <button class="danger" onclick="confirmRun('destroy')">destroy</button>
@@ -291,6 +302,7 @@ async function writeConfig() {
   try {
     const r = await api('/api/config', { method: 'POST', body: configBody(false) });
     ENV_NAME = $('environment').value.trim() || 'dev';
+    $('deployEnvName').textContent = ENV_NAME;
     $('configPreview').innerHTML =
       `<div class="preview">${r.preview.replace(/</g,'&lt;')}</div>` +
       `<div class="note ok">✔ written — profile: ${r.profile_file.split('/').pop()}</div>`;
@@ -312,11 +324,16 @@ async function run(step, confirm = '', approve_destroy = '') {
 }
 
 async function confirmRun(step) {
+  // Keep the displayed/typed name in sync with what's configured, so you always
+  // know what to type (the server checks it against the written environment).
+  ENV_NAME = ($('environment').value.trim() || ENV_NAME || 'dev');
   $('confirmTitle').textContent = 'Confirm ' + step;
-  $('confirmText').textContent = step === 'apply'
-    ? 'Apply creates real, billable Azure resources from the saved plan. Type the environment name to continue.'
-    : 'Destroy permanently removes every resource Terraform manages in this environment. Type the environment name to continue.';
+  $('confirmText').innerHTML = (step === 'apply'
+    ? 'Apply creates real, billable Azure resources from the saved plan. '
+    : 'Destroy permanently removes every resource Terraform manages in this environment. ')
+    + 'Type the environment name <code>' + ENV_NAME + '</code> to continue.';
   $('confirmInput').value = '';
+  $('confirmInput').placeholder = ENV_NAME;
   $('confirmGo').onclick = () => {
     document.getElementById('confirmDialog').close();
     run(step, $('confirmInput').value.trim());
@@ -357,7 +374,11 @@ function startStream() {
     const last = st.history[st.history.length - 1];
     if (last) setStatus(last.status, `${last.step} ${last.status}`);
     if (last && last.status === 'succeeded' && last.step === 'apply') {
-      logLine('[forge] 🎉 deployment applied — run "show outputs" for service endpoints', 'ok');
+      logLine('[forge] 🎉 deployment applied. Next steps:', 'ok');
+      logLine('[forge]   1. "show outputs" for service endpoints + the Key Vault name.', 'meta');
+      logLine('[forge]   2. Seed real provider keys + the Postgres connection strings (pass 2):', 'meta');
+      logLine('[forge]      POSTGRES_CONNECTION_STRING=... scripts/seed-keyvault.sh -v <vault>, then restart the apps.', 'meta');
+      logLine('[forge]   3. Enable a chat surface (Telegram/Discord/Teams) — see docs/getting-started.md.', 'meta');
       markDone('deploy');
     }
   });


### PR DESCRIPTION
## What

Closes several gaps a first-time operator hits in the Forge Console GUI. All **client-side** (`installer/static/index.html`), no backend change.

### 1. The environment name is now visible where you're asked to type it
The apply/destroy confirmation makes you type the environment name as a safety token (`app.py` checks `confirm == environment`), but the dialog said *"type the environment name"* without ever showing what it is — and the Environment field lives in the (collapsible) Configure step, so going straight to Deploy you never saw it. Now:
- the confirm dialog shows it: *"Type the environment name `dev` to continue"* (+ pre-filled placeholder),
- the Deploy step shows **Target environment: `dev`**.

### 2. First-deploy bootstrap callout
The Key Vault module reads `postgres-admin-password` as a data source, so the very first `plan` fails until the vault is seeded. The Deploy step now warns about this and points to `scripts/bootstrap.sh --apply` (the one-command bootstrap).

### 3. Inline input help (closes the open half of #29)
The Foundry **endpoint**, **deployment id** (a deployment *name* not a GUID, defaults `gpt-4o-mini`, with the `az ... deployment list` command), and **image-tag** fields now explain what they are and how to obtain them — inline in the form, so you can fill the wizard without hand-editing tfvars.

### 4. Post-apply next steps
A successful apply used to end on one line. It now lists the actual next steps: show outputs, seed the pass-2 connection strings + restart, enable a chat surface.

## Validation

- 65 installer tests pass (HTML-only change doesn't touch them).
- The page's JavaScript passes `node --check`.

## Notes

Backend hardening ideas the audit surfaced (init-before-plan guard, runner timeout, randomized destroy token, subscription-access check) are deliberately **not** in this PR — they need `core.py`/`app.py` changes + tests and some are debatable; tracking separately. This PR is the high-value, low-risk first-run UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)