### PR TITLE
feat(installer): Forge Console CI/CD Setup page (turnkey scaffold-3)

### DIFF
--- a/installer/app.py
+++ b/installer/app.py
@@ -161,6 +161,43 @@ def run_step(body: RunBody, request: Request) -> dict:
     return {"started": run.step}
 
 
+SCAFFOLD_APPLY_TOKEN = "scaffold-apply"
+
+
+class ScaffoldBody(BaseModel):
+    params: dict = {}
+    secrets: dict[str, str] = {}
+    apply: bool = False
+    confirm: str = ""
+
+
+@app.post("/api/scaffold")
+def scaffold(body: ScaffoldBody, request: Request) -> dict:
+    """Run scripts/scaffold-cicd.sh (CI/CD one-time setup), streamed.
+
+    Preview-first: without apply it changes nothing. An apply mutates Azure
+    identity/RBAC and GitHub repo config, so it requires a distinct typed token.
+    Provider-key secrets pass via the subprocess environment, never on argv."""
+    _guard(request)
+    if body.apply and body.confirm != SCAFFOLD_APPLY_TOKEN:
+        raise HTTPException(
+            428,
+            f"type '{SCAFFOLD_APPLY_TOKEN}' to run scaffold with --apply "
+            "(it mutates Azure identity/RBAC and GitHub config)",
+        )
+    params = {**body.params, "apply": body.apply}
+    try:
+        cmd = core.build_scaffold_command(params)
+    except ValueError as e:
+        raise HTTPException(422, str(e))
+    env = {k: str(v) for k, v in (body.secrets or {}).items() if v}
+    try:
+        run = runner.start("scaffold", cmd, env=env)
+    except RuntimeError as e:
+        raise HTTPException(409, str(e))
+    return {"started": run.step, "preview": not body.apply}
+
+
 @app.get("/api/state")
 def state(request: Request) -> dict:
     _guard(request)

--- a/installer/core.py
+++ b/installer/core.py
@@ -327,6 +327,7 @@ STEP_TIMEOUTS = {
     "compose-up": 1800,
     "compose-down": 600,
     "compose-ps": 120,
+    "scaffold": 900,
 }
 DEFAULT_STEP_TIMEOUT = 3600
 
@@ -405,7 +406,7 @@ class Runner:
         return self.current is not None and self.current.status == "running"
 
     def start(self, step: str, cmd: list[str], cwd: Path = REPO_ROOT,
-              timeout: Optional[float] = None) -> StepRun:
+              timeout: Optional[float] = None, env: Optional[dict] = None) -> StepRun:
         with self._lock:
             if self.busy():
                 raise RuntimeError(f"a step is already running: {self.current.step}")
@@ -413,19 +414,22 @@ class Runner:
             self.current = run
         if timeout is None:
             timeout = STEP_TIMEOUTS.get(step, DEFAULT_STEP_TIMEOUT)
-        thread = threading.Thread(target=self._execute, args=(run, cmd, cwd, timeout), daemon=True)
+        thread = threading.Thread(target=self._execute, args=(run, cmd, cwd, timeout, env), daemon=True)
         thread.start()
         return run
 
     def _execute(self, run: StepRun, cmd: list[str], cwd: Path,
-                 timeout: Optional[float] = None) -> None:
+                 timeout: Optional[float] = None, env: Optional[dict] = None) -> None:
         self._emit(run, f"$ {' '.join(cmd)}")
         timer = None
         timed_out = threading.Event()
+        proc_env = {**os.environ, "TF_IN_AUTOMATION": "1"}
+        if env:
+            proc_env.update(env)
         try:
             proc = subprocess.Popen(
                 cmd, cwd=str(cwd), stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                text=True, bufsize=1, env={**os.environ, "TF_IN_AUTOMATION": "1"},
+                text=True, bufsize=1, env=proc_env,
             )
             # Watchdog: a step that produces no output and never exits would
             # otherwise block the read loop (and the single-run lock) forever.

