### PR TITLE
feat(paperclip): sandbox execution seam — local adapter + factory (B2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,8 @@ jobs:
           node-version: "22"
       - name: auth-proxy unit tests (no deps; node built-in runner)
         run: node --test tests/auth-proxy/*.test.mjs
+      - name: sandbox seam unit tests (no deps; node built-in runner)
+        run: node --test tests/sandbox/*.test.mjs
 
   python:
     runs-on: ubuntu-latest

--- a/apps/paperclip/sandbox.mjs
+++ b/apps/paperclip/sandbox.mjs
@@ -1,0 +1,163 @@
+/**
+ * Sandbox execution seam — the provider-pluggable boundary for running an
+ * agent's child process.
+ *
+ * This is the CONTRACT + the `local` adapter only. It is intentionally NOT yet
+ * wired into the adapter spawn path (apps/paperclip/patch-adapter.mjs). With
+ * nothing wired, this module is inert — importing it is side-effect-free and
+ * changes no runtime behavior. Wiring it in, and adding an isolated `aca-job`
+ * provider (ACA dynamic sessions), are follow-ons.
+ *
+ * The seam lets a task run either in-container (`local`, today's behavior) or,
+ * later, in an isolated ephemeral sandbox without changing the caller.
+ *
+ * Result shape matches the adapter's child-process return, so the seam is a
+ * drop-in at the spawn dispatch:
+ *   { exitCode: number|null, signal: string|null, timedOut: boolean,
+ *     stdout: string, stderr: string }
+ */
+
+import { spawn } from "node:child_process";
+
+const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024; // 10 MiB per stream, then truncate
+
+/**
+ * The `local` provider: runs the command in the current container, exactly as
+ * today. A thin, well-tested wrapper over child_process.spawn that honors a
+ * timeout and an AbortSignal and never rejects — failures come back in the
+ * result shape (so callers branch on exitCode/timedOut, not try/catch).
+ */
+class LocalSandbox {
+  constructor(config = {}) {
+    this.provider = "local";
+    this.config = config;
+  }
+
+  /**
+   * @param {string} cmd
+   * @param {string[]} args
+   * @param {{env?:object, cwd?:string, timeoutMs?:number, signal?:AbortSignal,
+   *          maxBuffer?:number, input?:string}} opts
+   * @returns {Promise<{exitCode:number|null, signal:string|null,
+   *                    timedOut:boolean, stdout:string, stderr:string}>}
+   */
+  async exec(cmd, args = [], opts = {}) {
+    const {
+      env,
+      cwd,
+      timeoutMs,
+      signal,
+      maxBuffer = DEFAULT_MAX_BUFFER,
+      input,
+    } = opts;
+
+    return await new Promise((resolve) => {
+      let stdout = "";
+      let stderr = "";
+      let outLen = 0;
+      let errLen = 0;
+      let timedOut = false;
+      let settled = false;
+      let timer = null;
+
+      const child = spawn(cmd, Array.isArray(args) ? args : [], {
+        env: env || process.env,
+        cwd: cwd || undefined,
+      });
+
+      const onAbort = () => {
+        try { child.kill("SIGTERM"); } catch { /* already gone */ }
+      };
+
+      const cleanup = () => {
+        if (timer) clearTimeout(timer);
+        if (signal && typeof signal.removeEventListener === "function") {
+          signal.removeEventListener("abort", onAbort);
+        }
+      };
+
+      const done = (res) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(res);
+      };
+
+      if (signal) {
+        if (signal.aborted) {
+          try { child.kill("SIGTERM"); } catch { /* noop */ }
+        } else if (typeof signal.addEventListener === "function") {
+          signal.addEventListener("abort", onAbort, { once: true });
+        }
+      }
+
+      if (timeoutMs && timeoutMs > 0) {
+        timer = setTimeout(() => {
+          timedOut = true;
+          try { child.kill("SIGTERM"); } catch { /* noop */ }
+        }, timeoutMs);
+      }
+
+      // Capture output, truncating each stream at maxBuffer (never OOM on a
+      // runaway command; the truncation is silent like the webhook body caps).
+      child.stdout.on("data", (d) => {
+        if (outLen < maxBuffer) {
+          stdout += d.toString("utf-8");
+          outLen += d.length;
+          if (outLen >= maxBuffer) stdout = stdout.slice(0, maxBuffer);
+        }
+      });
+      child.stderr.on("data", (d) => {
+        if (errLen < maxBuffer) {
+          stderr += d.toString("utf-8");
+          errLen += d.length;
+          if (errLen >= maxBuffer) stderr = stderr.slice(0, maxBuffer);
+        }
+      });
+
+      child.on("error", (err) => {
+        // spawn failure (e.g. ENOENT) — surface as a non-zero-ish result rather
+        // than throwing, so the seam never rejects.
+        done({
+          exitCode: null,
+          signal: null,
+          timedOut,
+          stdout,
+          stderr: stderr || String((err && err.message) || err),
+        });
+      });
+
+      child.on("close", (code, sig) => {
+        done({ exitCode: code, signal: sig, timedOut, stdout, stderr });
+      });
+
+      if (input != null) {
+        try { child.stdin.write(input); } catch { /* stdin may be closed */ }
+      }
+      try { child.stdin.end(); } catch { /* noop */ }
+    });
+  }
+}
+
+// Provider registry. `aca-job` registers here later; until then asking
+// for it fails LOUD rather than silently falling back to in-container exec.
+const PROVIDERS = {
+  local: LocalSandbox,
+};
+
+/**
+ * Construct a sandbox for the configured provider.
+ * @param {string} [provider=process.env.SANDBOX_PROVIDER||"local"]
+ * @param {object} [config]
+ */
+function createSandbox(provider = process.env.SANDBOX_PROVIDER || "local", config = {}) {
+  const Ctor = PROVIDERS[provider];
+  if (!Ctor) {
+    throw new Error(
+      `Unknown SANDBOX_PROVIDER: '${provider}' (known: ${Object.keys(PROVIDERS).join(", ")})`,
+    );
+  }
+  return new Ctor(config);
+}
+
+export { createSandbox, LocalSandbox, PROVIDERS };

