### PR TITLE
security(ci): two-app OIDC least-privilege split in deploy.yml (A1)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,13 @@ env:
   TF_DIR: infrastructure/environments/dev
   TF_IN_AUTOMATION: "1"
   ARM_USE_OIDC: "true"
-  ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+  # Least-privilege OIDC split. The un-gated jobs (build/seed/plan/smoke) run as
+  # the LOW-PRIVILEGE plan identity by default; only `apply` overrides this to
+  # the privileged identity (see the apply job). A poisoned dependency in the
+  # pre-approval jobs therefore cannot reach subscription Contributor.
+  # REQUIRES `vars.AZURE_CLIENT_ID_PLAN` to exist — provision the plan identity
+  # FIRST (provision.sh / scaffold-cicd.sh), then this workflow. See PROVISIONING.md.
+  ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID_PLAN }}
   ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
   ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
@@ -79,7 +85,7 @@ jobs:
       - uses: azure/login@v2
         if: steps.reg.outputs.name != ''
         with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          client-id: ${{ env.ARM_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
@@ -111,7 +117,7 @@ jobs:
       - uses: azure/login@v2
         if: steps.v.outputs.name != ''
         with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          client-id: ${{ env.ARM_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
@@ -147,7 +153,7 @@ jobs:
 
       - uses: azure/login@v2
         with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          client-id: ${{ env.ARM_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
@@ -247,12 +253,16 @@ jobs:
       needs.plan.result == 'success' &&
       (needs.plan.outputs.has_destroy == 'false' || needs.gate.result == 'success')
     runs-on: ubuntu-latest
+    # apply is the ONLY job that mutates infra — it overrides the low-priv default
+    # and runs as the PRIVILEGED identity. Keep this the single Contributor holder.
+    env:
+      ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
     steps:
       - uses: actions/checkout@v5
 
       - uses: azure/login@v2
         with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          client-id: ${{ env.ARM_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
@@ -293,7 +303,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: azure/login@v2
         with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          client-id: ${{ env.ARM_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - uses: hashicorp/setup-terraform@v3

--- a/scripts/scaffold-cicd.sh
+++ b/scripts/scaffold-cicd.sh
@@ -163,6 +163,8 @@ fi
 MAIN_SUBJECT="repo:${REPO}:ref:refs/heads/main"
 ENV_SUBJECT_STR="repo:${REPO}:environment:deploy-destroy"
 SUB_SCOPE="/subscriptions/${SUBSCRIPTION_ID}"
+STATE_SCOPE="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${STATE_RG}"
+PLAN_APP_NAME="${APP_NAME}-plan"
 
 echo "== AzureAgentForge CI/CD scaffold =="
 echo "mode=$([ "$APPLY" -eq 1 ] && echo APPLY || echo preview) repo=$REPO app=$APP_NAME github=$([ "$SKIP_GITHUB" -eq 1 ] && echo skip || echo yes)"
@@ -259,9 +261,52 @@ else
 fi
 echo
 
+# ── Step B2: low-privilege PLAN identity (least-privilege split) ─────────────
+# build/seed/plan/smoke run as this Reader-only identity; only `apply` uses the
+# privileged app above (deploy.yml selects per job). A poisoned dependency in a
+# pre-approval job therefore can't reach subscription Contributor.
+echo "-- step B2: low-privilege plan identity ($PLAN_APP_NAME) --"
+PLAN_APP_ID="<plan-app-id>"
+if [ "$APPLY" -eq 1 ]; then
+  PLAN_APP_ID="$(az ad app list --display-name "$PLAN_APP_NAME" --query '[0].appId' -o tsv 2>/dev/null || true)"
+  if [ -n "$PLAN_APP_ID" ]; then
+    echo "  app exists: $PLAN_APP_NAME ($PLAN_APP_ID)"
+  else
+    echo "  creating app registration: $PLAN_APP_NAME"
+    PLAN_APP_ID="$(az ad app create --display-name "$PLAN_APP_NAME" --query appId -o tsv)"
+  fi
+  az ad sp show --id "$PLAN_APP_ID" >/dev/null 2>&1 || run az ad sp create --id "$PLAN_APP_ID"
+  # Reader @ subscription (read, never mutate) + Storage Blob Data Contributor @
+  # state RG (read/write tfstate only). NEVER Contributor on this identity.
+  for pr in "Reader|$SUB_SCOPE" "Storage Blob Data Contributor|$STATE_SCOPE"; do
+    prole="${pr%%|*}"; pscope="${pr##*|}"
+    if [ -n "$(az role assignment list --assignee "$PLAN_APP_ID" --role "$prole" --scope "$pscope" --query '[0].id' -o tsv 2>/dev/null || true)" ]; then
+      echo "  role exists: $prole on $pscope"
+    else
+      run az role assignment create --assignee "$PLAN_APP_ID" --role "$prole" --scope "$pscope"
+    fi
+  done
+  # Same federated credentials as the privileged app (identical workflow runs).
+  pfics="aaf-plan-main|$MAIN_SUBJECT"
+  [ "$ENV_SUBJECT" -eq 1 ] && pfics="$pfics aaf-plan-env|$ENV_SUBJECT_STR"
+  for fc in $pfics; do
+    fname="${fc%%|*}"; fsubj="${fc##*|}"
+    if [ -n "$(az ad app federated-credential list --id "$PLAN_APP_ID" --query "[?subject=='$fsubj'].id" -o tsv 2>/dev/null || true)" ]; then
+      echo "  federated credential exists: $fsubj"
+    else
+      run az ad app federated-credential create --id "$PLAN_APP_ID" --parameters "{\"name\":\"$fname\",\"issuer\":\"https://token.actions.githubusercontent.com\",\"subject\":\"$fsubj\",\"audiences\":[\"api://AzureADTokenExchange\"]}"
+    fi
+  done
+else
+  echo "+ az ad app create --display-name $PLAN_APP_NAME       (find-or-create, Reader-only)"
+  echo "+ roles: Reader @ subscription + Storage Blob Data Contributor @ $STATE_RG (never Contributor)"
+fi
+echo
+
 if [ "$SKIP_GITHUB" -eq 1 ]; then
   echo "== Azure side done (--skip-github). Set the GitHub side with another run, or:"
-  echo "   gh variable set AZURE_CLIENT_ID --repo $REPO --body \"$APP_ID\"   (and the rest — see docs/deploy-pipeline.md)"
+  echo "   gh variable set AZURE_CLIENT_ID --repo $REPO --body \"$APP_ID\""
+  echo "   gh variable set AZURE_CLIENT_ID_PLAN --repo $REPO --body \"$PLAN_APP_ID\"   (and the rest — see docs/deploy-pipeline.md)"
   [ "$APPLY" -eq 1 ] || echo "(this was a preview — re-run with --apply)"
   exit 0
 fi
@@ -273,6 +318,7 @@ gh_var() {
   run gh variable set "$1" --repo "$REPO" --body "$2"
 }
 gh_var AZURE_CLIENT_ID "$APP_ID"
+gh_var AZURE_CLIENT_ID_PLAN "$PLAN_APP_ID"
 gh_var AZURE_TENANT_ID "$TENANT_ID"
 gh_var AZURE_SUBSCRIPTION_ID "$SUBSCRIPTION_ID"
 gh_var TFSTATE_RESOURCE_GROUP "$STATE_RG"


### PR DESCRIPTION
Workstream A / **Task A1** of `docs/migration-remediation-plan.md`.

Wires the documented two-identity split into the pipeline: build/seed/plan/smoke default to the **low-privilege** plan identity (`vars.AZURE_CLIENT_ID_PLAN`); only **`apply`** (the sole infra-mutating job) overrides to the **privileged** identity (`vars.AZURE_CLIENT_ID`). The destroy-aware `deploy-destroy` gate is untouched.

**⚠️ Do not merge before provisioning is paired.** `vars.AZURE_CLIENT_ID_PLAN` must exist first — provision the plan identity (`provision.sh` / `scaffold-cicd.sh`) and set the repo Variable, **then** merge. `deploy.yml` is `workflow_dispatch`-only, so merging won't fire a run, but the next dispatch needs the variable. Scaffolding that creates the plan identity should land alongside this.

**Staged for review** (not auto-merged) because it changes pipeline auth and depends on the provisioning step above. YAML validated; the split verified (low-priv default + privileged `apply` override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)