### PR TITLE
ci(deploy): thread observability_enabled so activation survives deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -225,6 +225,7 @@ jobs:
             -var="ai_foundry_endpoint=${{ vars.AI_FOUNDRY_ENDPOINT }}" \
             -var="ai_foundry_deployment_id=${{ vars.AI_FOUNDRY_DEPLOYMENT_ID }}" \
             -var='keyvault_admin_object_ids=${{ vars.KEYVAULT_ADMIN_OBJECT_IDS }}' \
+            -var="observability_enabled=${{ vars.OBSERVABILITY_ENABLED || 'false' }}" \
             ${{ steps.img.outputs.vars }} \
             -out=tfplan
 


### PR DESCRIPTION
Observability (v1.3) was activated via `az containerapp update`; the next pipeline deploy would reset it (var defaults off). Thread `observability_enabled` from a repo var (`|| 'false'` keeps adopters safe), matching the ai_foundry vars. dev repo var set to true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)