--- a/tests/sandbox/sandbox.test.mjs
+++ b/tests/sandbox/sandbox.test.mjs
@@ -1,0 +1,134 @@
+/**
+ * Sandbox seam unit tests (node:test, zero dependencies).
+ *
+ * Run:  node --test tests/sandbox/sandbox.test.mjs
+ *
+ * Covers the seam contract + `local` adapter: output capture, exit codes,
+ * stderr, env, cwd, stdin, timeout, abort, and the fail-closed provider factory.
+ * Pure/offline — uses `sh -c` (CI runs Ubuntu; dev runs macOS, both have sh).
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+const { createSandbox, LocalSandbox, PROVIDERS } = await import("../../apps/paperclip/sandbox.mjs");
+
+describe("createSandbox factory", () => {
+  test("defaults to the local provider", () => {
+    const sb = createSandbox();
+    assert.ok(sb instanceof LocalSandbox);
+    assert.equal(sb.provider, "local");
+  });
+
+  test("returns a LocalSandbox for provider='local'", () => {
+    assert.ok(createSandbox("local") instanceof LocalSandbox);
+  });
+
+  test("throws (fail closed) on an unknown provider", () => {
+    assert.throws(() => createSandbox("aca-job"), /Unknown SANDBOX_PROVIDER/);
+    assert.throws(() => createSandbox("e2b"), /Unknown SANDBOX_PROVIDER/);
+  });
+
+  test("the registry exposes only local for now", () => {
+    assert.deepEqual(Object.keys(PROVIDERS), ["local"]);
+  });
+});
+
+describe("LocalSandbox.exec — basic execution", () => {
+  const sb = new LocalSandbox();
+
+  test("captures stdout and a zero exit code", async () => {
+    const r = await sb.exec("sh", ["-c", "printf hello"]);
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.signal, null);
+    assert.equal(r.timedOut, false);
+    assert.equal(r.stdout, "hello");
+    assert.equal(r.stderr, "");
+  });
+
+  test("propagates a non-zero exit code", async () => {
+    const r = await sb.exec("sh", ["-c", "exit 3"]);
+    assert.equal(r.exitCode, 3);
+    assert.equal(r.timedOut, false);
+  });
+
+  test("captures stderr separately from stdout", async () => {
+    const r = await sb.exec("sh", ["-c", "printf out; printf err 1>&2"]);
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.stdout, "out");
+    assert.equal(r.stderr, "err");
+  });
+
+  test("does not reject when the binary is missing (ENOENT → result, not throw)", async () => {
+    const r = await sb.exec("this-binary-does-not-exist-xyz", []);
+    assert.equal(r.exitCode, null);
+    assert.match(r.stderr, /ENOENT|not.*found|spawn/i);
+  });
+});
+
+describe("LocalSandbox.exec — env / cwd / stdin", () => {
+  const sb = new LocalSandbox();
+
+  test("passes a custom env", async () => {
+    const r = await sb.exec("sh", ["-c", "printf %s \"$FOO\""], { env: { ...process.env, FOO: "bar" } });
+    assert.equal(r.stdout, "bar");
+  });
+
+  test("honors cwd", async () => {
+    const r = await sb.exec("sh", ["-c", "pwd"], { cwd: "/tmp" });
+    // macOS reports /private/tmp for /tmp; accept either.
+    assert.match(r.stdout.trim(), /(^|\/)tmp$/);
+  });
+
+  test("feeds stdin from opts.input", async () => {
+    const r = await sb.exec("cat", [], { input: "piped-in" });
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.stdout, "piped-in");
+  });
+});
+
+describe("LocalSandbox.exec — timeout and abort", () => {
+  const sb = new LocalSandbox();
+
+  test("kills a command that exceeds timeoutMs and flags timedOut", async () => {
+    const r = await sb.exec("sh", ["-c", "sleep 5"], { timeoutMs: 100 });
+    assert.equal(r.timedOut, true);
+    // killed by SIGTERM → exitCode null, signal SIGTERM (platform-dependent but
+    // both Linux and macOS report this for a sh -c sleep killed mid-flight).
+    assert.equal(r.exitCode, null);
+    assert.equal(r.signal, "SIGTERM");
+  });
+
+  test("a fast command under the timeout completes normally", async () => {
+    const r = await sb.exec("sh", ["-c", "printf done"], { timeoutMs: 5000 });
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.timedOut, false);
+    assert.equal(r.stdout, "done");
+  });
+
+  test("an AbortSignal aborted mid-run kills the child", async () => {
+    const ac = new AbortController();
+    const p = sb.exec("sh", ["-c", "sleep 5"], { signal: ac.signal });
+    setTimeout(() => ac.abort(), 50);
+    const r = await p;
+    assert.equal(r.exitCode, null);
+    assert.equal(r.signal, "SIGTERM");
+  });
+
+  test("an already-aborted signal kills immediately", async () => {
+    const r = await sb.exec("sh", ["-c", "sleep 5"], { signal: AbortSignal.abort() });
+    assert.equal(r.exitCode, null);
+    assert.equal(r.signal, "SIGTERM");
+  });
+});
+
+describe("LocalSandbox.exec — output cap", () => {
+  const sb = new LocalSandbox();
+
+  test("truncates output at maxBuffer instead of growing unbounded", async () => {
+    // Emit ~50KB but cap at 1KB.
+    const r = await sb.exec("sh", ["-c", "for i in $(seq 1 5000); do printf 0123456789; done"], { maxBuffer: 1024 });
+    assert.equal(r.exitCode, 0);
+    assert.ok(r.stdout.length <= 1024, `stdout ${r.stdout.length} should be <= 1024`);
+  });
+});


### PR DESCRIPTION
## Summary
Ports the provider-pluggable **sandbox execution seam** into AAF (v1.3 feature B2): the contract + a `local` adapter + a fail-closed provider factory. The seam is **inert** — not wired into the adapter spawn path — so importing it is side-effect-free and changes no runtime behavior. Wiring it in and adding an `aca-job` (ACA dynamic-sessions) provider are follow-ons.

- `apps/paperclip/sandbox.mjs` — `createSandbox()` factory (throws on unknown provider), `LocalSandbox` (a `child_process.spawn` wrapper that never rejects — failures come back in a result object), `PROVIDERS = { local }`.
- `tests/sandbox/sandbox.test.mjs` — 16 `node:test` unit tests (output capture, exit codes, stderr, env/cwd/stdin, timeout, abort, ENOENT, output cap, fail-closed factory).
- `.github/workflows/ci.yml` — runs the new tests in the `node-tests` job.

Zero new dependencies (`node:child_process` only).

## Test Plan
- [x] `node --test tests/sandbox/*.test.mjs` → 16/16 pass
- [x] Combined with auth-proxy as CI runs them → 57/57 pass
- [x] Seam inert: no importers in `patch-adapter.mjs` / `auth-proxy.mjs`
- [x] `scripts/scan-internal-refs.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)