--- a/installer/core.py
+++ b/installer/core.py
@@ -261,6 +261,44 @@ def build_step_command(step: str, profile: str, tf_dir: Path = TF_DIR,
     return commands[step]
 
 
+_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+def build_scaffold_command(params: dict, repo_root: Path = REPO_ROOT) -> list[str]:
+    """Map validated UI params to a scripts/scaffold-cicd.sh invocation.
+
+    Preview-first: `--apply` is only added when params['apply'] is truthy.
+    Provider-key SECRETS are NOT handled here — they pass via the subprocess
+    environment (see /api/scaffold), so nothing secret ever lands on argv."""
+    repo = (params.get("repo") or "").strip()
+    if repo and not _REPO_RE.match(repo):
+        raise ValueError(f"invalid repo (want OWNER/REPO): {repo!r}")
+
+    cmd = ["bash", str((repo_root / "scripts" / "scaffold-cicd.sh").resolve())]
+
+    str_flags = {
+        "repo": "--repo", "subscription": "--subscription", "app_name": "--app-name",
+        "location": "--location", "state_rg": "--state-rg",
+        "state_account": "--state-account", "state_container": "--state-container",
+        "registry": "--registry", "key_vault": "--key-vault",
+        "smoke_url": "--smoke-url", "reviewers": "--reviewers",
+    }
+    for key, flag in str_flags.items():
+        val = (params.get(key) or "").strip()
+        if val:
+            cmd += [flag, val]
+
+    bool_flags = {
+        "grant_uaa": "--grant-uaa", "environment_subject": "--environment-subject",
+        "skip_github": "--skip-github", "apply": "--apply",
+    }
+    for key, flag in bool_flags.items():
+        if params.get(key):
+            cmd.append(flag)
+
+    return cmd
+
+
 # Steps that change real infrastructure or remove resources. The API layer
 # requires a typed confirmation (the environment name) before running these.
 DANGEROUS_STEPS = {"apply", "destroy", "compose-down"}

--- a/installer/static/index.html
+++ b/installer/static/index.html
@@ -399,5 +399,83 @@ function startStream() {
   loadChecks();
 })();
 </script>
+
+<section id="cicd-setup">
+  <h2>CI/CD Setup</h2>
+  <p>One-time setup for the reference deploy pipeline: an Entra OIDC app, the
+     Terraform state backend, and GitHub variables/secrets + the
+     <code>deploy-destroy</code> approval environment. <strong>Preview first;</strong>
+     apply mutates Azure identity/RBAC and GitHub config.</p>
+
+  <label>GitHub repo (OWNER/REPO) <input id="sc-repo" placeholder="me/AzureAgentForge"></label>
+  <label>Subscription ID <input id="sc-subscription" placeholder="(current az account)"></label>
+  <label>App name <input id="sc-app-name" placeholder="aaf-deploy"></label>
+  <label>Location <input id="sc-location" placeholder="eastus"></label>
+  <label><input type="checkbox" id="sc-grant-uaa"> Grant User Access Administrator</label>
+  <label><input type="checkbox" id="sc-skip-github"> Azure only (skip GitHub)</label>
+
+  <fieldset>
+    <legend>Provider secrets (sent via env, never logged)</legend>
+    <label>GPT4O_API_KEY <input id="sc-sec-gpt4o" type="password"></label>
+    <label>AI_FOUNDRY_API_KEY <input id="sc-sec-foundry" type="password"></label>
+  </fieldset>
+
+  <button id="sc-preview">Preview</button>
+  <button id="sc-apply">Apply&#8230;</button>
+  <pre id="sc-output"></pre>
+</section>
+
+<script>
+(function () {
+  function scaffoldBody(apply, confirm) {
+    const params = {
+      repo: document.getElementById('sc-repo').value,
+      subscription: document.getElementById('sc-subscription').value,
+      app_name: document.getElementById('sc-app-name').value,
+      location: document.getElementById('sc-location').value,
+      grant_uaa: document.getElementById('sc-grant-uaa').checked,
+      skip_github: document.getElementById('sc-skip-github').checked,
+    };
+    const secrets = {};
+    const g = document.getElementById('sc-sec-gpt4o').value;
+    const f = document.getElementById('sc-sec-foundry').value;
+    if (g) secrets.GPT4O_API_KEY = g;
+    if (f) secrets.AI_FOUNDRY_API_KEY = f;
+    return { params, secrets, apply, confirm };
+  }
+
+  async function runScaffold(apply) {
+    let confirm = '';
+    if (apply) {
+      confirm = window.prompt(
+        "Apply mutates Azure identity/RBAC and GitHub config.\nType 'scaffold-apply' to proceed:"
+      );
+      if (confirm !== 'scaffold-apply') return;
+    }
+    const out = document.getElementById('sc-output');
+    out.textContent = '';
+    const resp = await fetch('/api/scaffold', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-forge-token': TOKEN },
+      body: JSON.stringify(scaffoldBody(apply, confirm)),
+    });
+    if (!resp.ok) {
+      out.textContent = 'error: ' + (await resp.text());
+      return;
+    }
+    // Subscribe to the SSE stream to show live output in sc-output.
+    const es = new EventSource('/api/stream?token=' + encodeURIComponent(TOKEN));
+    es.onmessage = function(ev) {
+      out.textContent += ev.data + '\n';
+      out.scrollTop = out.scrollHeight;
+    };
+    es.addEventListener('stepend', function() { es.close(); });
+    es.onerror = function() { es.close(); };
+  }
+
+  document.getElementById('sc-preview').addEventListener('click', function() { runScaffold(false); });
+  document.getElementById('sc-apply').addEventListener('click', function() { runScaffold(true); });
+})();
+</script>
 </body>
 </html>

