### PR TITLE
docs: fix install accuracy + first-deploy robustness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,8 @@
 LLM_PROVIDER=azure_foundry
 
 # ── Azure AI Foundry — primary endpoint ──────────────────────────────────────
-# Key Vault secrets: platform-azure-foundry-endpoint
-#                    platform-azure-foundry-api-key
+# Key Vault secret (prod): the API key is gpt4o-api-key. The endpoint is NOT a
+#   Key Vault secret — it's the ai_foundry_endpoint Terraform variable.
 # These activate the gpt4o-mini (primary) tier in the model-router.
 # Alternatively, set GPT4O_BASE_URL / GPT4O_API_KEY directly below.
 # AZURE_FOUNDRY_ENDPOINT is aliased to GPT4O_BASE_URL in docker-compose.yml.

--- a/docs/deploy-pipeline.md
+++ b/docs/deploy-pipeline.md
@@ -97,10 +97,10 @@ variables), each named for the Key Vault secret upper-cased with underscores:
 `CLAUDE_API_KEY`, `AI_FOUNDRY_API_KEY`, `OPENAI_API_KEY`, `BRAVE_SEARCH_API_KEY`,
 `TELEGRAM_BOT_TOKEN`, `DISCORD_BOT_TOKEN`, `CF_TUNNEL_TOKEN`,
 `POSTGRES_CONNECTION_STRING`, `PAPERCLIP_DB_URL`. Set only the ones your
-deployment uses; the rest are seeded as empty placeholders so every container's
-Key Vault reference resolves (an unset model tier or surface stays inert until
-you provide its value and re-run). `scripts/seed-keyvault.sh --list` prints the
-full inventory.
+deployment uses; the rest are seeded as a non-empty `__unset__` placeholder so
+every container's Key Vault reference resolves (`az keyvault secret set` rejects
+an empty value). An unset model tier or surface stays inert until you provide its
+value and re-run. `scripts/seed-keyvault.sh --list` prints the full inventory.
 
 ### 3. The approval gate - a GitHub **Environment**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -176,6 +176,19 @@ LLM token usage is billed separately and is not included in those figures.
 
 ### 5. Plan and apply
 
