### PR TITLE
docs: refresh README and v1.3 docs; apply writing-rules pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Then you try to run one for real work and the uncomfortable questions show up:
 
 **AzureAgentForge is built for that gap.**
 
-It brings together three leading open-source agent tools, **PaperClip** for orchestration and UI, **Hermes** for agent execution, and **Honcho** for private memory, then wraps them in an Azure-ready foundation with Terraform, Key Vault, Container Apps, PostgreSQL, budget-aware model routing, and centralized logging.
+It brings together three open-source agent tools: **PaperClip** for orchestration and UI, **Hermes** for agent execution, and **Honcho** for private memory. It wraps them in an Azure foundation with Terraform, Key Vault, Container Apps, PostgreSQL, budget-aware model routing, and centralized logging.
 
-Most LLM calls are routed through **Azure AI Foundry**, which keeps model integration simple while aligning with the Azure security model. Where supported, the platform is designed to favor Microsoft Entra ID and managed identity patterns over long-lived API keys.
+Most LLM calls route through **Azure AI Foundry**, which keeps model integration simple and aligned with the Azure security model. Where supported, the platform favors Microsoft Entra ID and managed identity over long-lived API keys.
 
-This is not another cute local demo. It is a practical starting point for people who want agent teams they can deploy, monitor, constrain, talk to, and improve.
+You can deploy these agent teams, watch them, constrain them, talk to them, and improve them. That is the point.
 
 ---
 
@@ -59,41 +59,36 @@ The part most demos skip is what happens when a request is dangerous. Ask the or
 
 ## What's new
 
+New in v1.3 (since v1.2):
+
+- **GenAI observability, now live**: every LLM call through the model-router emits one OpenTelemetry GenAI span (model, token counts, cost) to Application Insights, behind `OBSERVABILITY_ENABLED` (off by default), with content redacted. The same change closes the Anthropic cost gap: Claude-tier calls return no billed cost from the SDK, so they now carry a list-price estimate and show up in both cost tracking and traces. The span export was fixed and verified against a live Application Insights workspace.
+- **Sandbox execution seam**: a provider-pluggable sandbox contract in PaperClip with a `local` adapter and a fail-closed factory, shipped unwired so importing it changes nothing at runtime. It is the seam for an Azure Container Apps dynamic-sessions provider later. 16 unit tests in CI ([`apps/paperclip/sandbox.mjs`](apps/paperclip/sandbox.mjs)).
+- **Turnkey CI/CD setup**: the Forge Console gains a CI/CD Setup page that runs [`scripts/scaffold-cicd.sh`](scripts/scaffold-cicd.sh), provisioning the OIDC app, the Terraform state backend, and the GitHub variables the deploy pipeline needs. It runs preview-first and live-streamed, behind an apply-confirmation gate. The reference [`deploy.yml`](.github/workflows/deploy.yml) now runs green end to end against a clean subscription.
+- **Obsidian memory interface**: a two-way `memory ↔ vault` CLI in the governor. `export` projects governed memory into an Obsidian-compatible Markdown vault, you curate it in Obsidian, and `sync` applies your edits back conservatively, re-checking server state and skipping conflicts ([`docs/obsidian-memory-interface.md`](docs/obsidian-memory-interface.md)).
+
 New in v1.2 (since v1.1):
 
