### PR TITLE
Forge Console: time out a hung step so it can't wedge the console

### DIFF
--- a/installer/core.py
+++ b/installer/core.py
@@ -276,6 +276,22 @@ PLAN_FILE = "tfplan"
 # environment-name confirmation so a destructive apply can't be waved through.
 DESTROY_APPROVAL_TOKEN = "approve-destroy"
 
+# Per-step wall-clock timeouts (seconds). Generous so a legitimate long apply is
+# never killed, but a hung step (a stuck state lock, a wedged API call) can't pin
+# the single-run lock forever and lock the console out of every further step.
+STEP_TIMEOUTS = {
+    "init": 600,
+    "validate": 300,
+    "plan": 1800,
+    "apply": 3600,
+    "destroy": 3600,
+    "output": 300,
+    "compose-up": 1800,
+    "compose-down": 600,
+    "compose-ps": 120,
+}
+DEFAULT_STEP_TIMEOUT = 3600
+
 
 # ---------------------------------------------------------------------------
 # Destroy-aware apply gate
@@ -350,29 +366,54 @@ class Runner:
     def busy(self) -> bool:
         return self.current is not None and self.current.status == "running"
 
-    def start(self, step: str, cmd: list[str], cwd: Path = REPO_ROOT) -> StepRun:
+    def start(self, step: str, cmd: list[str], cwd: Path = REPO_ROOT,
+              timeout: Optional[float] = None) -> StepRun:
         with self._lock:
             if self.busy():
                 raise RuntimeError(f"a step is already running: {self.current.step}")
             run = StepRun(step=step)
             self.current = run
-        thread = threading.Thread(target=self._execute, args=(run, cmd, cwd), daemon=True)
+        if timeout is None:
+            timeout = STEP_TIMEOUTS.get(step, DEFAULT_STEP_TIMEOUT)
+        thread = threading.Thread(target=self._execute, args=(run, cmd, cwd, timeout), daemon=True)
         thread.start()
         return run
 
-    def _execute(self, run: StepRun, cmd: list[str], cwd: Path) -> None:
+    def _execute(self, run: StepRun, cmd: list[str], cwd: Path,
+                 timeout: Optional[float] = None) -> None:
         self._emit(run, f"$ {' '.join(cmd)}")
+        timer = None
+        timed_out = threading.Event()
         try:
             proc = subprocess.Popen(
                 cmd, cwd=str(cwd), stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                 text=True, bufsize=1, env={**os.environ, "TF_IN_AUTOMATION": "1"},
             )
+            # Watchdog: a step that produces no output and never exits would
+            # otherwise block the read loop (and the single-run lock) forever.
+            if timeout and timeout > 0:
+                def _kill() -> None:
+                    timed_out.set()
+                    try:
+                        proc.kill()
+                    except Exception:
+                        pass
+                timer = threading.Timer(timeout, _kill)
+                timer.daemon = True
+                timer.start()
             assert proc.stdout is not None
             for line in proc.stdout:
                 self._emit(run, line.rstrip("\n"))
             run.returncode = proc.wait()
         except OSError as e:
             self._emit(run, f"[forge] failed to start: {e}")
+            run.returncode = -1
+        finally:
+            if timer is not None:
+                timer.cancel()
+        if timed_out.is_set():
+            self._emit(run, f"[forge] step '{run.step}' timed out after {int(timeout)}s — killed. "
+                            "Check the Azure Portal for any partially-created resources.")
             run.returncode = -1
         run.status = "succeeded" if run.returncode == 0 else "failed"
         run.finished_at = time.time()

--- a/installer/tests/test_core.py
+++ b/installer/tests/test_core.py
@@ -242,6 +242,26 @@ def test_runner_handles_missing_binary(tmp_path):
     assert r.history[-1].status == "failed"
 
 
+def test_runner_kills_a_step_that_exceeds_timeout(tmp_path):
+    # A step that would otherwise hang (30s sleep) must be killed by the watchdog
+    # and the single-run lock released, so the console isn't wedged forever.
+    r = core.Runner()
+    r.start("slow-timeout", [sys.executable, "-c", "import time; time.sleep(30)"],
+            cwd=tmp_path, timeout=0.5)
+    _wait(r)  # _wait asserts the runner finished (i.e. it was killed, not hung)
+    assert r.history[-1].status == "failed"
+    assert not r.busy()
+
+
+def test_runner_resolves_a_default_timeout_per_step(tmp_path):
+    # A fast step under its (default) timeout completes normally.
+    r = core.Runner()
+    r.start("apply", [sys.executable, "-c", "print('ok')"], cwd=tmp_path)
+    _wait(r)
+    assert r.history[-1].status == "succeeded"
+    assert core.STEP_TIMEOUTS["apply"] >= 1800  # generous, won't kill a real apply
+
+
 # ---------------------------------------------------------------------------
 # API layer — guards (uses FastAPI TestClient when available)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The Forge Console's step Runner read subprocess stdout with **no timeout**, so a hung step (a stuck Terraform state lock, a wedged Azure API call) blocked the read loop forever. Because the single-run lock stayed held, every subsequent step was then rejected with *"a step is already running"* — the console was **permanently wedged** with no recovery short of restarting `./forge`.

## Fix

A per-step wall-clock watchdog (`threading.Timer`) kills the process after `STEP_TIMEOUTS[step]`, emits a clear *"timed out … killed"* line, marks the step failed, and **releases the lock** so the console stays usable. Timeouts are deliberately generous so a legitimate long run is never killed:

| step | timeout |
|---|---|
| apply / destroy | 60 min |
| plan | 30 min |
| init / compose-up | 10–30 min |
| validate / output / compose-ps | ≤5 min |

`start(..., timeout=)` allows an explicit override (used by the test); otherwise it resolves from `STEP_TIMEOUTS` with a 60-min default.

## Tests

+2 (`installer/tests/test_core.py`): a 30s sleep with a 0.5s timeout gets killed and the runner is freed (`not r.busy()`); a fast step under its default timeout still succeeds. Full installer suite **65 → 67**, all pass.

## Context

Surfaced by the robustness audit alongside the first-run UX fixes (#46) and the doc accuracy fixes (#47). I skipped the audit's other backend suggestions (init-before-plan guard, randomized destroy token, rate-limiting) — terraform's own "have you run init?" error is already clear, and the rest are low-value or over-engineering for a loopback single-user console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)