--- a/installer/tests/test_scaffold.py
+++ b/installer/tests/test_scaffold.py
@@ -77,3 +77,72 @@ class TestRunnerEnv:
         _wait_done(run)
         assert run.status == "succeeded"
         assert any("ok" in line for line in run.lines)
+
+
+from fastapi.testclient import TestClient
+
+from installer import app as appmod  # noqa: E402
+
+
+def _client_and_headers():
+    return TestClient(appmod.app), {"x-forge-token": appmod.SESSION_TOKEN}
+
+
+class TestScaffoldEndpoint:
+    def test_preview_wires_command_and_env(self, monkeypatch):
+        captured = {}
+
+        def fake_start(step, cmd, cwd=appmod.core.REPO_ROOT, timeout=None, env=None):
+            captured.update(step=step, cmd=cmd, env=env)
+            run = appmod.core.StepRun(step=step)
+            return run
+
+        monkeypatch.setattr(appmod.runner, "start", fake_start)
+        client, headers = _client_and_headers()
+        resp = client.post("/api/scaffold", headers=headers, json={
+            "params": {"repo": "me/proj"},
+            "secrets": {"GPT4O_API_KEY": "super-secret"},
+        })
+        assert resp.status_code == 200
+        assert resp.json()["preview"] is True
+        assert "--apply" not in captured["cmd"]
+        assert "super-secret" not in captured["cmd"]          # secret not on argv
+        assert captured["env"]["GPT4O_API_KEY"] == "super-secret"  # secret via env
+
+    def test_apply_requires_confirmation_token(self, monkeypatch):
+        def boom(*a, **k):
+            raise AssertionError("runner.start must not be called without confirmation")
+
+        monkeypatch.setattr(appmod.runner, "start", boom)
+        client, headers = _client_and_headers()
+        resp = client.post("/api/scaffold", headers=headers, json={
+            "params": {"repo": "me/proj"}, "apply": True,
+        })
+        assert resp.status_code == 428
+        assert appmod.SCAFFOLD_APPLY_TOKEN in resp.json()["detail"]
+
+    def test_apply_runs_with_correct_token(self, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(
+            appmod.runner, "start",
+            lambda step, cmd, cwd=appmod.core.REPO_ROOT, timeout=None, env=None:
+                (captured.update(cmd=cmd) or appmod.core.StepRun(step=step)),
+        )
+        client, headers = _client_and_headers()
+        resp = client.post("/api/scaffold", headers=headers, json={
+            "params": {"repo": "me/proj"}, "apply": True,
+            "confirm": appmod.SCAFFOLD_APPLY_TOKEN,
+        })
+        assert resp.status_code == 200
+        assert "--apply" in captured["cmd"]
+
+    def test_invalid_repo_returns_422(self, monkeypatch):
+        monkeypatch.setattr(appmod.runner, "start", lambda *a, **k: None)
+        client, headers = _client_and_headers()
+        resp = client.post("/api/scaffold", headers=headers, json={"params": {"repo": "bad"}})
+        assert resp.status_code == 422
+
+    def test_requires_session_token(self):
+        client, _ = _client_and_headers()
+        resp = client.post("/api/scaffold", json={"params": {"repo": "me/proj"}})
+        assert resp.status_code == 401

--- a/installer/tests/test_scaffold.py
+++ b/installer/tests/test_scaffold.py
@@ -47,3 +47,33 @@ class TestBuildScaffoldCommand:
         cmd = core.build_scaffold_command({"repo": "me/proj", "GPT4O_API_KEY": "super-secret"})
         assert "super-secret" not in cmd
         assert "--GPT4O_API_KEY" not in cmd
+
+
+import time
+
+
+def _wait_done(run, timeout=10.0):
+    deadline = time.time() + timeout
+    while run.status == "running" and time.time() < deadline:
+        time.sleep(0.02)
+    return run
+
+
+class TestRunnerEnv:
+    def test_env_reaches_subprocess(self):
+        runner = core.Runner()
+        run = runner.start(
+            "scaffold",
+            ["sh", "-c", 'printf %s "$FORGE_SCAFFOLD_TEST"'],
+            env={"FORGE_SCAFFOLD_TEST": "envvalue"},
+        )
+        _wait_done(run)
+        assert run.status == "succeeded"
+        assert any("envvalue" in line for line in run.lines)
+
+    def test_no_env_still_runs(self):
+        runner = core.Runner()
+        run = runner.start("scaffold", ["sh", "-c", "printf ok"])
+        _wait_done(run)
+        assert run.status == "succeeded"
+        assert any("ok" in line for line in run.lines)

--- a/installer/tests/test_scaffold.py
+++ b/installer/tests/test_scaffold.py
@@ -1,0 +1,49 @@
+"""Offline tests for the scaffold-cicd Forge Console integration — no az/gh/network."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from installer import core  # noqa: E402
+
+
+class TestBuildScaffoldCommand:
+    def test_preview_has_no_apply_flag(self):
+        cmd = core.build_scaffold_command({"repo": "me/proj"})
+        assert cmd[0] == "bash"
+        assert cmd[1].endswith("scripts/scaffold-cicd.sh")
+        assert "--repo" in cmd and "me/proj" in cmd
+        assert "--apply" not in cmd
+
+    def test_apply_flag_when_requested(self):
+        cmd = core.build_scaffold_command({"repo": "me/proj", "apply": True})
+        assert "--apply" in cmd
+
+    def test_string_flags_only_included_when_set(self):
+        cmd = core.build_scaffold_command({
+            "repo": "me/proj", "subscription": "sub-123", "location": "westus2",
+        })
+        assert cmd[cmd.index("--subscription") + 1] == "sub-123"
+        assert cmd[cmd.index("--location") + 1] == "westus2"
+        assert "--registry" not in cmd  # not provided → absent
+
+    def test_bool_flags(self):
+        cmd = core.build_scaffold_command({
+            "repo": "me/proj", "grant_uaa": True, "skip_github": True,
+            "environment_subject": True,
+        })
+        assert "--grant-uaa" in cmd
+        assert "--skip-github" in cmd
+        assert "--environment-subject" in cmd
+
+    def test_invalid_repo_rejected(self):
+        with pytest.raises(ValueError, match="OWNER/REPO"):
+            core.build_scaffold_command({"repo": "not-a-repo"})
+
+    def test_secrets_never_placed_on_command_line(self):
+        cmd = core.build_scaffold_command({"repo": "me/proj", "GPT4O_API_KEY": "super-secret"})
+        assert "super-secret" not in cmd
+        assert "--GPT4O_API_KEY" not in cmd


### PR DESCRIPTION
## Summary
Adds a **CI/CD Setup** page to the Forge Console (v1.3 feature turnkey scaffold-3) that runs the existing `scripts/scaffold-cicd.sh` (OIDC app + TF state backend + GitHub vars/secrets/deploy-destroy env) as a live-streamed, **preview-first** operation.

- `installer/core.py` — pure `build_scaffold_command(params)` (secrets structurally never on argv) + `Runner` `env` passthrough + a `scaffold` timeout.
- `installer/app.py` — `POST /api/scaffold` with a server-enforced apply-confirmation gate (`scaffold-apply` token); provider secrets passed via the subprocess **env**, never the command line or logs.
- `installer/static/index.html` — CI/CD Setup form (password secret fields) + live `/api/stream` output.

## Test Plan
- [x] `pytest installer/tests` → 80 pass (+13 new in test_scaffold.py)
- [x] Security: secrets never reach argv/logs; apply-gate enforced server-side (verified)
- [x] `scripts/scan-internal-refs.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)