### PR TITLE
fix(bootstrap): unblock first-deploy onboarding (#50)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Line-ending normalization. Shell scripts MUST be checked out LF even on
+# Windows (git core.autocrlf=true) — a CRLF shebang fails under WSL/Linux with
+#   /usr/bin/env: 'bash\r': No such file or directory
+* text=auto eol=lf
+*.sh   text eol=lf
+*.bash text eol=lf
+
+# Windows-native scripts keep CRLF.
+*.ps1 text eol=crlf
+*.bat text eol=crlf
+*.cmd text eol=crlf

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -159,9 +159,16 @@ discord_enabled  = false
 ```
 
 Fill in your `subscription_id`. Change `location` if you want a different
-Azure region. The `container_registry_name` variable (in `variables.tf`)
-defaults to `"aafregistry"`, which must be globally unique, so override it
-in `terraform.tfvars` if that name is taken.
+Azure region.
+
+**Globally-unique names.** Three resources need names unique across all of Azure:
+the Container Registry (`container_registry_name`, default `"aafregistry"`), the
+Key Vault, and the storage account. The latter two derive from `project_name`
+(default `"aaf-vault"` → `aaf-vault-<env>-kv` and `aafvault<env>sa`). The defaults
+**will collide** with other adopters, so set `project_name` and
+`container_registry_name` in `terraform.tfvars` to values unique to your
+subscription. `scripts/bootstrap.sh` preflights all three up front and tells you
+exactly which one to change if it's already taken.
 
 ### 4. Choose a cost profile
 

--- a/infrastructure/environments/dev/variables.tf
+++ b/infrastructure/environments/dev/variables.tf
@@ -4,7 +4,7 @@ variable "subscription_id" {
 }
 
 variable "project_name" {
-  description = "Project name prefix for all resources"
+  description = "Project name prefix for all resources. Drives GLOBALLY-UNIQUE names — the Key Vault (<project>-<env>-kv) and the storage account (<project><env>sa, dashes stripped, 24 chars) — so the default 'aaf-vault' WILL collide with other adopters. Set it to a value unique to your subscription; scripts/bootstrap.sh preflights availability and tells you if it's taken."
   type        = string
   default     = "aaf-vault"
 }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -29,6 +29,8 @@ ENVIRONMENT="dev"
 VAULT=""
 AUTO_APPROVE=0
 DRY_RUN=0
+SUB_ID=""
+NAME_CONFLICTS=""
 
 die() { echo "error: $*" >&2; exit 2; }
 
@@ -41,8 +43,8 @@ Usage: scripts/bootstrap.sh [options]
   -v, --vault NAME        Key Vault name. Optional — by default it's read from the
                           `key_vault_name` Terraform output after the vault is
                           created. Pass it to skip the lookup.
-  -y, --yes               Auto-approve both `terraform apply` runs (first deploy
-                          only — it's all creates).
+  -y, --yes, --apply      Auto-approve both `terraform apply` runs (first deploy
+                          only — it's all creates). --apply is an alias for --yes.
   -n, --dry-run           Print the steps without running terraform/az/seed.
   -h, --help              This help.
 
@@ -57,7 +59,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     -e|--environment) ENVIRONMENT="${2:-}"; shift 2 ;;
     -v|--vault) VAULT="${2:-}"; shift 2 ;;
-    -y|--yes) AUTO_APPROVE=1; shift ;;
+    -y|--yes|--apply) AUTO_APPROVE=1; shift ;;
     -n|--dry-run) DRY_RUN=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) die "unknown argument: $1 (try --help)" ;;
@@ -84,6 +86,70 @@ tf() {
   terraform -chdir="$TF_DIR" "$@"
 }
 
+# Read a simple `name = "value"` assignment from the environment's tfvars files
+# (best effort — falls back to the given default, which matches the variable's
+# default in variables.tf).
+tfvar() {
+  local name="$1" def="$2" val=""
+  val="$(grep -hE "^[[:space:]]*${name}[[:space:]]*=" "$TF_DIR"/*.tfvars "$TF_DIR"/*.auto.tfvars 2>/dev/null \
+        | head -1 | sed -E 's/^[^=]*=[[:space:]]*"?([^"#]*[^"# ])"?.*$/\1/')"
+  printf '%s' "${val:-$def}"
+}
+
+# Fail early if a globally-unique Azure name is taken by SOMEONE ELSE. A name you
+# already own (re-running bootstrap) is fine. check_one KIND NAME VAR-TO-CHANGE
+check_one() {
+  local kind="$1" name="$2" hint="$3" avail="unknown"
+  case "$kind" in
+    keyvault)
+      if [ "$(az keyvault list --query "[?name=='$name'] | length(@)" -o tsv 2>/dev/null || echo 0)" != "0" ]; then
+        echo "  ok: key vault '$name' (already in your subscription)"; return 0; fi
+      avail="$(az rest --method post \
+        --url "https://management.azure.com/subscriptions/$SUB_ID/providers/Microsoft.KeyVault/checkNameAvailability?api-version=2023-07-01" \
+        --headers Content-Type=application/json \
+        --body "{\"name\":\"$name\",\"type\":\"Microsoft.KeyVault/vaults\"}" \
+        --query nameAvailable -o tsv 2>/dev/null || echo unknown)" ;;
+    registry)
+      if az acr show -n "$name" >/dev/null 2>&1; then
+        echo "  ok: registry '$name' (already in your subscription)"; return 0; fi
+      avail="$(az acr check-name -n "$name" --query nameAvailable -o tsv 2>/dev/null || echo unknown)" ;;
+    storage)
+      if az storage account show -n "$name" >/dev/null 2>&1; then
+        echo "  ok: storage account '$name' (already in your subscription)"; return 0; fi
+      avail="$(az storage account check-name -n "$name" --query nameAvailable -o tsv 2>/dev/null || echo unknown)" ;;
+  esac
+  if [ "$avail" = "true" ]; then
+    echo "  ok: $kind '$name' (available)"
+  elif [ "$avail" = "false" ]; then
+    NAME_CONFLICTS="${NAME_CONFLICTS}"$'\n'"  - $kind name '$name' is taken globally — set $hint"
+  else
+    echo "  warn: could not check $kind '$name' availability — continuing (apply will surface a collision)"
+  fi
+}
+
+# Resolve the globally-unique names Terraform will create and check them up front,
+# so a collision points at the exact variable to change instead of failing deep in
+# `terraform apply`. Mirrors the naming in main.tf / the modules.
+check_names() {
+  local project prefix kv sa acr
+  project="$(tfvar project_name aaf-vault)"
+  prefix="${project}-${ENVIRONMENT}"
+  kv="${prefix}-kv"                       # modules/keyvault: "${prefix}-kv"
+  acr="$(tfvar container_registry_name aafregistry)"
+  sa="${prefix}sa"; sa="${sa//-/}"; sa="${sa:0:24}"   # modules/container-apps/storage.tf
+  SUB_ID="$(az account show --query id -o tsv 2>/dev/null || true)"
+  echo "-- preflight: globally-unique name availability --"
+  check_one keyvault "$kv"  "project_name (drives <project>-<env>-kv)"
+  check_one registry "$acr" "container_registry_name"
+  check_one storage  "$sa"  "project_name (drives the storage account name)"
+  if [ -n "$NAME_CONFLICTS" ]; then
+    printf 'error: globally-unique Azure names are taken — edit infrastructure/environments/%s/terraform.tfvars:%s\n' \
+      "$ENVIRONMENT" "$NAME_CONFLICTS" >&2
+    die "set the variable(s) above to values unique to your subscription, then re-run"
+  fi
+  echo
+}
+
 echo "== AzureAgentForge first-deploy bootstrap =="
 echo "environment=$ENVIRONMENT vault=${VAULT:-<from terraform output>} auto_approve=$AUTO_APPROVE dry_run=$DRY_RUN"
 echo
@@ -95,6 +161,9 @@ if [ ! -d "$TF_DIR/.terraform" ]; then
   tf init -input=false
   echo
 fi
+
+# Catch globally-unique name collisions before terraform does (clearer error).
+[ "$DRY_RUN" -eq 0 ] && check_names
 
 echo "-- step 1: create the resource group + key vault --"
 tf apply "${APPLY_OPTS[@]}" -target=azurerm_resource_group.main -target=module.keyvault


### PR DESCRIPTION
Fixes the four blockers a real adopter (@Dokken1337) hit in #50:

1. **CRLF on WSL** — added `.gitattributes` forcing `*.sh` to LF, so a Windows checkout (`core.autocrlf=true`) no longer yields a `bash\r` shebang. `.ps1`/`.bat` keep CRLF.
2. **`--apply` rejected** — `bootstrap.sh` now accepts `--apply` as an alias for `--yes`. getting-started.md already tells users to run `scripts/bootstrap.sh --apply`, so the documented command now works.
3. **Opaque name collisions** — `bootstrap.sh` preflights the Key Vault / registry / storage-account names against Azure availability before applying, and fails with the exact variable to change (`project_name` / `container_registry_name`). Idempotent-safe (a name you already own is fine).
4. **Discoverability** — `project_name`'s description + getting-started now state that `project_name` (→ KV + storage) and `container_registry_name` are globally unique and the defaults collide with other adopters.

Validated locally: `bash -n` + `shellcheck --severity=error` clean, `--apply` accepted, preflight runs end-to-end and resolves already-owned resources without false conflicts.

Closes #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)