### PR TITLE
feat(governor): schema migration overlay + idempotent apply path

### DIFF
--- a/services/memory-governor/migrations/0001_governed_memory_overlay.sql
+++ b/services/memory-governor/migrations/0001_governed_memory_overlay.sql
@@ -11,7 +11,7 @@
 -- migrations/README.md), which the governor runs on startup.
 --
 -- ⚠️ TYPE RECONCILIATION: column TYPES below are derived from the governor's
--- query usage, not from the canonical MRTek migrations. Before enabling the
+-- query usage, not from the canonical source migrations (in the private upstream platform). Before enabling the
 -- governor in production, reconcile `documents.id`'s type (UUID vs text) so the
 -- *_doc_id references match, and confirm against the live Honcho schema.
 
@@ -52,7 +52,7 @@ CREATE TABLE IF NOT EXISTS agent_events (
 CREATE INDEX IF NOT EXISTS agent_events_type_time_idx ON agent_events (event_type, created_at);
 
 -- TODO(0002): port `session_memory` and `skill_candidates` from the canonical
--- MRTek migrations — their exact columns/types/indexes can't be safely derived
+-- canonical source migrations — their exact columns/types/indexes can't be safely derived
 -- from the governor's query usage alone. The scope-watcher and skill-miner loops
 -- stay idle until those exist (they fail closed), so the overlay above is enough
 -- for memory export/curation + the flag spine; the full feature set needs 0002.

--- a/services/memory-governor/migrations/0001_governed_memory_overlay.sql
+++ b/services/memory-governor/migrations/0001_governed_memory_overlay.sql
@@ -1,0 +1,58 @@
+-- 0001 governed-memory overlay on the shared Honcho Postgres.
+--
+-- The governor does NOT own its own database — it operates on Honcho's Postgres
+-- (the `documents`/`collections` tables + their 1536-dim embeddings are created
+-- by Honcho's own migrations). This overlay adds:
+--   (a) the governed-memory columns the governor reads/writes on `documents`, and
+--   (b) the governor-owned tables (feature_flags, agent_events).
+--
+-- Idempotent (IF NOT EXISTS everywhere) so it is safe to (re-)apply and never
+-- clobbers Honcho's columns. Applied by `python -m governor.migrate` (see
+-- migrations/README.md), which the governor runs on startup.
+--
+-- ⚠️ TYPE RECONCILIATION: column TYPES below are derived from the governor's
+-- query usage, not from the canonical MRTek migrations. Before enabling the
+-- governor in production, reconcile `documents.id`'s type (UUID vs text) so the
+-- *_doc_id references match, and confirm against the live Honcho schema.
+
+-- (a) governed-memory columns on Honcho's documents table ---------------------
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS memory_class            text;
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS verification_state      text;
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS memory_scope_kind       text;
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS memory_scope_id         text;
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS source_type             text;
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS created_by_peer         text;
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS last_confirmed_at       timestamptz;
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS expires_at              timestamptz;
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS trust_score             real;
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS superseded_by           text;
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS promotion_source_doc_id text;
+
+CREATE INDEX IF NOT EXISTS documents_memory_class_idx ON documents (memory_class);
+CREATE INDEX IF NOT EXISTS documents_expires_at_idx   ON documents (expires_at);
+
+-- (b) governor-owned tables ---------------------------------------------------
+CREATE TABLE IF NOT EXISTS feature_flags (
+    name        text PRIMARY KEY,
+    enabled     boolean     NOT NULL DEFAULT false,
+    description text,
+    updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS agent_events (
+    id          bigserial PRIMARY KEY,
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    actor_peer  text        NOT NULL,
+    event_type  text        NOT NULL,
+    channel     text        NOT NULL DEFAULT 'system',
+    session_id  uuid,
+    issue_id    text,
+    payload     jsonb       NOT NULL DEFAULT '{}'::jsonb
+);
+CREATE INDEX IF NOT EXISTS agent_events_type_time_idx ON agent_events (event_type, created_at);
+
+-- TODO(0002): port `session_memory` and `skill_candidates` from the canonical
+-- MRTek migrations — their exact columns/types/indexes can't be safely derived
+-- from the governor's query usage alone. The scope-watcher and skill-miner loops
+-- stay idle until those exist (they fail closed), so the overlay above is enough
+-- for memory export/curation + the flag spine; the full feature set needs 0002.

--- a/services/memory-governor/migrations/README.md
+++ b/services/memory-governor/migrations/README.md
@@ -26,10 +26,10 @@ DATABASE_URL="<postgres-connection-string from Key Vault>" \
   `feature_flags` + `agent_events`. Enough for memory **export/curation** (the
   Obsidian interface) and the feature-flag spine.
 - **Column TYPES are derived from the governor's query usage, not the canonical
-  MRTek migrations.** Before enabling the governor in production, reconcile
+  canonical source migrations.** Before enabling the governor in production, reconcile
   against the live Honcho schema — in particular whether `documents.id` is `uuid`
   or `text` (so the `*_doc_id` reference columns match).
 - **TODO `0002`** — `session_memory` and `skill_candidates` can't be safely
-  derived from code; port them from the canonical MRTek migrations. The
+  derived from code; port them from the canonical source migrations (in the private upstream platform). The
   scope-watcher and skill-miner loops fail closed and stay idle until those exist,
   so the rest of the governor works without them.

--- a/services/memory-governor/migrations/README.md
+++ b/services/memory-governor/migrations/README.md
@@ -1,0 +1,35 @@
+# Governed-memory migrations
+
+The memory-governor shares **Honcho's Postgres** — it does not own a database.
+Honcho's own migrations create `documents`/`collections` (+ 1536-dim embeddings);
+these files add the **governed-memory overlay** on top: extra columns the governor
+reads/writes on `documents`, plus the governor-owned tables.
+
+## Apply path
+
+`python -m governor.migrate` applies every `*.sql` here in filename order, once
+each, tracked in a `governor_schema_migrations` table. Every file is written
+`IF NOT EXISTS`, so re-applying is a no-op and Honcho's columns are never
+clobbered. The governor also calls `migrate.apply()` on startup, so a deploy is
+self-provisioning — no separate pipeline stage needed.
+
+To apply by hand against the shared DB:
+
+```bash
+DATABASE_URL="<postgres-connection-string from Key Vault>" \
+  python -m governor.migrate
+```
+
+## Status / caveats
+
+- **`0001_governed_memory_overlay.sql`** — the documents overlay columns +
+  `feature_flags` + `agent_events`. Enough for memory **export/curation** (the
+  Obsidian interface) and the feature-flag spine.
+- **Column TYPES are derived from the governor's query usage, not the canonical
+  MRTek migrations.** Before enabling the governor in production, reconcile
+  against the live Honcho schema — in particular whether `documents.id` is `uuid`
+  or `text` (so the `*_doc_id` reference columns match).
+- **TODO `0002`** — `session_memory` and `skill_candidates` can't be safely
+  derived from code; port them from the canonical MRTek migrations. The
+  scope-watcher and skill-miner loops fail closed and stay idle until those exist,
+  so the rest of the governor works without them.

--- a/services/memory-governor/src/governor/main.py
+++ b/services/memory-governor/src/governor/main.py
@@ -36,8 +36,18 @@ async def require_key(x_governor_key: str | None = Header(default=None)) -> None
 @app.on_event("startup")
 async def _startup() -> None:
     import asyncio
+    import logging
 
-    from . import annotator, contradiction, scope_watcher, skill_miner
+    from . import annotator, contradiction, migrate, scope_watcher, skill_miner
+
+    # Apply the governed-memory schema overlay (idempotent) before the loops run,
+    # so a fresh deployment has the columns/tables the governor queries. Fail-open:
+    # a migration error is logged, not fatal (the API still serves; loops fail closed).
+    try:
+        await migrate.apply()
+    except Exception:
+        logging.getLogger("governor.main").exception(
+            "schema migration failed — governed memory may not work until resolved")
 
     # Always-spawn, gate-inside: each loop checks its own feature flag every
     # cycle and idles when off, so spawning them is a no-op until a flag is on.

--- a/services/memory-governor/src/governor/migrate.py
+++ b/services/memory-governor/src/governor/migrate.py
@@ -1,0 +1,65 @@
+"""Idempotent SQL migration runner for the governed-memory overlay.
+
+The governor shares Honcho's Postgres and adds an overlay (governed-memory
+columns on `documents` + its own tables). This applies the ordered *.sql files in
+../../migrations once each, tracked in `governor_schema_migrations`. Every
+migration is written IF-NOT-EXISTS so re-applying is a no-op.
+
+Run standalone (`python -m governor.migrate`) or via apply() on startup. Safe to
+call on every boot; already-applied files are skipped.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+from . import db
+
+log = logging.getLogger("governor.migrate")
+
+MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "migrations"
+
+_TRACK_DDL = """
+CREATE TABLE IF NOT EXISTS governor_schema_migrations (
+    filename   text PRIMARY KEY,
+    applied_at timestamptz NOT NULL DEFAULT now()
+)
+"""
+
+
+async def apply() -> list[str]:
+    """Apply every not-yet-applied migration in order. Returns applied filenames."""
+    pool = await db.pool()
+    applied: list[str] = []
+    async with pool.acquire() as conn:
+        await conn.execute(_TRACK_DDL)
+        done = {r["filename"] for r in await conn.fetch(
+            "SELECT filename FROM governor_schema_migrations")}
+        for path in sorted(MIGRATIONS_DIR.glob("*.sql")):
+            if path.name in done:
+                continue
+            log.info("applying migration %s", path.name)
+            # Each file is idempotent; run it + record atomically.
+            async with conn.transaction():
+                await conn.execute(path.read_text(encoding="utf-8"))
+                await conn.execute(
+                    "INSERT INTO governor_schema_migrations (filename) VALUES ($1) "
+                    "ON CONFLICT (filename) DO NOTHING", path.name)
+            applied.append(path.name)
+    if applied:
+        log.info("applied %d migration(s): %s", len(applied), ", ".join(applied))
+    else:
+        log.info("schema up to date (%d known)", len(list(MIGRATIONS_DIR.glob("*.sql"))))
+    return applied
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO)
+    applied = asyncio.run(apply())
+    print(f"applied {len(applied)} migration(s): {applied or 'none'}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
First step toward making the governor (advanced memory — the differentiator) actually enable-able in AAF. Validation found it would 500 on enable because its schema overlay on Honcho's shared Postgres is never provisioned (canonical MRTek migrations weren't ported).

**Adds:** an idempotent migration runner (`python -m governor.migrate`, also run on startup) + `0001` overlay (documents governed-memory columns + feature_flags + agent_events).

**Needs before enabling in prod (documented in migrations/README.md):** reconcile column types vs live Honcho (esp. `documents.id` uuid-vs-text), and a `0002` for `session_memory`/`skill_candidates` from the canonical source. Leaving for review — don't enable the governor until validated against the live schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)