### PR TITLE
ci(deploy): make reference deploy.yml runnable against a provisioned backend

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -175,7 +175,8 @@ jobs:
             -backend-config="key=${{ inputs.environment }}.terraform.tfstate" \
             -backend-config="subscription_id=${{ vars.AZURE_SUBSCRIPTION_ID }}" \
             -backend-config="tenant_id=${{ vars.AZURE_TENANT_ID }}" \
-            -backend-config="use_oidc=true"
+            -backend-config="use_oidc=true" \
+            -backend-config="use_azuread_auth=true"
 
       # Map the images that were actually built this run to the image-tag vars
       # the dev environment declares (router/hermes/honcho/paperclip). Images
@@ -206,6 +207,9 @@ jobs:
             -var="subscription_id=${{ vars.AZURE_SUBSCRIPTION_ID }}" \
             -var="environment=${{ inputs.environment }}" \
             -var="location=${{ inputs.location }}" \
+            -var="ai_foundry_endpoint=${{ vars.AI_FOUNDRY_ENDPOINT }}" \
+            -var="ai_foundry_deployment_id=${{ vars.AI_FOUNDRY_DEPLOYMENT_ID }}" \
+            -var='keyvault_admin_object_ids=${{ vars.KEYVAULT_ADMIN_OBJECT_IDS }}' \
             ${{ steps.img.outputs.vars }} \
             -out=tfplan
 
@@ -280,7 +284,8 @@ jobs:
             -backend-config="key=${{ inputs.environment }}.terraform.tfstate" \
             -backend-config="subscription_id=${{ vars.AZURE_SUBSCRIPTION_ID }}" \
             -backend-config="tenant_id=${{ vars.AZURE_TENANT_ID }}" \
-            -backend-config="use_oidc=true"
+            -backend-config="use_oidc=true" \
+            -backend-config="use_azuread_auth=true"
 
       - name: download plan
         uses: actions/download-artifact@v4
@@ -323,7 +328,8 @@ jobs:
             -backend-config="key=${{ inputs.environment }}.terraform.tfstate" \
             -backend-config="subscription_id=${{ vars.AZURE_SUBSCRIPTION_ID }}" \
             -backend-config="tenant_id=${{ vars.AZURE_TENANT_ID }}" \
-            -backend-config="use_oidc=true"
+            -backend-config="use_oidc=true" \
+            -backend-config="use_azuread_auth=true"
 
       - name: smoke test
         env:

--- a/infrastructure/environments/dev/backend.tf
+++ b/infrastructure/environments/dev/backend.tf
@@ -1,10 +1,8 @@
 terraform {
-  backend "azurerm" {
-    resource_group_name  = "rg-terraform-state"
-    storage_account_name = "YOUR_TF_STATE_STORAGE_ACCOUNT"
-    container_name       = "tfstate"
-    key                  = "dev.terraform.tfstate"
-    subscription_id      = "00000000-0000-0000-0000-000000000000"
-    tenant_id            = "00000000-0000-0000-0000-000000000000"
-  }
+  # Remote state in Azure Storage. All values are supplied at init time via
+  # -backend-config (see .github/workflows/deploy.yml; provision the backend
+  # with scripts/scaffold-cicd.sh). For a local-only first deploy, drop in a
+  # backend_override.tf containing `backend "local" {}` (Terraform loads
+  # *_override.tf last), then migrate with `terraform init -migrate-state`.
+  backend "azurerm" {}
 }

--- a/infrastructure/environments/dev/providers.tf
+++ b/infrastructure/environments/dev/providers.tf
@@ -32,7 +32,10 @@ provider "azurerm" {
 
 # Only used when cloudflare_managed = true. With an empty token and no Cloudflare
 # resources instantiated (the module is count-gated off by default), the provider
-# is configured but never authenticates.
+# is configured but never authenticates. NOTE: the cloudflare provider v5
+# validates the token FORMAT at plan time even with no resources, so an empty
+# string fails. Substitute a format-valid placeholder when no real token is
+# supplied so a tunnel-disabled `terraform plan` succeeds.
 provider "cloudflare" {
-  api_token = var.cloudflare_api_token
+  api_token = var.cloudflare_api_token != "" ? var.cloudflare_api_token : "0000000000000000000000000000000000000000"
 }


### PR DESCRIPTION
## What

Makes the reference `deploy.yml` actually plan/apply against a real, scaffolded Azure backend. Three fixes, validated locally by a **CI-equivalent `terraform plan` that came back `0 to add, 1 to change, 0 to destroy`** (the single change is a benign in-place `hermes` update adding `OBSERVABILITY_ENABLED`).

- **`backend.tf`** → partial `backend "azurerm" {}`; all values supplied at init via `-backend-config`. The placeholder values blocked remote init.
- **`deploy.yml`**:
  - `use_azuread_auth=true` on every `terraform init` so both OIDC identities reach the state blob via AAD (the low-priv plan identity has no `listKeys`).
  - Thread `ai_foundry_endpoint` / `ai_foundry_deployment_id` / `keyvault_admin_object_ids` into the plan step from repo vars. A clean CI checkout lacks the gitignored `terraform.tfvars`, so without this the plan would silently blank the Foundry endpoint and drop the KV admins.
- **`providers.tf`** → the cloudflare provider v5 validates the token *format* at plan time even with the tunnel disabled (`cloudflare_managed=false`); substitute a format-valid placeholder when no real token is supplied.

## Out-of-band provisioning (already applied to the dev sub)

`scripts/scaffold-cicd.sh --apply` (OIDC identities, state backend, repo vars, `deploy-destroy` env), state migrated local→remote, plus two RBAC grants the pipeline needs: `aaf-deploy` → Storage Blob Data Contributor on the state RG, `aaf-deploy-plan` → Key Vault Secrets User on `aaf-vault-dev-kv` (plan-time data-source reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)