### PR TITLE
fix(hermes): kanban dispatcher crash on Azure Files SMB (WAL lock)

### DIFF
--- a/infrastructure/modules/container-apps/hermes.tf
+++ b/infrastructure/modules/container-apps/hermes.tf
@@ -245,6 +245,16 @@ resource "azurerm_container_app" "hermes" {
         value = "/tmp/hermes-state.db"
       }
 
+      # Same SMB fix for the kanban board DB. Without this, kanban.db resolves to
+      # HERMES_HOME (/opt/data, the Azure File Share) and `PRAGMA journal_mode=WAL`
+      # fails on SMB as "database is locked", crashing the kanban dispatcher every
+      # tick. Pinning it to /tmp keeps WAL working. Ephemeral (lost on redeploy),
+      # consistent with HERMES_DB_PATH above.
+      env {
+        name  = "HERMES_KANBAN_DB"
+        value = "/tmp/kanban.db"
+      }
+
       # Disable Hermes' lazy-install dispatch. Read by `tools/lazy_deps.py:216`
       # (`_allow_lazy_installs`) ahead of the `security.allow_lazy_installs`
       # config check, so this takes effect even if /opt/data/config.yaml is

--- a/services/agent-runtime/Dockerfile
+++ b/services/agent-runtime/Dockerfile
@@ -28,6 +28,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY apps/hermes/src/ .
 
+# AAF source patch: teach Hermes' WAL fallback to recognize Azure Files SMB
+# ("database is locked") so SMB-resident SQLite DBs fall back to DELETE journal
+# mode instead of crashing. The submodule can't be edited here; patch the copied
+# source at build time (idempotent, fails the build if the anchor is missing).
+COPY services/agent-runtime/patch-hermes-wal-markers.py /tmp/patch-wal-markers.py
+RUN python /tmp/patch-wal-markers.py hermes_state.py
+
 # AAF security override (see services/agent-runtime/constraints.txt).
 # Hermes pins several deps with EXACT '==' (e.g. aiohttp==3.13.3), which a pip
 # *constraints* file cannot override (ResolutionImpossible). So install Hermes

--- a/services/agent-runtime/patch-hermes-wal-markers.py
+++ b/services/agent-runtime/patch-hermes-wal-markers.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""AAF build-time patch — teach Hermes' WAL fallback about Azure Files SMB.
+
+apps/hermes/src is an upstream submodule (NousResearch/hermes-agent) we can't
+edit, so we patch the copied source at image-build time.
+
+Hermes' apply_wal_with_fallback() is designed to fall back to DELETE journal
+mode on WAL-hostile filesystems, but _WAL_INCOMPAT_MARKERS only matches
+"locking protocol" / "not authorized" / "disk i/o error". Azure Files (SMB/CIFS)
+surfaces the `PRAGMA journal_mode=WAL` failure as "database is locked"
+(SQLITE_BUSY), which fell through the marker check and was re-raised — crashing
+the kanban dispatcher every tick. This adds that marker so any SMB-resident DB
+degrades to DELETE mode instead of crashing.
+
+Idempotent. Run from the Hermes source root (where hermes_state.py lives).
+Upstream fix: add the marker to _WAL_INCOMPAT_MARKERS in NousResearch/hermes-agent.
+"""
+import sys
+import pathlib
+
+MARKER = '"database is locked"'
+NEW_LINE = '    "database is locked",     # Azure Files / SMB surfaces WAL-incompat as SQLITE_BUSY'
+
+
+def patch(src: str) -> str:
+    """Insert the new marker line after the 'disk i/o error' line. Idempotent."""
+    if MARKER in src:
+        return src
+    out = []
+    inserted = False
+    for line in src.splitlines(keepends=True):
+        out.append(line)
+        if not inserted and '"disk i/o error"' in line:
+            eol = "\n" if line.endswith("\n") else ""
+            out.append(NEW_LINE + eol)
+            inserted = True
+    if not inserted:
+        raise SystemExit("[patch-wal-markers] FATAL: anchor '\"disk i/o error\"' not found")
+    return "".join(out)
+
+
+def main() -> int:
+    target = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "hermes_state.py")
+    src = target.read_text()
+    if MARKER in src:
+        print("[patch-wal-markers] already applied")
+        return 0
+    patched = patch(src)
+    target.write_text(patched)
+    assert MARKER in target.read_text(), "patch did not take"
+    print("[patch-wal-markers] added 'database is locked' to _WAL_INCOMPAT_MARKERS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/agent-runtime/tests/test_patch_wal_markers.py
+++ b/services/agent-runtime/tests/test_patch_wal_markers.py
@@ -1,0 +1,40 @@
+"""Offline test for the WAL-markers build-time patch (no Hermes deps needed)."""
+import importlib.util
+import pathlib
+
+_spec = importlib.util.spec_from_file_location(
+    "patch_wal_markers",
+    pathlib.Path(__file__).resolve().parents[1] / "patch-hermes-wal-markers.py",
+)
+patch_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(patch_mod)
+
+SAMPLE = (
+    "_WAL_INCOMPAT_MARKERS = (\n"
+    '    "locking protocol",       # SQLITE_PROTOCOL on NFS/SMB\n'
+    '    "not authorized",         # Some FUSE mounts block WAL pragma outright\n'
+    '    "disk i/o error",         # Flaky network FS during WAL setup\n'
+    ")\n"
+)
+
+
+def test_adds_database_is_locked_marker_inside_the_tuple():
+    out = patch_mod.patch(SAMPLE)
+    assert '"database is locked"' in out
+    # inserted after the disk-i/o line and before the tuple closes
+    assert out.index('"database is locked"') > out.index('"disk i/o error"')
+    assert out.index('"database is locked"') < out.rindex(")")
+
+
+def test_idempotent():
+    once = patch_mod.patch(SAMPLE)
+    twice = patch_mod.patch(once)
+    assert once == twice
+    assert once.count('"database is locked"') == 1
+
+
+def test_missing_anchor_fails_loud():
+    import pytest
+
+    with pytest.raises(SystemExit):
+        patch_mod.patch("_WAL_INCOMPAT_MARKERS = ()\n")


### PR DESCRIPTION
Root-caused via systematic debugging. `kanban.db` resolved to the Azure File Share (`/opt/data`, via `HERMES_HOME`); SQLite WAL doesn't work on SMB, so `PRAGMA journal_mode=WAL` failed as `database is locked` and crashed the kanban dispatcher every ~2 min (~30/hr for 28+ hrs on dev). `state.db` already avoids this via `HERMES_DB_PATH=/tmp`; kanban had no equivalent pin.

**Layer 1** (`hermes.tf`): `HERMES_KANBAN_DB=/tmp/kanban.db` → kanban.db on local /tmp (WAL works). **Verified live on `ca-hermes-dev`: tick-failures 21→0 after the swap.** Ephemeral, consistent with `state.db`.

**Layer 2** (build-time patch + 3 tests): teach `apply_wal_with_fallback` to treat `database is locked` as WAL-incompat → DELETE-mode fallback instead of crashing, for any SMB-resident DB. Submodule can't be edited, so patched at image build (idempotent, fails loud). Lands on next image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)