+> **First deploy?** The Key Vault module reads `postgres-admin-password` as a
+> data source, so the *first* `terraform plan` fails until that secret exists.
+> The simplest path is the one-time bootstrap, which creates the vault, seeds the
+> secret, and runs the full apply for you:
+>
+> ```bash
+> scripts/bootstrap.sh --apply
+> ```
+>
+> Prefer to drive Terraform by hand? Seed `postgres-admin-password` first (see
+> [deploy-pipeline.md](deploy-pipeline.md#first-deploy-a-one-time-key-vault-bootstrap)),
+> then the commands below are your steady-state loop.
+
 ```bash
 terraform plan \
   -var-file=../../profiles/cost-optimized.tfvars \
@@ -219,23 +232,29 @@ Image build, push, and service startup are automated in v1.2 via
 
 ### 6. Seed Key Vault secrets
 
-After apply, the Container Apps pull secrets from Key Vault by name. Seed
-them with the `az` CLI:
+After apply, the Container Apps pull secrets from Key Vault by name. Seed them
+with [`scripts/seed-keyvault.sh`](../scripts/seed-keyvault.sh) — it generates the
+internal secrets (JWT keys, admin passwords) and reads external ones (provider
+keys, bot tokens, the Postgres connection strings) from like-named environment
+variables:
 
 ```bash
 KV=$(terraform output -raw key_vault_name)
 
-az keyvault secret set --vault-name "$KV" \
-  --name platform-azure-foundry-endpoint \
-  --value "https://<your-project>.openai.azure.com/"
-
-az keyvault secret set --vault-name "$KV" \
-  --name platform-azure-foundry-api-key \
-  --value "<your-key>"
+# Pass the keys/tokens you have; an unset external gets a non-empty `__unset__`
+# placeholder and stays inert until you set it and re-run. The Postgres
+# connection strings are a SECOND pass — they can only be known now that the
+# database exists, so derive them from your Postgres resource.
+AI_FOUNDRY_API_KEY="<your-key>" \
+POSTGRES_CONNECTION_STRING="<from your Postgres resource>" \
+PAPERCLIP_DB_URL="<from your Postgres resource>" \
+  scripts/seed-keyvault.sh -v "$KV"
 ```
 
-Repeat for any additional model endpoints you enabled (see `.env.example` for
-the full list of secret names, each annotated with its Key Vault secret name).
+`scripts/seed-keyvault.sh --list` prints the full inventory and the env var each
+secret reads. Note the Azure AI Foundry **endpoint** is *not* a Key Vault secret
+— it's the `ai_foundry_endpoint` Terraform variable (set in `terraform.tfvars`
+or the Forge form); only the API key (`ai-foundry-api-key`) is a secret.
 
 ### 7. After deploy
 
@@ -252,6 +271,8 @@ From here, the same steps as the local path apply:
 - Add or modify agents: [`../agents/README.md`](../agents/README.md)
 - Enable Telegram: [`../integrations/telegram/README.md`](../integrations/telegram/README.md)
 - Enable Discord: [`../integrations/discord/README.md`](../integrations/discord/README.md)
+- Enable Teams: [`../integrations/teams/README.md`](../integrations/teams/README.md)
+- Public ingress / a chat surface going live (e.g. Teams) needs a Cloudflare tunnel + DNS — managed by the `cloudflare-tunnel` Terraform module under `infrastructure/modules/`.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -20,8 +20,9 @@ The `.gitignore` excludes `.env`, `.env.*`, `*.tfvars`, `*.pem`, `*.key`, and th
 `.env.example` lists every variable the platform needs, with Key Vault secret names annotated inline. For example:
 
 ```
-# Key Vault secrets: platform-azure-foundry-endpoint
-AZURE_FOUNDRY_ENDPOINT=https://your-endpoint.openai.azure.com/
+# Key Vault secret: gpt4o-api-key   (the endpoint is the ai_foundry_endpoint
+#                                    Terraform variable, not a Key Vault secret)
+AZURE_FOUNDRY_API_KEY=<your-foundry-key>
 ```
 
 The Terraform modules reference Key Vault secret IDs at deploy time; the actual values are never written to Terraform state in plaintext.


### PR DESCRIPTION
## What

Fixes install-doc bugs that cause silent first-deploy failures, found while hardening the install path for a first-time operator. All verified against the actual scripts/Terraform.

### 1. Wrong Key Vault secret names (deploy-breaker)
`getting-started.md` §6, `security.md`, and `.env.example` all told users to seed **`platform-azure-foundry-endpoint`** / **`platform-azure-foundry-api-key`** — secrets `seed-keyvault.sh` never seeds and no container references. Hand-seeding them does nothing; the deploy then fails on the *real* missing secret.
- The real Foundry API-key secret is **`gpt4o-api-key`** (`memory_governor.tf:78`).
- The **endpoint is the `ai_foundry_endpoint` Terraform variable, not a secret** (`environments/dev/main.tf:114`, `variables.tf:117`).
- Rewrote §6 to use `scripts/seed-keyvault.sh` (the real mechanism), and corrected the annotations in `security.md` + `.env.example`. No more `platform-azure-foundry-*` anywhere in the repo.

### 2. Missing first-deploy bootstrap
`getting-started.md` §5 went straight to `terraform plan`, which fails on a fresh subscription (the Key Vault module reads `postgres-admin-password` as a data source). Added a callout: run `scripts/bootstrap.sh --apply`, or seed it by hand per `deploy-pipeline.md`.

### 3. Accuracy + completeness
- `deploy-pipeline.md`: "empty placeholders" → the non-empty **`__unset__`** sentinel (`az keyvault secret set` rejects `""`).
- Added **Teams** + the **Cloudflare-tunnel public-ingress** pointer to the after-deploy steps; documented the **two-pass connection-string** seeding.

## Validation

- `grep` confirms zero `platform-azure-foundry-*` references remain.
- `scripts/scan-internal-refs.sh` clean.
- Link targets verified present on the branch (Teams README, seed-keyvault.sh, the deploy-pipeline anchor). The `bootstrap.sh` reference + the Cloudflare module land with PRs #43/#45; the Cloudflare mention is intentionally not a hard link to avoid a dangling link before #45 merges.

## Not changed

Left the Foundry endpoint example as `cognitiveservices.azure.com` form — it's resource-type-dependent and matches the operator's own issue #29; "correcting" it risked introducing a wrong value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)