### PR TITLE
ci(deploy): fetch submodules in the build job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,7 +76,13 @@ jobs:
       tag: ${{ steps.b.outputs.tag }}
       built: ${{ steps.b.outputs.built }}
     steps:
+      # submodules:recursive pulls apps/hermes/src + apps/honcho/src (public
+      # github.com submodules) — the upstream image builds (hermes/honcho/
+      # paperclip) copy and patch that source, so without them they fail on
+      # missing files (e.g. hermes_state.py).
       - uses: actions/checkout@v7
+        with:
+          submodules: recursive
 
       - name: registry configured?
         id: reg


### PR DESCRIPTION
The build job's upstream images (hermes/honcho/paperclip) copy & patch source from the `apps/hermes/src` + `apps/honcho/src` submodules. `actions/checkout` doesn't fetch submodules by default, so a live build failed with `FileNotFoundError: hermes_state.py`. Both submodules are public github.com repos → default token suffices.

Follow-up to #74; the 4 self-contained images already build fine — this unblocks the 3 upstream ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)