-- **End-to-end Azure deploy, now validated**: a full deploy from a clean subscription — server-side image build/push (`az acr build`), Key Vault seeding, `terraform apply`, and post-deploy smoke — with a [step-by-step walkthrough](docs/getting-started.md#deployment-walkthrough-forge-console).
+- **End-to-end Azure deploy, now validated**: a full deploy from a clean subscription covering server-side image build and push (`az acr build`), Key Vault seeding, `terraform apply`, and post-deploy smoke. See the [step-by-step walkthrough](docs/getting-started.md#deployment-walkthrough-forge-console).
 - **One-command full local stack**: the upstream PaperClip/Honcho/Hermes sources are vendored so the full image set builds and runs with `scripts/local-stack.sh up` (or `docker compose --profile full up`).
 - **Microsoft Teams integration**: the `teams-bridge` Bot Framework service files inbound Teams messages as Orchestrator issues and replies with Adaptive Cards, gated by `teams_enabled` at parity with Telegram/Discord ([`services/teams-bridge`](services/teams-bridge/)).
-- **Hardened model-router tests**: 146 offline tests covering auth, rate limiting, per-tier budget/fallback, Foundry registration, and the OpenAI↔Anthropic translation layer — guarding the silent-downgrade and budget-exhaustion paths.
+- **Hardened model-router tests**: 146 offline tests covering auth, rate limiting, per-tier budget/fallback, Foundry registration, and the OpenAI↔Anthropic translation layer, guarding the silent-downgrade and budget-exhaustion paths.
 - **Observability module**: opt-in Log Analytics alert rules (watchdog findings, secret expiry, run failures) plus an Azure Monitor workbook, no app changes ([`infrastructure/modules/monitoring`](infrastructure/modules/monitoring/)).
 
-New in v1.1 (since the v1.0 open-source release):
-
-- **Governance &amp; blast-radius walkthrough**: a destructive request traced through every control that refuses it, backed by reproducible replay fixtures and the demos above.
-- **Destroy-aware approval gate**: in the Forge Console *and* as a reference CI/CD pipeline ([`.github/workflows/deploy.yml`](.github/workflows/deploy.yml)). Routine plans apply unattended; any delete/replace blocks on human approval. OIDC auth, no stored secrets ([setup](docs/deploy-pipeline.md)).
-- **Forge Console** (`./forge`): a local web installer that runs preflight checks and a live-streamed `init → validate → plan → apply`, with typed confirmations for `apply`/`destroy`.
-- **Governed memory, now shipped (flag-gated off)**: the four-plane / six-class memory model with admission control, computed trust, contradiction detection, hybrid pgvector retrieval, and a self-improvement loop, ported as real code under [`services/memory-governor/`](services/memory-governor/) + [`services/watchdog/`](services/watchdog/) (~150 offline tests in CI). Every flag seeds **off**, so it's inert until you enable it. Architecture and the explicitly-not-built long tail: [`docs/design/memory-system.md`](docs/design/memory-system.md).
-- **14 golden orchestration replay fixtures**: regression tests that pin agent routing and refusal behavior ([`tests/replay/`](tests/replay/)).
-- **Measured Azure costs**: figures validated against real bills (~$83/mo observed on cost-optimized), not just guessed from list prices ([`docs/cost.md`](docs/cost.md)).
+Earlier releases (v1.1, v1.0) are in the [roadmap](#roadmap).
 
 ---
 
-## The mental model
+## The components
 
-Think of AzureAgentForge as a small operations center for agent teams.
-
-- **PaperClip** is the front desk and work dashboard.
-- **Hermes** is where the agents actually do the work.
-- **OpenClaw** support is planned as an additional agent execution option.
-- **Honcho** is the memory layer that keeps context private.
+- **PaperClip** is the orchestrator: the UI, the issue board, and the work dashboard.
+- **Hermes** runs the agents that do the work. **OpenClaw** is planned as a second runtime option.
+- **Honcho** is the memory layer that keeps agent context inside your network.
 - **Memory Governor** is the optional governance layer over that memory. It decides what's worth remembering, how much to trust it, and what to forget.
-- **Model Router** is the spending guardrail.
+- **Model Router** enforces the spending limits.
 - **Azure AI Foundry** is the preferred model gateway.
-- **Azure** is the secure building everything runs inside.
+- **Azure** is where all of it runs.
 
-You bring the goals.
-
-The platform gives your agents a place to work, remember, call tools, stay within budget, talk to people, and leave an audit trail.
+You bring the goals. The platform gives your agents a place to work, remember, call tools, stay within budget, talk to people, and leave an audit trail.
 
 ---
 
@@ -224,7 +219,7 @@ Each is designed so the *default* outcome is "nothing destructive happens," and 
 request has to defeat all of them. See it traced end to end, with reproducible
 replay fixtures, in the [governance &amp; blast-radius walkthrough](docs/walkthroughs/governance-and-blast-radius.md).
 
-### Deployable on Azure, not just runnable on a laptop
+### Deployable on Azure
 
 Terraform provisions the Azure foundation, including:
 
@@ -237,11 +232,11 @@ Terraform provisions the Azure foundation, including:
 
 CI validates and plans clean on every commit.
 
-### Observable without container archaeology
+### Observability: logs and GenAI traces
 
-Every service logs to a shared Log Analytics workspace. Application Insights is optional.
+Every service logs to a shared Log Analytics workspace. As of v1.3, each model-router LLM call also emits an OpenTelemetry GenAI span (model, token counts, estimated cost) to Application Insights when you set `OBSERVABILITY_ENABLED`. Content is redacted, and the flag is off by default.
 
-You should be able to understand what happened without SSHing into containers and spelunking through logs like it is 2007.
+You can see what an agent did and what it spent without SSHing into a container and reading logs line by line.
 
 ### Built for where people already work
 
@@ -254,7 +249,7 @@ discord_enabled  = true
 
 Both are off by default.
 
-Full Microsoft Teams integration shipped in v1.2 — the `teams-bridge` Bot Framework service — so agent teams can move closer to the place many organizations already coordinate work.
+Full Microsoft Teams integration shipped in v1.2: the `teams-bridge` Bot Framework service, with Bot Framework JWT validation added on the inbound endpoint in v1.3. Teams joins Telegram and Discord as a place agents can reach people where they already work.
 
 ### Voice as a first-class interface
 
@@ -288,7 +283,7 @@ AzureAgentForge gives you the starting foundation: orchestration, runtime, memor
 
 ## What is included today
 
-As of v1.2, AzureAgentForge includes:
+As of v1.3, AzureAgentForge includes:
 
 - Full Terraform IaC for the Azure foundation
 - Two infrastructure cost profiles
@@ -298,33 +293,31 @@ As of v1.2, AzureAgentForge includes:
 - OpenAI-compatible fallback support
 - Sanitized Dockerfiles and service configuration
 - Key Vault-based secret loading
-- Log Analytics integration
+- Log Analytics integration plus opt-in GenAI traces to Application Insights
 - Private VNet design
 - Local working slice with PostgreSQL and the model router
 - Optional Telegram, Discord, and Microsoft Teams surfaces
 - Governance & blast-radius walkthrough with reproducible replay fixtures
 - Destroy-aware approval gate (Forge Console + reference CI/CD pipeline)
 - 14 golden orchestration replay fixtures (agent-behavior regression tests)
-- Governed memory: governor service, retrieval planner, background loops, hybrid vector retrieval, and self-improvement watchdog (shipped, flag-gated off)
-- Automated end-to-end Azure deploy: image build/push, Key Vault seeding, and post-deploy smoke tests
+- Governed memory: governor service, retrieval planner, background loops, hybrid vector retrieval, schema migrations, and self-improvement watchdog (shipped, flag-gated off)
+- Obsidian memory interface: two-way memory↔vault CLI for the governor
+- Sandbox execution seam in PaperClip (shipped unwired)
+- Automated end-to-end Azure deploy: image build/push, Key Vault seeding, and post-deploy smoke tests, with a turnkey CI/CD setup page in the Forge Console
 - One-command full local stack (`scripts/local-stack.sh up`)
 - Multi-tenant architecture design and early scaffolding
 
-The current local quickstart brings up PostgreSQL and the model router; the full platform runs locally with one command (`scripts/local-stack.sh up`, or `docker compose --profile full up`). The full end-to-end Azure deploy is automated in v1.2 (`scripts/build-and-push.sh`, `scripts/seed-keyvault.sh`, the Forge Console, and the reference deploy pipeline).
+The local quickstart brings up PostgreSQL and the model router. The full platform runs locally with one command (`scripts/local-stack.sh up`, or `docker compose --profile full up`). The end-to-end Azure deploy is automated (`scripts/build-and-push.sh`, `scripts/seed-keyvault.sh`, the Forge Console, and the reference deploy pipeline, which now runs green end to end).
 
 ---
 
 ## What's not finished yet
 
-AzureAgentForge is not a one-click SaaS product.
+AzureAgentForge is not a one-click SaaS product. Standing up your own instance takes real setup: an Azure subscription, GitHub-to-Azure IAM (OIDC), and a handful of environment-specific values.
 
-v1.2 gives you the architecture, Terraform, model router, role schema, Docker/config scaffolding, the full local stack, the Forge Console, a reference deploy pipeline, and automated image build/push + Key Vault seeding for the full Azure deploy. Standing up your own instance still takes real setup work: an Azure subscription, GitHub-to-Azure IAM (OIDC), and a handful of environment-specific configuration values.
+The v1.3 release gives you the architecture, Terraform, model router, role schema, Docker and config scaffolding, the full local stack, the Forge Console, a reference deploy pipeline that now runs green end to end, and automated image build/push plus Key Vault seeding. The end-to-end Azure deploy is validated against a clean subscription.
 
-Full end-to-end deploy automation shipped in v1.2 and is validated against a clean subscription — but it is not a one-click product: expect to wire IAM and supply a handful of environment values.
-
-If you want magic, this is not magic.
-
-If you want a serious foundation you can inspect, fork, improve, and run in your own Azure environment, you are in the right place.
+What you get is a foundation you can inspect, fork, improve, and run in your own Azure environment.
 
 ---
 
@@ -353,7 +346,9 @@ that writes your `terraform.tfvars` (with preview), then live-streamed
 `init → validate → plan → apply` in a terminal pane. Local Terraform state
 is handled automatically, so a first deploy needs zero pre-provisioned
 infrastructure. `apply` and `destroy` require typing the environment name,
-so there are no accidental clicks. Details and the security model:
+so there are no accidental clicks. v1.3 adds a CI/CD Setup page that scaffolds
+the OIDC app, Terraform state backend, and GitHub variables for the reference
+deploy pipeline. Details and the security model:
 [`installer/README.md`](installer/README.md).
 
 Prefer a guided walkthrough with an AI assistant instead? Start with
@@ -419,7 +414,7 @@ terraform -chdir=infrastructure/environments/dev apply \
 
 This provisions infrastructure. It does not yet build and push all service images or seed every runtime secret.
 
-The complete end-to-end deploy flow shipped in v1.2 — see the [deployment walkthrough](docs/getting-started.md#deployment-walkthrough-forge-console).
+The complete end-to-end deploy flow shipped in v1.2; see the [deployment walkthrough](docs/getting-started.md#deployment-walkthrough-forge-console).
 
 See [`docs/getting-started.md`](docs/getting-started.md) for the full Azure walkthrough, including Key Vault secret seeding.
 
@@ -482,6 +477,15 @@ See [`docs/getting-started.md`](docs/getting-started.md) for the full Azure walk
 - ✅ Full Microsoft Teams integration
 - ✅ First fully validated end-to-end Azure deployment from a clean subscription ([walkthrough](docs/getting-started.md#deployment-walkthrough-forge-console))
 
+### Shipped in v1.3
+
+- ✅ GenAI observability: an OpenTelemetry GenAI span per model-router call to Application Insights (flag-gated off), plus a list-price cost estimate for Claude-tier calls
+- ✅ Sandbox execution seam in PaperClip: provider-pluggable contract + `local` adapter, shipped unwired
+- ✅ Turnkey CI/CD setup: Forge Console page + `scripts/scaffold-cicd.sh` + `scripts/bootstrap.sh`; the reference `deploy.yml` runs green end to end
+- ✅ Obsidian memory interface: a two-way `memory ↔ vault` CLI in the governor
+- ✅ Governor schema migrations: an idempotent overlay applied on startup
+- ✅ Bot Framework JWT validation on the Teams inbound endpoint
+
 ### Future releases
 
 - ⬜ OpenClaw support as an additional agent runtime
@@ -495,10 +499,10 @@ See [`docs/getting-started.md`](docs/getting-started.md) for the full Azure walk
 - ⬜ Skills manager
 - ⬜ Artifacts and work products
 - ⬜ Cloud sandbox agents
-- ⬜ Deeper observability pipeline
+- ⬜ Deeper observability pipeline: SLO burn-rate alerts and a `gen_ai.usage` cost metric on top of the v1.3 spans
 - ⬜ Agent inventory and operational dashboard patterns
 - ⬜ Private enterprise RAG patterns with Azure AI Search
-- ⬜ Azure Container Apps Sandboxes exploration
+- ⬜ Azure Container Apps dynamic-sessions provider behind the v1.3 sandbox seam
 - ⬜ Microsoft Foundry Agent Service alignment
 - ⬜ Microsoft 365 and Agent 365 publishing exploration
 - ⬜ Work IQ API exploration
@@ -529,7 +533,7 @@ AzureAgentForge is intentionally aligned with where Microsoft is moving the agen
 - **Log Analytics and Application Insights** for operations and troubleshooting
 - **Microsoft 365 and Agent 365** as future distribution points where agents can meet users where they already work
 
-AzureAgentForge does not chase every new service that ships. It picks the ones that pull their weight and makes itself a practical bridge between open-source agent tooling and the Microsoft cloud capabilities that make agent systems safer and easier to operate inside real organizations.
+AzureAgentForge does not chase every new service that ships. It picks the ones that pull their weight, connecting open-source agent tooling to the Microsoft cloud features that make agent systems safer and easier to operate inside real organizations.
 
 ---
 
@@ -570,6 +574,7 @@ Multi-tenant support is designed and partially scaffolded.
 | [`docs/agents.md`](docs/agents.md) | The 14-role model and how to add your own |
 | [`docs/design/memory-system.md`](docs/design/memory-system.md) | Governed-memory architecture (four planes, six classes, trust model, self-improvement loop); shipped flag-gated off; code under [`services/memory-governor/`](services/memory-governor/) + [`services/watchdog/`](services/watchdog/) |
 | [`docs/deploy-pipeline.md`](docs/deploy-pipeline.md) | Reference GitHub Actions deploy pipeline with a destroy-aware approval gate (OIDC, no stored secrets) |
+| [`docs/obsidian-memory-interface.md`](docs/obsidian-memory-interface.md) | Two-way memory ↔ Obsidian vault CLI: export governed memory, curate in Obsidian, sync edits back |
 
 ---
 
@@ -602,7 +607,7 @@ AzureAgentForge is designed with a private-by-default posture:
 
 Before using this for sensitive workloads, review [`docs/security.md`](docs/security.md), validate your own Azure policies, and complete your own threat model.
 
-This is infrastructure you control, not a security guarantee you outsource.
+You own and control this infrastructure; the security posture is yours to verify.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,15 +7,15 @@
 
 # Roadmap
 
-## v1.0 — foundation (released)
+## v1.0: foundation (released)
 
-This stack runs in production on Azure; v1.0 is its sanitized, reusable version. Architecture, decisions, and full Terraform IaC are in the repo. Two cost profiles — cost-optimized (targets under $150/month) and hardened (zone-redundant, private endpoints) — and the repo's CI validates and plans both clean. The 13-role agent schema ships with tests. The model-router builds and runs locally: Azure AI Foundry as primary, any OpenAI-compatible endpoint as fallback. PaperClip, Honcho, and the agent-runtime ship as sanitized Dockerfiles and config. Telegram and Discord are each a single Terraform variable. Multi-tenant architecture is designed and partially scaffolded (see [`experimental/multi-tenant/`](experimental/multi-tenant/)).
+This stack runs in production on Azure; v1.0 is its sanitized, reusable version. Architecture, decisions, and full Terraform IaC are in the repo. Two cost profiles, cost-optimized (targets under $150/month) and hardened (zone-redundant, private endpoints), and the repo's CI validates and plans both clean. The 13-role agent schema ships with tests. The model-router builds and runs locally: Azure AI Foundry as primary, any OpenAI-compatible endpoint as fallback. PaperClip, Honcho, and the agent-runtime ship as sanitized Dockerfiles and config. Telegram and Discord are each a single Terraform variable. Multi-tenant architecture is designed and partially scaffolded (see [`experimental/multi-tenant/`](experimental/multi-tenant/)).
 
 `docker compose up` runs the working slice: Postgres and the model-router.
 
-## v1.1 — shipped
+## v1.1: shipped
 
-**Forge Console** (`./forge`) — a local web GUI installer that replaced the
+**Forge Console** (`./forge`) is a local web GUI installer that replaced the
 originally planned ANSI TUI: preflight checks, an Azure configuration wizard
 with tfvars preview, automatic local-state backend handling, and a
 live-streamed `init → validate → plan → apply` flow with typed confirmations.
@@ -25,7 +25,7 @@ cost-optimized profile). **Measured cost figures** from real bills landed in
 
 **Governance & safety.** Role-scoped toolsets, a dedicated `CostGuardian` role,
 and a **destroy-aware approval gate** that lets routine plans apply unattended
-but blocks any delete/replace behind explicit human approval — in the
+but blocks any delete/replace behind explicit human approval, in the
 Forge Console and as a **reference CI/CD deploy pipeline**
 ([`.github/workflows/deploy.yml`](.github/workflows/deploy.yml),
 [setup](docs/deploy-pipeline.md)) with OIDC auth and no stored secrets. The
@@ -43,7 +43,7 @@ flag seeds off, so it stays inert until you enable it. The explicitly-not-built
 long tail (reflection pass, inspector UI, in-channel controls, contradiction
 auto-resolve) stays design-only.
 
-## v1.2 — shipped
+## v1.2: shipped
 
 Closing the path from "infrastructure provisioned" to "fully running stack in one command".
 
@@ -60,18 +60,20 @@ Also in v1.2:
 - Microsoft Teams integration: shipped as the `teams-bridge` service (a Bot Framework messaging endpoint that files inbound Teams messages as Orchestrator issues and replies with Adaptive Cards), gated by the `teams_enabled` variable at parity with Discord/Telegram ([`services/teams-bridge`](services/teams-bridge/), [`integrations/teams`](integrations/teams/)). Internal ingress by default; going live needs the Cloudflare-tunnel exposure + Bot Framework JWT validation noted in the service README.
 - Secret-expiry monitoring goes live: the watchdog detector that lists Key Vault secret/cert expiry and files an issue before a lapsed credential takes down the agents that depend on it. Detector + watchdog wiring shipped and **now unit-tested** (8 boundary tests in `services/watchdog/tests/test_secret_expiry.py`); opt-in via `WATCHDOG_KEY_VAULT_URI`, activates with the first deploy.
 - Model-router test coverage hardened: the gateway's auth, rate limiting, request validation, per-tier budget/fallback, Foundry tier registration, the OpenAI↔Anthropic translation layer, and the chat/messages endpoints now have **121 offline tests** alongside the original routing/embeddings suites (`services/model-router/tests/`, 146 total). These guard the silent-downgrade and budget-exhaustion paths that previously only surfaced in production.
-- Observability surface in the monitoring module ([`infrastructure/modules/monitoring`](infrastructure/modules/monitoring/)): three Log Analytics alert rules (watchdog critical findings, Key Vault secret expiry, watchdog run failures) wired to an email action group, plus an Azure Monitor workbook for watchdog activity and gateway health. Queries match the services' existing console-log markers — no app changes. Both opt-in (`alert_emails`, `enable_observability_workbook`); the default footprint is unchanged. `terraform validate` clean.
-- ✅ **Done:** first fully validated end-to-end Azure deploy from a clean subscription — see the [deployment walkthrough](docs/getting-started.md#deployment-walkthrough-forge-console).
+- Observability surface in the monitoring module ([`infrastructure/modules/monitoring`](infrastructure/modules/monitoring/)): three Log Analytics alert rules (watchdog critical findings, Key Vault secret expiry, watchdog run failures) wired to an email action group, plus an Azure Monitor workbook for watchdog activity and gateway health. Queries match the services' existing console-log markers, with no app changes. Both opt-in (`alert_emails`, `enable_observability_workbook`); the default footprint is unchanged. `terraform validate` clean.
+- ✅ **Done:** first fully validated end-to-end Azure deploy from a clean subscription; see the [deployment walkthrough](docs/getting-started.md#deployment-walkthrough-forge-console).
 
-## v1.3 — shipped
+## v1.3: shipped
 
-Observability deepened and the agent surface widened. Four features, flag-gated where they touch runtime:
+Observability deepened and the agent surface widened. The main features, flag-gated where they touch runtime:
 
-- **GenAI-semconv observability.** Every model call through the [model-router](services/model-router/) emits one OpenTelemetry GenAI-semantic-convention span (model, tokens, cost) to Application Insights, behind `OBSERVABILITY_ENABLED` (default off), content-redacted. The port also **closes the Anthropic cost gap** — Claude-tier calls weren't cost-tracked (the SDK returns no billed cost); they now carry a list-price estimate, so they're both tracked and observable. Wired onto the router sidecar in Terraform behind a default-false flag; spans + estimator are offline-tested.
-- **ACA Sandboxes — execution seam.** A provider-pluggable sandbox seam ([`apps/paperclip/sandbox.mjs`](apps/paperclip/sandbox.mjs)): the contract + a `local` adapter + a fail-closed provider factory, shipped **unwired** (importing it changes no runtime behavior). Wiring it into the spawn path and adding an `aca-job` (ACA dynamic-sessions) provider are follow-ons. 16 `node:test` unit tests in CI.
-- **Turnkey CI/CD setup page.** The Forge Console gains a **CI/CD Setup** page that runs [`scripts/scaffold-cicd.sh`](scripts/scaffold-cicd.sh) (OIDC app + Terraform state backend + GitHub variables/secrets/`deploy-destroy` environment) as a live-streamed, **preview-first** operation, with a server-enforced apply-confirmation gate. Provider secrets travel via the subprocess environment — never the command line or logs.
-- **Obsidian memory interface.** A two-way `memory ↔ Obsidian vault` CLI ([`governor.vault`](services/memory-governor/src/governor/vault.py)): `export` projects governed memory into a local Obsidian-compatible Markdown+frontmatter vault (the six-class model maps 1:1 onto note frontmatter, so Obsidian *is* the UI — no frontend to build); `sync` applies operator edits back (delete → forget, frontmatter → confirm/pin/demote/dispute) **conservatively** — it re-fetches server state and skips conflicts, so the governor stays source of truth and nothing is silently clobbered. Local operator CLI, no Azure infra.
+- **GenAI-semconv observability.** Every model call through the [model-router](services/model-router/) emits one OpenTelemetry GenAI-semantic-convention span (model, tokens, cost) to Application Insights, behind `OBSERVABILITY_ENABLED` (default off), content-redacted. The port also **closes the Anthropic cost gap**: Claude-tier calls weren't cost-tracked (the SDK returns no billed cost), so they now carry a list-price estimate and are both tracked and observable. The span export was fixed after release and verified against a live Application Insights workspace. Wired onto the router sidecar in Terraform behind a default-false flag; spans and estimator are offline-tested.
+- **ACA Sandboxes: execution seam.** A provider-pluggable sandbox seam ([`apps/paperclip/sandbox.mjs`](apps/paperclip/sandbox.mjs)): the contract, a `local` adapter, and a fail-closed provider factory, shipped **unwired** (importing it changes no runtime behavior). Wiring it into the spawn path and adding an `aca-job` (ACA dynamic-sessions) provider are follow-ons. 16 `node:test` unit tests in CI.
+- **Turnkey CI/CD setup page.** The Forge Console gains a **CI/CD Setup** page that runs [`scripts/scaffold-cicd.sh`](scripts/scaffold-cicd.sh) (OIDC app, Terraform state backend, and GitHub variables/secrets/`deploy-destroy` environment) as a live-streamed, **preview-first** operation, with a server-enforced apply-confirmation gate. Provider secrets travel via the subprocess environment, never the command line or logs.
+- **Obsidian memory interface.** A two-way `memory ↔ Obsidian vault` CLI ([`governor.vault`](services/memory-governor/src/governor/vault.py)): `export` projects governed memory into a local Obsidian-compatible Markdown+frontmatter vault (the six-class model maps 1:1 onto note frontmatter, so Obsidian *is* the UI, with no frontend to build); `sync` applies operator edits back (delete → forget, frontmatter → confirm/pin/demote/dispute) **conservatively**: it re-fetches server state and skips conflicts, so the governor stays source of truth and nothing is silently clobbered. Local operator CLI, no Azure infra.
+
+Also in v1.3: Bot Framework JWT validation on the Teams inbound endpoint, governor schema migrations (an idempotent schema overlay on Honcho's shared Postgres, applied on startup), and the reference `deploy.yml` validated green end to end against a clean subscription.
 
 ## Later
 
-Multi-tenant implementation (the [`experimental/multi-tenant/`](experimental/multi-tenant/) design). More chat surfaces. The rest of the observability pipeline — SLO burn-rate alerts and a `gen_ai.usage` cost metric — building on the v1.3 spans and the v1.2 alert rules + workbook.
+Multi-tenant implementation (the [`experimental/multi-tenant/`](experimental/multi-tenant/) design). More chat surfaces. The rest of the observability pipeline: SLO burn-rate alerts and a `gen_ai.usage` cost metric, building on the v1.3 spans and the v1.2 alert rules and workbook.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ Pick a path:
 
 The local router registers a `gpt4o-mini` primary tier when you provide either
 the `AZURE_FOUNDRY_*` pair or the direct `GPT4O_*` pair (the former is aliased
-to the latter in `docker-compose.yml`) — point either at any OpenAI-compatible
+to the latter in `docker-compose.yml`). Point either at any OpenAI-compatible
 endpoint: Azure AI Foundry, Ollama, vLLM, or a hosted API. Optional tiers
 (Grok, Kimi, Claude, Phi) register only when their own env vars are set.
 
@@ -240,7 +240,7 @@ Image build, push, and service startup are automated in v1.2 via
 ### 6. Seed Key Vault secrets
 
 After apply, the Container Apps pull secrets from Key Vault by name. Seed them
-with [`scripts/seed-keyvault.sh`](../scripts/seed-keyvault.sh) — it generates the
+with [`scripts/seed-keyvault.sh`](../scripts/seed-keyvault.sh); it generates the
 internal secrets (JWT keys, admin passwords) and reads external ones (provider
 keys, bot tokens, the Postgres connection strings) from like-named environment
 variables:
@@ -250,7 +250,7 @@ KV=$(terraform output -raw key_vault_name)
 
 # Pass the keys/tokens you have; an unset external gets a non-empty `__unset__`
 # placeholder and stays inert until you set it and re-run. The Postgres
-# connection strings are a SECOND pass — they can only be known now that the
+# connection strings are a SECOND pass: they can only be known now that the
 # database exists, so derive them from your Postgres resource.
 AI_FOUNDRY_API_KEY="<your-key>" \
 POSTGRES_CONNECTION_STRING="<from your Postgres resource>" \
@@ -259,9 +259,9 @@ PAPERCLIP_DB_URL="<from your Postgres resource>" \
 ```
 
 `scripts/seed-keyvault.sh --list` prints the full inventory and the env var each
-secret reads. Note the Azure AI Foundry **endpoint** is *not* a Key Vault secret
-— it's the `ai_foundry_endpoint` Terraform variable (set in `terraform.tfvars`
-or the Forge form); only the API key (`ai-foundry-api-key`) is a secret.
+secret reads. Note the Azure AI Foundry **endpoint** is *not* a Key Vault secret;
+it is the `ai_foundry_endpoint` Terraform variable (set in `terraform.tfvars`
+or the Forge form). Only the API key (`ai-foundry-api-key`) is a secret.
 
 ### 7. After deploy
 
@@ -279,7 +279,7 @@ From here, the same steps as the local path apply:
 - Enable Telegram: [`../integrations/telegram/README.md`](../integrations/telegram/README.md)
 - Enable Discord: [`../integrations/discord/README.md`](../integrations/discord/README.md)
 - Enable Teams: [`../integrations/teams/README.md`](../integrations/teams/README.md)
-- Public ingress / a chat surface going live (e.g. Teams) needs a Cloudflare tunnel + DNS — managed by the `cloudflare-tunnel` Terraform module under `infrastructure/modules/`.
+- Public ingress or a chat surface going live (e.g. Teams) needs a Cloudflare tunnel and DNS, managed by the `cloudflare-tunnel` Terraform module under `infrastructure/modules/`.
 
 ---
 
@@ -303,37 +303,37 @@ A full end-to-end deploy of the cloud stack from a **clean subscription** via th
 Forge Console (`PYTHON=python3.13 ./forge`). Image builds run server-side in ACR
 (`az acr build`), so no local Docker is required.
 
-1. **Build & push the images** — `scripts/build-and-push.sh` (server-side `az acr build`; run `--list` first to preview the seven images):
+1. **Build and push the images** with `scripts/build-and-push.sh` (server-side `az acr build`; run `--list` first to preview the seven images):
    ![Image build to ACR](assets/deploy-1-acr-build.png)
-2. **Preflight checks** — Terraform, `az` login, and subscription detection:
+2. **Preflight checks**: Terraform, `az` login, and subscription detection:
    ![Forge Console preflight](assets/deploy-2-preflight.png)
-3. **Configuration wizard** — the tfvars form with live preview:
+3. **Configuration wizard**: the tfvars form with live preview:
    ![tfvars wizard](assets/deploy-3-config-wizard.png)
-4. **Plan** — live-streamed `terraform plan`:
+4. **Plan**: live-streamed `terraform plan`:
    ![terraform plan](assets/deploy-4-plan.png)
-5. **Destroy-aware apply gate** — typed confirmation; routine changes apply, any delete/replace blocks:
+5. **Destroy-aware apply gate**: typed confirmation; routine changes apply, any delete/replace blocks:
    ![apply gate](assets/deploy-5-apply-gate.png)
-6. **Apply complete** — infrastructure provisioned:
+6. **Apply complete**: infrastructure provisioned:
    ![apply complete](assets/deploy-6-apply-complete.png)
-7. **Running stack** — the resource group with the Container Apps environment and the deployed apps:
+7. **Running stack**: the resource group with the Container Apps environment and the deployed apps:
    ![resource group](assets/deploy-7-resource-group.png)
-8. **Post-deploy smoke + live UI** — `scripts/smoke-test.sh` PASS and the PaperClip UI over the Cloudflare tunnel:
+8. **Post-deploy smoke and live UI**: `scripts/smoke-test.sh` PASS and the PaperClip UI over the Cloudflare tunnel:
    ![smoke pass and PaperClip UI](assets/deploy-8-smoke-and-ui.png)
 
 > Key Vault is seeded with `scripts/seed-keyvault.sh` (the generate-class secrets,
 > incl. `postgres-admin-password`, must exist before the first `terraform apply`).
 > The same flow runs unattended via the [reference deploy pipeline](deploy-pipeline.md).
 
-### Deploy inputs — how to obtain each one
+### Deploy inputs: how to obtain each one
 
 Everything the Forge form (and `terraform.tfvars`) asks for, and where each value
-comes from — fill these in and you won't need to hand-edit `terraform.tfvars`:
+comes from. Fill these in and you won't need to hand-edit `terraform.tfvars`:
 
 | Input | What it is | How to get it |
 |---|---|---|
 | `subscription_id` | Your Azure subscription GUID | `az account show --query id -o tsv` |
 | `ai_foundry_endpoint` | The Azure AI Foundry project endpoint URL | Portal → your Foundry / AI Services resource → **Endpoint**, e.g. `https://<name>.cognitiveservices.azure.com/` |
-| `ai_foundry_deployment_id` | The **name of a model deployment** you created in Foundry (e.g. `gpt-4o-mini`) — a deployment name, **not** a GUID. Defaults to `gpt-4o-mini`. | `az cognitiveservices account deployment list -n <foundry> -g <rg> -o table` |
+| `ai_foundry_deployment_id` | The **name of a model deployment** you created in Foundry (e.g. `gpt-4o-mini`), a deployment name and **not** a GUID. Defaults to `gpt-4o-mini`. | `az cognitiveservices account deployment list -n <foundry> -g <rg> -o table` |
 | `keyvault_admin_object_ids` | Your Entra **object id**, granted Key Vault Secrets Officer so the seed step can write secrets (without it the seed 403s) | `az ad signed-in-user show --query id -o tsv` (or a service principal's object id) |
 | Container image tag | The commit short-SHA `scripts/build-and-push.sh` pushes (e.g. `9bf1a51`); blank uses `latest`. The Forge **Container image tag** field fans one tag out to all four service images. | `git rev-parse --short HEAD`, or `az acr repository show-tags -n <registry> --repository paperclip --orderby time_desc --top 1 -o tsv` |
 
@@ -353,5 +353,5 @@ container up by hand outside the provided Terraform:
   Azure; the deploy wires the cluster-internal names for you.
 
 Key Vault secret names are kept consistent across what `scripts/seed-keyvault.sh`
-seeds, what the container-apps modules reference, and what `data.tf` reads — so a
+seeds, what the container-apps modules reference, and what `data.tf` reads, so a
 fresh deploy resolves every secret reference without manual reconciliation.

--- a/docs/obsidian-memory-interface.md
+++ b/docs/obsidian-memory-interface.md
@@ -1,8 +1,8 @@
 # Obsidian memory interface
 
-A two-way bridge between AzureAgentForge's **governed memory** and a local
+A two-way interface between AzureAgentForge's **governed memory** and a local
 [Obsidian](https://obsidian.md) vault. The governed-memory six-class model maps
-1:1 onto Markdown-note-with-frontmatter, so an Obsidian vault *is* the UI — there
+1:1 onto Markdown notes with frontmatter, so an Obsidian vault *is* the UI; there
 is no frontend to install.
 
 - **`export`** projects every governed memory into `<vault>/<id>.md`.
@@ -11,7 +11,7 @@ is no frontend to install.
 
 Implementation: [`services/memory-governor/src/governor/vault.py`](../services/memory-governor/src/governor/vault.py).
 It is a thin `httpx` client over the governor's operator API plus pure
-render/parse/diff — no database access and no Azure SDK.
+render/parse/diff, with no database access and no Azure SDK.
 
 ---
 
@@ -35,7 +35,7 @@ Enable and deploy it:
    secret mount.
 
 > The governor ingress is **internal** (VNet-only), exactly like the model
-> router — it is intentionally not exposed to the public internet.
+> router; it is intentionally not exposed to the public internet.
 
 ---
 
@@ -61,13 +61,13 @@ export GOVERNOR_API_KEY="$(az keyvault secret show \
 Because `ca-memory-governor-dev` has internal ingress, a laptop cannot hit it
 directly. Pick one:
 
-- **Run from inside the VNet** — e.g. a one-off container/job in the same
-  Container Apps environment (the most reliable path; the same approach used to
-  probe the internal router).
+- **Run from inside the VNet**: e.g. a one-off container or job in the same
+  Container Apps environment (the most reliable path, and the same approach used
+  to probe the internal router).
 - **Tunnel** to the internal FQDN (VPN, Cloudflare tunnel, or a jump host), then
   set `GOVERNOR_BASE_URL` to the reachable address.
-- **Auth-proxy** — if a public mission-control host fronts the governor, set
-  `MEMORY_API_BASE_URL` + `MEMORY_API_TOKEN` and skip the VNet entirely.
+- **Auth-proxy**: if a public mission-control host fronts the governor, set
+  `MEMORY_API_BASE_URL` and `MEMORY_API_TOKEN` and skip the VNet entirely.
 
 ---
 
@@ -101,7 +101,7 @@ Empty/None fields are omitted.
 
 ---
 
-## Repeated exports — no duplicates
+## Repeated exports: no duplicates
 
 **Re-running `export` never creates duplicates.** Each note is named by the
 memory's **stable governor id** (`<id>.md`), so a second export *overwrites the
@@ -109,12 +109,12 @@ same file in place*; it is idempotent. The baseline file is likewise rewritten.
 
 Two things to know before you re-export, though:
 
-1. **Re-export overwrites notes wholesale** — it re-renders each note from the
-   current server state, so it **clobbers any local edits you have not synced
-   yet**. The intended loop is **export → curate → `sync` → (optionally re-export
-   to refresh)**. Always `sync` before re-exporting if you have pending edits.
-2. **Export does not prune** — notes for memories that were *forgotten/deleted
-   server-side* are not removed from the vault; the stale `<id>.md` lingers (it is
+1. **Re-export overwrites notes wholesale.** It re-renders each note from the
+   current server state, so it clobbers any local edits you have not synced yet.
+   The intended loop is **export → curate → `sync` → (optionally re-export to
+   refresh)**. Always `sync` before re-exporting if you have pending edits.
+2. **Export does not prune.** Notes for memories that were forgotten or deleted
+   server-side are not removed from the vault; the stale `<id>.md` lingers (it is
    stale, not a duplicate). To get a clean mirror, export into a fresh directory,
    or delete notes whose ids no longer appear in a fresh `list`. (`sync` *does*
    treat a note you delete locally as a `forget`.)
@@ -141,8 +141,8 @@ governor actions (all attributed to `actor=operator`):
 
 **Conflict safety:** before applying, `sync` re-fetches current server state and
 **skips any memory whose class/verification changed on the server since your
-export** (listed in the output). The governor stays the source of truth — nothing
-is silently clobbered. Re-`export` to pick up those server changes, then curate
+export** (listed in the output). The governor stays the source of truth, and
+nothing is silently clobbered. Re-`export` to pick up those server changes, then curate
 again.
 
 **Not handled:** editing a note's **body/content** is *not* synced (creating a


### PR DESCRIPTION
## Why

The README badge already said v1.3, but the body stopped at v1.2: "What's new", "What is included today" ("As of v1.2"), and the roadmap had no v1.3 section, and several shipped features still sat under "Future releases". This brings the front-door docs current and applies a consistent prose pass.

## What changed

**Content (v1.3 now documented)**
- Added v1.3 to "What's new", "What is included today", and a new "Shipped in v1.3" roadmap block.
- Moved shipped items out of "Future releases": GenAI observability and the sandbox seam.
- Covered the four v1.3 features plus this week's hardening: GenAI observability (with the live span-export fix verified against App Insights), the PaperClip sandbox execution seam (shipped unwired), the turnkey CI/CD setup page (`scaffold-cicd.sh`; reference `deploy.yml` runs green end to end), the Obsidian memory interface, governor schema migrations, and Teams Bot Framework JWT validation.
- Rewrote the observability section to cover the new GenAI spans, and added a docs-table row for the Obsidian guide.

**Prose pass (applied to all four files)**
- Removed every em dash (0 remain, verified by grep).
- Removed banned vocabulary; kept "turnkey" only where it names the actual feature.
- Replaced the reframe heading "Deployable on Azure, not just runnable on a laptop" with a direct one.
- Made the component-list metaphors ("front desk", "operations center", "secure building") literal.
- Kept roadmap status glyphs (✅/⬜/🧠) as a functional convention.

## Files
- `README.md`
- `ROADMAP.md`
- `docs/getting-started.md`
- `docs/obsidian-memory-interface.md`

No code or behavior changes. All referenced paths verified to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)