### PR TITLE
docs: archive the v1.3 planning + spec docs (sanitized)

### DIFF
--- a/docs/superpowers/plans/2026-06-24-b2-sandbox-port.md
+++ b/docs/superpowers/plans/2026-06-24-b2-sandbox-port.md
@@ -1,0 +1,429 @@
+# B2 — ACA Sandboxes Seam (port) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a provider-pluggable sandbox execution seam to AAF's paperclip — the contract plus a `local` adapter and a fail-closed provider factory — flag-off and unwired, with full unit tests, as the public mirror of the internally-shipped B2-1.
+
+**Architecture:** One new ES module `apps/paperclip/sandbox.mjs` exporting `createSandbox()` (provider factory), `LocalSandbox` (a `child_process.spawn` wrapper that never rejects — failures come back in a result object), and a `PROVIDERS` registry containing only `local`. Asking for any other provider throws (fail-closed). The module is side-effect-free on import and is **not** wired into the adapter spawn path, so it changes no runtime behavior; wiring it in and adding an `aca-job` (ACA dynamic-sessions) provider are follow-ons.
+
+**Tech Stack:** Node 22, ES modules, `node:test` built-in runner (zero dependencies), `node:child_process`.
+
+---
+
+## File Structure
+
+- **Create** `apps/paperclip/sandbox.mjs` — the seam (contract + `local` adapter + factory).
+- **Create** `tests/sandbox/sandbox.test.mjs` — `node:test` unit tests for the contract.
+- **Modify** `.github/workflows/ci.yml` — run the new test file in the `node-tests` job.
+
+AAF's paperclip JS lives in `apps/paperclip/` and its node tests in `tests/<area>/*.test.mjs` (e.g. `tests/auth-proxy/auth-proxy.test.mjs`), run by the `node-tests` CI job via `node --test`. This port follows that exact layout.
+
+---
+
+## Task 1: Port the sandbox seam unit tests (red)
+
+**Files:**
+- Create: `tests/sandbox/sandbox.test.mjs`
+
+- [ ] **Step 1: Create the test file**
+
+Create `tests/sandbox/sandbox.test.mjs`:
+
+```javascript
+/**
+ * Sandbox seam unit tests (node:test, zero dependencies).
+ *
+ * Run:  node --test tests/sandbox/sandbox.test.mjs
+ *
+ * Covers the seam contract + `local` adapter: output capture, exit codes,
+ * stderr, env, cwd, stdin, timeout, abort, output cap, and the fail-closed
+ * provider factory. Pure/offline — uses `sh -c` (CI runs Ubuntu; dev runs
+ * macOS, both have sh).
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+const { createSandbox, LocalSandbox, PROVIDERS } = await import("../../apps/paperclip/sandbox.mjs");
+
+describe("createSandbox factory", () => {
+  test("defaults to the local provider", () => {
+    const sb = createSandbox();
+    assert.ok(sb instanceof LocalSandbox);
+    assert.equal(sb.provider, "local");
+  });
+
+  test("returns a LocalSandbox for provider='local'", () => {
+    assert.ok(createSandbox("local") instanceof LocalSandbox);
+  });
+
+  test("throws (fail closed) on an unknown provider", () => {
+    assert.throws(() => createSandbox("aca-job"), /Unknown SANDBOX_PROVIDER/);
+    assert.throws(() => createSandbox("e2b"), /Unknown SANDBOX_PROVIDER/);
+  });
+
+  test("the registry exposes only local for now", () => {
+    assert.deepEqual(Object.keys(PROVIDERS), ["local"]);
+  });
+});
+
+describe("LocalSandbox.exec — basic execution", () => {
+  const sb = new LocalSandbox();
+
+  test("captures stdout and a zero exit code", async () => {
+    const r = await sb.exec("sh", ["-c", "printf hello"]);
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.signal, null);
+    assert.equal(r.timedOut, false);
+    assert.equal(r.stdout, "hello");
+    assert.equal(r.stderr, "");
+  });
+
+  test("propagates a non-zero exit code", async () => {
+    const r = await sb.exec("sh", ["-c", "exit 3"]);
+    assert.equal(r.exitCode, 3);
+    assert.equal(r.timedOut, false);
+  });
+
+  test("captures stderr separately from stdout", async () => {
+    const r = await sb.exec("sh", ["-c", "printf out; printf err 1>&2"]);
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.stdout, "out");
+    assert.equal(r.stderr, "err");
+  });
+
+  test("does not reject when the binary is missing (ENOENT → result, not throw)", async () => {
+    const r = await sb.exec("this-binary-does-not-exist-xyz", []);
+    assert.equal(r.exitCode, null);
+    assert.match(r.stderr, /ENOENT|not.*found|spawn/i);
+  });
+});
+
+describe("LocalSandbox.exec — env / cwd / stdin", () => {
+  const sb = new LocalSandbox();
+
+  test("passes a custom env", async () => {
+    const r = await sb.exec("sh", ["-c", "printf %s \"$FOO\""], { env: { ...process.env, FOO: "bar" } });
+    assert.equal(r.stdout, "bar");
+  });
+
+  test("honors cwd", async () => {
+    const r = await sb.exec("sh", ["-c", "pwd"], { cwd: "/tmp" });
+    // macOS reports /private/tmp for /tmp; accept either.
+    assert.match(r.stdout.trim(), /(^|\/)tmp$/);
+  });
+
+  test("feeds stdin from opts.input", async () => {
+    const r = await sb.exec("cat", [], { input: "piped-in" });
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.stdout, "piped-in");
+  });
+});
+
+describe("LocalSandbox.exec — timeout and abort", () => {
+  const sb = new LocalSandbox();
+
+  test("kills a command that exceeds timeoutMs and flags timedOut", async () => {
+    const r = await sb.exec("sh", ["-c", "sleep 5"], { timeoutMs: 100 });
+    assert.equal(r.timedOut, true);
+    assert.equal(r.exitCode, null);
+    assert.equal(r.signal, "SIGTERM");
+  });
+
+  test("a fast command under the timeout completes normally", async () => {
+    const r = await sb.exec("sh", ["-c", "printf done"], { timeoutMs: 5000 });
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.timedOut, false);
+    assert.equal(r.stdout, "done");
+  });
+
+  test("an AbortSignal aborted mid-run kills the child", async () => {
+    const ac = new AbortController();
+    const p = sb.exec("sh", ["-c", "sleep 5"], { signal: ac.signal });
+    setTimeout(() => ac.abort(), 50);
+    const r = await p;
+    assert.equal(r.exitCode, null);
+    assert.equal(r.signal, "SIGTERM");
+  });
+
+  test("an already-aborted signal kills immediately", async () => {
+    const r = await sb.exec("sh", ["-c", "sleep 5"], { signal: AbortSignal.abort() });
+    assert.equal(r.exitCode, null);
+    assert.equal(r.signal, "SIGTERM");
+  });
+});
+
+describe("LocalSandbox.exec — output cap", () => {
+  const sb = new LocalSandbox();
+
+  test("truncates output at maxBuffer instead of growing unbounded", async () => {
+    // Emit ~50KB but cap at 1KB.
+    const r = await sb.exec("sh", ["-c", "for i in $(seq 1 5000); do printf 0123456789; done"], { maxBuffer: 1024 });
+    assert.equal(r.exitCode, 0);
+    assert.ok(r.stdout.length <= 1024, `stdout ${r.stdout.length} should be <= 1024`);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `node --test tests/sandbox/sandbox.test.mjs`
+Expected: FAIL — the dynamic `import("../../apps/paperclip/sandbox.mjs")` rejects with `ERR_MODULE_NOT_FOUND` (file doesn't exist yet).
+
+- [ ] **Step 3: Commit the red test**
+
+```bash
+git add tests/sandbox/sandbox.test.mjs
+git commit -m "test(paperclip): sandbox seam unit tests (red, B2)"
+```
+
+---
+
+## Task 2: Port the sandbox seam module (green)
+
+**Files:**
+- Create: `apps/paperclip/sandbox.mjs`
+
+- [ ] **Step 1: Create the module**
+
+Create `apps/paperclip/sandbox.mjs` (header genericized for this repo — no internal feature references):
+
+```javascript
+/**
+ * Sandbox execution seam — the provider-pluggable boundary for running an
+ * agent's child process.
+ *
+ * This is the CONTRACT + the `local` adapter only. It is intentionally NOT yet
+ * wired into the adapter spawn path (apps/paperclip/patch-adapter.mjs). With
+ * nothing wired, this module is inert — importing it is side-effect-free and
+ * changes no runtime behavior. Wiring it in, and adding an isolated `aca-job`
+ * provider (ACA dynamic sessions), are follow-ons.
+ *
+ * The seam lets a task run either in-container (`local`, today's behavior) or,
+ * later, in an isolated ephemeral sandbox without changing the caller.
+ *
+ * Result shape matches the adapter's child-process return, so the seam is a
+ * drop-in at the spawn dispatch:
+ *   { exitCode: number|null, signal: string|null, timedOut: boolean,
+ *     stdout: string, stderr: string }
+ */
+
+import { spawn } from "node:child_process";
+
+const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024; // 10 MiB per stream, then truncate
+
+/**
+ * The `local` provider: runs the command in the current container, exactly as
+ * today. A thin, well-tested wrapper over child_process.spawn that honors a
+ * timeout and an AbortSignal and never rejects — failures come back in the
+ * result shape (so callers branch on exitCode/timedOut, not try/catch).
+ */
+class LocalSandbox {
+  constructor(config = {}) {
+    this.provider = "local";
+    this.config = config;
+  }
+
+  /**
+   * @param {string} cmd
+   * @param {string[]} args
+   * @param {{env?:object, cwd?:string, timeoutMs?:number, signal?:AbortSignal,
+   *          maxBuffer?:number, input?:string}} opts
+   * @returns {Promise<{exitCode:number|null, signal:string|null,
+   *                    timedOut:boolean, stdout:string, stderr:string}>}
+   */
+  async exec(cmd, args = [], opts = {}) {
+    const {
+      env,
+      cwd,
+      timeoutMs,
+      signal,
+      maxBuffer = DEFAULT_MAX_BUFFER,
+      input,
+    } = opts;
+
+    return await new Promise((resolve) => {
+      let stdout = "";
+      let stderr = "";
+      let outLen = 0;
+      let errLen = 0;
+      let timedOut = false;
+      let settled = false;
+      let timer = null;
+
+      const child = spawn(cmd, Array.isArray(args) ? args : [], {
+        env: env || process.env,
+        cwd: cwd || undefined,
+      });
+
+      const onAbort = () => {
+        try { child.kill("SIGTERM"); } catch { /* already gone */ }
+      };
+
+      const cleanup = () => {
+        if (timer) clearTimeout(timer);
+        if (signal && typeof signal.removeEventListener === "function") {
+          signal.removeEventListener("abort", onAbort);
+        }
+      };
+
+      const done = (res) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(res);
+      };
+
+      if (signal) {
+        if (signal.aborted) {
+          try { child.kill("SIGTERM"); } catch { /* noop */ }
+        } else if (typeof signal.addEventListener === "function") {
+          signal.addEventListener("abort", onAbort, { once: true });
+        }
+      }
+
+      if (timeoutMs && timeoutMs > 0) {
+        timer = setTimeout(() => {
+          timedOut = true;
+          try { child.kill("SIGTERM"); } catch { /* noop */ }
+        }, timeoutMs);
+      }
+
+      // Capture output, truncating each stream at maxBuffer (never OOM on a
+      // runaway command; the truncation is silent like the webhook body caps).
+      child.stdout.on("data", (d) => {
+        if (outLen < maxBuffer) {
+          stdout += d.toString("utf-8");
+          outLen += d.length;
+          if (outLen >= maxBuffer) stdout = stdout.slice(0, maxBuffer);
+        }
+      });
+      child.stderr.on("data", (d) => {
+        if (errLen < maxBuffer) {
+          stderr += d.toString("utf-8");
+          errLen += d.length;
+          if (errLen >= maxBuffer) stderr = stderr.slice(0, maxBuffer);
+        }
+      });
+
+      child.on("error", (err) => {
+        // spawn failure (e.g. ENOENT) — surface as a non-zero-ish result rather
+        // than throwing, so the seam never rejects.
+        done({
+          exitCode: null,
+          signal: null,
+          timedOut,
+          stdout,
+          stderr: stderr || String((err && err.message) || err),
+        });
+      });
+
+      child.on("close", (code, sig) => {
+        done({ exitCode: code, signal: sig, timedOut, stdout, stderr });
+      });
+
+      if (input != null) {
+        try { child.stdin.write(input); } catch { /* stdin may be closed */ }
+      }
+      try { child.stdin.end(); } catch { /* noop */ }
+    });
+  }
+}
+
+// Provider registry. An `aca-job` provider registers here later; until then
+// asking for it fails LOUD rather than silently falling back to in-container exec.
+const PROVIDERS = {
+  local: LocalSandbox,
+};
+
+/**
+ * Construct a sandbox for the configured provider.
+ * @param {string} [provider=process.env.SANDBOX_PROVIDER||"local"]
+ * @param {object} [config]
+ */
+function createSandbox(provider = process.env.SANDBOX_PROVIDER || "local", config = {}) {
+  const Ctor = PROVIDERS[provider];
+  if (!Ctor) {
+    throw new Error(
+      `Unknown SANDBOX_PROVIDER: '${provider}' (known: ${Object.keys(PROVIDERS).join(", ")})`,
+    );
+  }
+  return new Ctor(config);
+}
+
+export { createSandbox, LocalSandbox, PROVIDERS };
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `node --test tests/sandbox/sandbox.test.mjs`
+Expected: PASS — all suites green (factory, basic execution, env/cwd/stdin, timeout/abort, output cap).
+
+- [ ] **Step 3: Confirm the module is inert (no accidental wiring)**
+
+Run: `grep -rn "sandbox.mjs\|createSandbox\|LocalSandbox" apps/paperclip/patch-adapter.mjs apps/paperclip/auth-proxy.mjs`
+Expected: no matches — nothing imports the seam yet (it ships unwired by design).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/paperclip/sandbox.mjs
+git commit -m "feat(paperclip): sandbox execution seam — local adapter + factory (B2, flag-off)"
+```
+
+---
+
+## Task 3: Run the new tests in CI
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `node-tests` job)
+
+- [ ] **Step 1: Add a CI step for the sandbox tests**
+
+In `.github/workflows/ci.yml`, in the `node-tests` job, immediately after the existing auth-proxy step:
+
+```yaml
+      - name: auth-proxy unit tests (no deps; node built-in runner)
+        run: node --test tests/auth-proxy/*.test.mjs
+```
+
+add:
+
+```yaml
+      - name: sandbox seam unit tests (no deps; node built-in runner)
+        run: node --test tests/sandbox/*.test.mjs
+```
+
+- [ ] **Step 2: Validate the workflow locally (syntax)**
+
+Run: `python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml')); print('ci.yml: valid YAML')"`
+Expected: `ci.yml: valid YAML`
+
+- [ ] **Step 3: Re-run the full node test set the way CI will**
+
+Run: `node --test tests/auth-proxy/*.test.mjs tests/sandbox/*.test.mjs`
+Expected: PASS — both suites green together.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: run sandbox seam unit tests in the node-tests job (B2)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (against §2.2 of the v1.3 design):
+- `apps/paperclip/sandbox.mjs` with provider factory + local adapter, unwired → Tasks 1–2. ✅
+- Ported unit tests → Task 1. ✅
+- Flag-off / fail-closed factory (`createSandbox` throws on unknown provider) → covered by `createSandbox` + its tests. ✅
+- Seam-only, hot-path wiring (B2-2) and `aca-job` adapter (B2-3) stay future → enforced by Task 2 Step 3 (no imports). ✅
+- CI runs the tests → Task 3. ✅
+
+**Placeholder scan:** none — both files are complete; CI edit shows exact YAML.
+
+**Type consistency:** the result shape `{exitCode, signal, timedOut, stdout, stderr}` is identical across the module (`LocalSandbox.exec` resolutions) and the test assertions. Exports (`createSandbox`, `LocalSandbox`, `PROVIDERS`) match the test's destructured import.
+
+**Public-repo hygiene:** header comment genericized — no internal feature/spec names; module body is generic Node with no internal hostnames. Run `scripts/scan-internal-refs.sh` after staging to confirm.

--- a/docs/superpowers/plans/2026-06-24-b3-observability.md
+++ b/docs/superpowers/plans/2026-06-24-b3-observability.md
@@ -1,0 +1,598 @@
+# B3 — GenAI-semconv Observability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every model call through AAF's `services/model-router` emits one OpenTelemetry GenAI-semconv span (model, tokens, cost, latency) to Application Insights — behind `OBSERVABILITY_ENABLED` (default off), content-redacted — and the previously-untracked Anthropic path becomes cost-tracked + observable.
+
+**Architecture:** A pure attribute-mapping function (`genai_semconv_attrs`) feeds a flag-gated, fail-open emitter (`observe_genai`) that lazily initialises an Azure Monitor tracer (`_init_tracer`). The single cost chokepoint `record_cost` is widened to carry model/token metadata and call the emitter, so both the litellm and Anthropic cost paths flow through one hook. The Anthropic path additionally gets a list-price cost estimator since the Anthropic SDK doesn't return `response_cost`.
+
+**Tech Stack:** Python 3, FastAPI, OpenTelemetry via the `azure-monitor-opentelemetry` distro, pytest.
+
+---
+
+## File Structure
+
+- **Modify** `services/model-router/main.py`:
+  - new "Observability" section (after the Budget Tracking block, ~line 385): `_genai_system`, `genai_semconv_attrs`, `_init_tracer`, `observe_genai`, `OBSERVABILITY_ENABLED`, `_ANTHROPIC_PRICING_PER_MTOK`, `_estimate_anthropic_cost`.
+  - widen `record_cost` (line 377-379).
+  - wire both cost paths in `_call_model` (lines 1062-1069).
+- **Modify** `services/model-router/requirements.txt`: add the OTel distro.
+- **Modify** `infrastructure/modules/container-apps/hermes.tf`: add two env vars to the router **sidecar** container block (B3c).
+- **Create** `services/model-router/tests/test_observability.py`: unit tests for the pure mapping, the emitter's flag-gating/fail-open, the estimator, and the path wiring.
+- **Modify** `services/model-router/tests/test_budget.py`: extend for the widened `record_cost` signature.
+
+All tests live under `services/model-router/tests/` and inherit `conftest.py` (which primes tier env vars before `main` imports and exposes the `router` fixture = the imported `main` module).
+
+---
+
+## Task 1: Pure GenAI-semconv attribute mapping
+
+**Files:**
+- Modify: `services/model-router/main.py` (new Observability section after line 385)
+- Test: `services/model-router/tests/test_observability.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `services/model-router/tests/test_observability.py`:
+
+```python
+"""Tests for the B3 GenAI-semconv observability layer: the pure attribute
+mapping, the flag-gated fail-open emitter, the Anthropic cost estimator, and
+the wiring of both cost paths through the widened record_cost."""
+
+import pytest
+
+
+class TestGenaiSemconvAttrs:
+    def test_maps_standard_and_agent_attributes(self, router):
+        attrs = router.genai_semconv_attrs(
+            tier="gpt4o-mini", model="gpt-4o-mini",
+            input_tokens=100, output_tokens=20, cost_usd=0.0012345678, run_id="r1",
+        )
+        assert attrs["gen_ai.operation.name"] == "chat"
+        assert attrs["gen_ai.system"] == "az.ai.foundry"
+        assert attrs["gen_ai.request.model"] == "gpt-4o-mini"
+        assert attrs["gen_ai.usage.input_tokens"] == 100
+        assert attrs["gen_ai.usage.output_tokens"] == 20
+        # cost rounded to 6 decimal places
+        assert attrs["gen_ai.usage.cost_usd"] == 0.001235
+        assert attrs["agent.tier"] == "gpt4o-mini"
+        assert attrs["agent.run_id"] == "r1"
+
+    def test_run_id_omitted_when_absent(self, router):
+        attrs = router.genai_semconv_attrs(
+            tier="gpt4o-mini", model="gpt-4o-mini",
+            input_tokens=1, output_tokens=1, cost_usd=0.0,
+        )
+        assert "agent.run_id" not in attrs
+
+    def test_anthropic_tier_system(self, router):
+        # CLAUDE tier is registered as an anthropic/ litellm_model in conftest's env
+        attrs = router.genai_semconv_attrs(
+            tier="claude", model="claude-sonnet-4-6",
+            input_tokens=1, output_tokens=1, cost_usd=0.0,
+        )
+        assert attrs["gen_ai.system"] == "anthropic"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/model-router && python -m pytest tests/test_observability.py::TestGenaiSemconvAttrs -v`
+Expected: FAIL with `AttributeError: module 'main' has no attribute 'genai_semconv_attrs'`.
+
+> Note: the `claude` tier presence depends on Foundry CLAUDE env vars. If `test_anthropic_tier_system` errors on a missing `claude` tier rather than asserting, prime it like the other tiers by adding to `conftest.py`: `os.environ.setdefault("CLAUDE_BASE_URL", "http://localhost:7777"); os.environ.setdefault("CLAUDE_API_KEY", "test-claude-key")`. Add that line in this step if the tier is absent.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `services/model-router/main.py`, add after the Budget Tracking block (after `is_over_budget`, ~line 385):
+
+```python
+# ─── Observability (GenAI semconv) ────────────────────────────────────────────
+# One OTel span per model call with GenAI semantic-convention attributes, behind
+# OBSERVABILITY_ENABLED (default off), content-redacted (no prompt/response text).
+# `gen_ai.*` are the OTel standard attributes; `agent.*` are this repo's custom
+# additions (tier + optional run id).
+
+def _genai_system(tier: str) -> str:
+    """gen_ai.system: 'anthropic' for Anthropic-dispatched tiers, else Foundry."""
+    return "anthropic" if _is_anthropic_tier(tier) else "az.ai.foundry"
+
+
+def genai_semconv_attrs(
+    *, tier: str, model: str, input_tokens: int, output_tokens: int,
+    cost_usd: float, run_id: str | None = None,
+) -> dict[str, object]:
+    """Pure mapping → OTel GenAI-semconv span attributes. No I/O."""
+    attrs: dict[str, object] = {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.system": _genai_system(tier),
+        "gen_ai.request.model": model or tier,
+        "gen_ai.usage.input_tokens": int(input_tokens or 0),
+        "gen_ai.usage.output_tokens": int(output_tokens or 0),
+        "gen_ai.usage.cost_usd": round(float(cost_usd or 0.0), 6),
+        "agent.tier": tier,
+    }
+    if run_id:
+        attrs["agent.run_id"] = run_id
+    return attrs
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd services/model-router && python -m pytest tests/test_observability.py::TestGenaiSemconvAttrs -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/model-router/main.py services/model-router/tests/test_observability.py
+git commit -m "feat(model-router): genai_semconv_attrs pure mapping (B3a)"
+```
+
+---
+
+## Task 2: Flag-gated, fail-open emitter + lazy tracer
+
+**Files:**
+- Modify: `services/model-router/main.py` (Observability section)
+- Test: `services/model-router/tests/test_observability.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `services/model-router/tests/test_observability.py`:
+
+```python
+class TestObserveGenai:
+    def test_noop_when_flag_disabled(self, router, monkeypatch):
+        calls = []
+        monkeypatch.setattr(router, "OBSERVABILITY_ENABLED", False)
+        monkeypatch.setattr(router, "_init_tracer", lambda: calls.append("init") or None)
+        router.observe_genai(tier="gpt4o-mini", model="gpt-4o-mini",
+                             input_tokens=1, output_tokens=1, cost_usd=0.0)
+        assert calls == []  # flag off → tracer never touched
+
+    def test_noop_when_no_tracer(self, router, monkeypatch):
+        monkeypatch.setattr(router, "OBSERVABILITY_ENABLED", True)
+        monkeypatch.setattr(router, "_init_tracer", lambda: None)
+        # No exception when there is no configured exporter.
+        router.observe_genai(tier="gpt4o-mini", model="gpt-4o-mini",
+                             input_tokens=1, output_tokens=1, cost_usd=0.0)
+
+    def test_fail_open_on_tracer_error(self, router, monkeypatch):
+        def boom():
+            raise RuntimeError("exporter down")
+        monkeypatch.setattr(router, "OBSERVABILITY_ENABLED", True)
+        monkeypatch.setattr(router, "_init_tracer", boom)
+        # A telemetry error must never propagate to the caller.
+        router.observe_genai(tier="gpt4o-mini", model="gpt-4o-mini",
+                             input_tokens=1, output_tokens=1, cost_usd=0.0)
+
+    def test_emits_span_with_attrs(self, router, monkeypatch):
+        recorded = {}
+
+        class FakeSpan:
+            def set_attribute(self, k, v): recorded[k] = v
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+
+        class FakeTracer:
+            def start_as_current_span(self, name):
+                recorded["__span_name__"] = name
+                return FakeSpan()
+
+        monkeypatch.setattr(router, "OBSERVABILITY_ENABLED", True)
+        monkeypatch.setattr(router, "_init_tracer", lambda: FakeTracer())
+        router.observe_genai(tier="gpt4o-mini", model="gpt-4o-mini",
+                             input_tokens=5, output_tokens=2, cost_usd=0.001, run_id="r9")
+        assert recorded["__span_name__"] == "gen_ai.chat"
+        assert recorded["gen_ai.request.model"] == "gpt-4o-mini"
+        assert recorded["gen_ai.usage.input_tokens"] == 5
+        assert recorded["agent.run_id"] == "r9"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/model-router && python -m pytest tests/test_observability.py::TestObserveGenai -v`
+Expected: FAIL with `AttributeError: module 'main' has no attribute 'OBSERVABILITY_ENABLED'` (or `observe_genai`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `services/model-router/main.py`, append to the Observability section:
+
+```python
+OBSERVABILITY_ENABLED = os.environ.get("OBSERVABILITY_ENABLED", "").strip().lower() in (
+    "1", "true", "yes",
+)
+
+_tracer = None
+_tracer_initialised = False
+
+
+def _init_tracer():
+    """Lazily configure the Azure Monitor OTel tracer once. Returns the tracer or
+    None when no connection string is set or setup fails. Swap point: replace the
+    configure_azure_monitor call with any OTLP exporter for a non-Azure backend."""
+    global _tracer, _tracer_initialised
+    if _tracer_initialised:
+        return _tracer
+    _tracer_initialised = True
+    conn = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING")
+    if not conn:
+        return None
+    try:
+        from azure.monitor.opentelemetry import configure_azure_monitor
+        from opentelemetry import trace
+        configure_azure_monitor(connection_string=conn)
+        _tracer = trace.get_tracer("model-router")
+    except Exception as e:  # pragma: no cover - exercised via fail-open test
+        log.warning("observability: tracer init failed, disabling: %s", e)
+        _tracer = None
+    return _tracer
+
+
+def observe_genai(
+    *, tier: str, model: str, input_tokens: int, output_tokens: int,
+    cost_usd: float, run_id: str | None = None,
+) -> None:
+    """Emit one GenAI-semconv span. Flag-gated and FAIL-OPEN: any telemetry error
+    is swallowed so it can never break a model call (the router is on every call)."""
+    if not OBSERVABILITY_ENABLED:
+        return
+    try:
+        tracer = _init_tracer()
+        if tracer is None:
+            return
+        attrs = genai_semconv_attrs(
+            tier=tier, model=model, input_tokens=input_tokens,
+            output_tokens=output_tokens, cost_usd=cost_usd, run_id=run_id,
+        )
+        with tracer.start_as_current_span("gen_ai.chat") as span:
+            for k, v in attrs.items():
+                span.set_attribute(k, v)
+    except Exception as e:  # fail-open: never surface telemetry errors
+        log.debug("observe_genai swallowed: %s", e)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd services/model-router && python -m pytest tests/test_observability.py::TestObserveGenai -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/model-router/main.py services/model-router/tests/test_observability.py
+git commit -m "feat(model-router): flag-gated fail-open observe_genai + lazy tracer (B3a)"
+```
+
+---
+
+## Task 3: Widen record_cost + hook the emitter
+
+**Files:**
+- Modify: `services/model-router/main.py:377-379`
+- Test: `services/model-router/tests/test_budget.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `services/model-router/tests/test_budget.py` (inside the file, a new test class):
+
+```python
+class TestRecordCostObservability:
+    def test_still_accumulates_with_new_kwargs(self, router):
+        router._spend.clear()
+        router.record_cost("gpt4o-mini", 0.10, model="gpt-4o-mini",
+                           input_tokens=100, output_tokens=20)
+        assert router._spend["gpt4o-mini"] == pytest.approx(0.10)
+
+    def test_calls_observe_genai_with_metadata(self, router, monkeypatch):
+        seen = {}
+        monkeypatch.setattr(
+            router, "observe_genai",
+            lambda **kw: seen.update(kw),
+        )
+        router._spend.clear()
+        router.record_cost("gpt4o-mini", 0.05, model="gpt-4o-mini",
+                           input_tokens=7, output_tokens=3, run_id="rX")
+        assert seen["tier"] == "gpt4o-mini"
+        assert seen["model"] == "gpt-4o-mini"
+        assert seen["input_tokens"] == 7
+        assert seen["output_tokens"] == 3
+        assert seen["cost_usd"] == pytest.approx(0.05)
+        assert seen["run_id"] == "rX"
+
+    def test_backward_compatible_positional_call(self, router):
+        # Existing callers using record_cost(tier, cost) must still work.
+        router._spend.clear()
+        router.record_cost("gpt4o-mini", 0.02)
+        assert router._spend["gpt4o-mini"] == pytest.approx(0.02)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/model-router && python -m pytest tests/test_budget.py::TestRecordCostObservability -v`
+Expected: FAIL — `test_calls_observe_genai_with_metadata` fails because `record_cost` doesn't accept `model=`/`input_tokens=` yet (`TypeError: record_cost() got an unexpected keyword argument`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `services/model-router/main.py`, replace `record_cost` (lines 377-379):
+
+```python
+def record_cost(
+    tier: str, cost: float, *, model: str | None = None,
+    input_tokens: int = 0, output_tokens: int = 0, run_id: str | None = None,
+) -> None:
+    _reset_if_new_day()
+    _spend[tier] += cost
+    observe_genai(
+        tier=tier, model=model or MODELS.get(tier, {}).get("litellm_model", tier),
+        input_tokens=input_tokens, output_tokens=output_tokens,
+        cost_usd=cost, run_id=run_id,
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd services/model-router && python -m pytest tests/test_budget.py -v`
+Expected: PASS (all existing budget tests + the 3 new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/model-router/main.py services/model-router/tests/test_budget.py
+git commit -m "feat(model-router): widen record_cost with model/token metadata + observe hook (B3a)"
+```
+
+---
+
+## Task 4: Anthropic list-price cost estimator
+
+**Files:**
+- Modify: `services/model-router/main.py` (Observability section)
+- Test: `services/model-router/tests/test_observability.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `services/model-router/tests/test_observability.py`:
+
+```python
+class TestAnthropicCostEstimate:
+    def test_sonnet_rates(self, router):
+        # 1,000,000 input @ $3 + 1,000,000 output @ $15 = $18.00 (sonnet list price)
+        cost = router._estimate_anthropic_cost("claude-sonnet-4-6", 1_000_000, 1_000_000)
+        assert cost == pytest.approx(18.0)
+
+    def test_opus_rates(self, router):
+        # 1,000,000 input @ $15 + 1,000,000 output @ $75 = $90.00
+        cost = router._estimate_anthropic_cost("claude-opus-4-8", 1_000_000, 1_000_000)
+        assert cost == pytest.approx(90.0)
+
+    def test_partial_tokens(self, router):
+        # 100 input + 50 output on sonnet = 100/1e6*3 + 50/1e6*15
+        cost = router._estimate_anthropic_cost("claude-sonnet-4-6", 100, 50)
+        assert cost == pytest.approx(100 / 1e6 * 3 + 50 / 1e6 * 15)
+
+    def test_unknown_model_falls_back_to_sonnet(self, router):
+        cost = router._estimate_anthropic_cost("some-future-claude", 1_000_000, 0)
+        assert cost == pytest.approx(3.0)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/model-router && python -m pytest tests/test_observability.py::TestAnthropicCostEstimate -v`
+Expected: FAIL with `AttributeError: module 'main' has no attribute '_estimate_anthropic_cost'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `services/model-router/main.py`, append to the Observability section:
+
+```python
+# Anthropic list-price per-million-token rates (input, output). The Anthropic SDK
+# does not return response_cost, so cost on this path is a LIST-PRICE ESTIMATE,
+# not a billed figure. Substring match on the model name; sonnet is the fallback.
+_ANTHROPIC_PRICING_PER_MTOK: dict[str, tuple[float, float]] = {
+    "claude-opus": (15.0, 75.0),
+    "claude-sonnet": (3.0, 15.0),
+    "claude-haiku": (0.80, 4.0),
+}
+
+
+def _estimate_anthropic_cost(model: str, input_tokens: int, output_tokens: int) -> float:
+    """List-price estimate in USD for an Anthropic call. Defaults to sonnet rates."""
+    name = (model or "").lower()
+    in_rate, out_rate = next(
+        (rates for key, rates in _ANTHROPIC_PRICING_PER_MTOK.items() if key in name),
+        _ANTHROPIC_PRICING_PER_MTOK["claude-sonnet"],
+    )
+    return (input_tokens or 0) / 1_000_000 * in_rate + (output_tokens or 0) / 1_000_000 * out_rate
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd services/model-router && python -m pytest tests/test_observability.py::TestAnthropicCostEstimate -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/model-router/main.py services/model-router/tests/test_observability.py
+git commit -m "feat(model-router): Anthropic list-price cost estimator (B3b)"
+```
+
+---
+
+## Task 5: Wire both cost paths through the widened record_cost
+
+**Files:**
+- Modify: `services/model-router/main.py:1062-1069` (inside `_call_model`)
+- Test: `services/model-router/tests/test_observability.py`
+
+This closes the Anthropic cost gap: the Anthropic path currently *skips* `record_cost` (line 1064 comment). After this task, both paths record cost with model/token metadata. To keep it unit-testable, extract usage parsing into a tiny pure helper first.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `services/model-router/tests/test_observability.py`:
+
+```python
+class TestUsageFromResult:
+    def test_extracts_tokens_and_model(self, router):
+        result = {"model": "claude-sonnet-4-6",
+                  "usage": {"prompt_tokens": 120, "completion_tokens": 34}}
+        model, inp, out = router._usage_from_result(result, fallback_tier="claude")
+        assert model == "claude-sonnet-4-6"
+        assert inp == 120
+        assert out == 34
+
+    def test_missing_usage_defaults_zero_and_tier_model(self, router):
+        result = {}
+        model, inp, out = router._usage_from_result(result, fallback_tier="gpt4o-mini")
+        assert inp == 0 and out == 0
+        # falls back to the tier's configured litellm_model (minus provider prefix)
+        assert model  # non-empty
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/model-router && python -m pytest tests/test_observability.py::TestUsageFromResult -v`
+Expected: FAIL with `AttributeError: module 'main' has no attribute '_usage_from_result'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `services/model-router/main.py`, append to the Observability section:
+
+```python
+def _usage_from_result(result: dict, *, fallback_tier: str) -> tuple[str, int, int]:
+    """Pull (model, input_tokens, output_tokens) from an OpenAI-shaped result dict,
+    falling back to the tier's configured model name when the result omits it."""
+    usage = result.get("usage") or {}
+    model = result.get("model") or MODELS[fallback_tier]["litellm_model"].split("/", 1)[-1]
+    return model, int(usage.get("prompt_tokens", 0) or 0), int(usage.get("completion_tokens", 0) or 0)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd services/model-router && python -m pytest tests/test_observability.py::TestUsageFromResult -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Wire the two cost paths**
+
+In `services/model-router/main.py`, replace the if/else cost block in `_call_model` (lines 1062-1069):
+
+```python
+            if is_anthropic:
+                result = await _call_anthropic_direct(tier, body)
+                # Anthropic SDK doesn't surface response_cost — estimate from
+                # list price so Claude calls are cost-tracked + observable (B3b).
+                _model, _in, _out = _usage_from_result(result, fallback_tier=tier)
+                record_cost(
+                    tier, _estimate_anthropic_cost(_model, _in, _out),
+                    model=_model, input_tokens=_in, output_tokens=_out,
+                )
+            else:
+                response = await litellm.acompletion(**kwargs)
+                result = response.model_dump()
+                _model, _in, _out = _usage_from_result(result, fallback_tier=tier)
+                record_cost(
+                    tier, response._hidden_params.get("response_cost") or 0.0,
+                    model=_model, input_tokens=_in, output_tokens=_out,
+                )
+```
+
+- [ ] **Step 6: Run the full router suite**
+
+Run: `cd services/model-router && python -m pytest tests/ -q`
+Expected: PASS — all pre-existing tests (146) plus the new observability tests green. (No new network; the wiring uses already-mocked paths in `test_endpoints.py`.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add services/model-router/main.py services/model-router/tests/test_observability.py
+git commit -m "feat(model-router): record cost on both paths incl. Anthropic estimate (B3b)"
+```
+
+---
+
+## Task 6: Dependency + infra env wiring (B3c) + go-live notes
+
+**Files:**
+- Modify: `services/model-router/requirements.txt`
+- Modify: `infrastructure/modules/container-apps/hermes.tf` (router sidecar container block)
+
+- [ ] **Step 1: Add the OTel distro dependency**
+
+In `services/model-router/requirements.txt`, append:
+
+```
+azure-monitor-opentelemetry>=1.6.0
+```
+
+- [ ] **Step 2: Verify the import is runtime-only (no default-image behavior change)**
+
+Run: `cd services/model-router && python -m pytest tests/ -q`
+Expected: PASS — tests don't import the distro (it's only imported inside `_init_tracer`, which the tests monkeypatch), so the suite stays green without the package installed.
+
+- [ ] **Step 3: Add the two env vars to the router sidecar (B3c)**
+
+In `infrastructure/modules/container-apps/hermes.tf`, locate the **router sidecar** `container` block (the second container in the hermes pod — the one running the model-router image, NOT the hermes app container). Add to its `env` list:
+
+```hcl
+    env {
+      name  = "OBSERVABILITY_ENABLED"
+      value = var.observability_enabled ? "true" : "false"
+    }
+    env {
+      name  = "APPLICATIONINSIGHTS_CONNECTION_STRING"
+      value = var.app_insights_connection_string
+    }
+```
+
+If `var.observability_enabled` does not yet exist, add it to the module's `variables.tf`:
+
+```hcl
+variable "observability_enabled" {
+  description = "Emit GenAI-semconv spans from the model-router to App Insights."
+  type        = bool
+  default     = false
+}
+```
+
+and pass it from the dev environment composition (`infrastructure/environments/dev/main.tf`) where the other hermes module inputs are set: `observability_enabled = var.observability_enabled`, with a matching `variable "observability_enabled" { type = bool, default = false }` in that environment's `variables.tf`. `var.app_insights_connection_string` is already a module input (used by the hermes app container) — reuse it.
+
+- [ ] **Step 4: Validate the Terraform**
+
+Run: `cd infrastructure/environments/dev && terraform init -backend=false && terraform validate`
+Expected: `Success! The configuration is valid.`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/model-router/requirements.txt infrastructure/modules/container-apps/hermes.tf infrastructure/modules/container-apps/variables.tf infrastructure/environments/dev/main.tf infrastructure/environments/dev/variables.tf
+git commit -m "feat(model-router): OTel dep + router-sidecar observability env wiring (B3c)"
+```
+
+- [ ] **Step 6: Operator go-live (manual, not a code step)**
+
+After merge + deploy with `observability_enabled = true`:
+1. Confirm the router sidecar has the env: `az containerapp show ... --query "properties.template.containers[?name=='model-router'].env"`.
+2. Drive one model call through an agent, then in App Insights run KQL:
+   `dependencies | where name == "gen_ai.chat" | project timestamp, customDimensions`
+   Expect a span with `gen_ai.request.model`, `gen_ai.usage.input_tokens/output_tokens/cost_usd`, `agent.tier`.
+3. Sanity: Σ `gen_ai.usage.cost_usd` over a run ≈ that run's `record_cost` total (check `/budget` or the `_spend` value via the status endpoint).
+
+---
+
+## Self-Review
+
+**Spec coverage** (against §2.1 of the v1.3 design):
+- `genai_semconv_attrs` (genericized `agent.tier`/`agent.run_id`) → Task 1. ✅
+- `observe_genai` (flag-gated, lazy, fail-open) + `_init_tracer` (distro + swap point) → Task 2. ✅
+- Widened `record_cost` + single-chokepoint hook → Task 3. ✅
+- Anthropic list-price estimator → Task 4. ✅
+- Wire both cost paths / close the Anthropic gap (`main.py:1062-1069`) → Task 5. ✅
+- Dependency + router-sidecar env (`hermes.tf`) + go-live KQL → Task 6. ✅
+- Tests: ported observability tests + estimator tests + extended budget test → Tasks 1–5. ✅
+- Fail-open + BatchSpanProcessor + content-redaction + `run_id` as attribute → covered by `observe_genai` design (Task 2) and the redaction-by-construction in `genai_semconv_attrs` (no text fields). ✅
+
+**Placeholder scan:** none — every code/test step has complete content.
+
+**Type consistency:** `record_cost` keyword params (`model`, `input_tokens`, `output_tokens`, `run_id`) are consistent across Tasks 3 and 5; `genai_semconv_attrs`/`observe_genai`/`_estimate_anthropic_cost`/`_usage_from_result` signatures match between definition and call sites. Span name `"gen_ai.chat"` is consistent between Task 2 (emit) and Task 6 (KQL).

--- a/docs/superpowers/plans/2026-06-24-obsidian-memory-interface.md
+++ b/docs/superpowers/plans/2026-06-24-obsidian-memory-interface.md
@@ -1,0 +1,677 @@
+# Obsidian Memory Interface Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A two-way `memory ↔ Obsidian vault` CLI: `export` projects governed-memory entries into a local Obsidian-compatible Markdown+frontmatter vault, and `sync` applies operator edits back to the governor (delete → rm, confirm/pin/dispute/demote via frontmatter) with conflict reporting. Read (export) ships first and is a prerequisite for write-back.
+
+**Architecture:** A new `governor.vault` module. Pure, fully-tested core: `render_note` (entry → Markdown), `parse_note` (Markdown → fields), `diff_to_actions` (baseline + vault → governor actions), `detect_conflicts` (baseline vs current server). Thin I/O wrappers: a `GovernorClient` (httpx) over the existing operator API (`GET /memory`, `GET /memory/{id}`, `POST /memory/{id}/action`), and `export()` / `sync()`. A CLI entry (`python -m governor.vault`). The vault never lives in Azure — the operator runs the CLI locally; conflicts (server changed since export) are reported and skipped, never overwritten.
+
+**Tech Stack:** Python 3, httpx, pytest. Talks to the governor admin API the same way `pc-memory.sh` does.
+
+---
+
+## File Structure
+
+- **Create** `services/memory-governor/src/governor/vault.py` — renderer, parser, diff, client, export/sync, CLI.
+- **Create** `tests/memory-governor/test_vault.py` — pure-function tests + mock-client export/sync tests (auto-run by the existing `pytest -q tests/memory-governor` CI step; `conftest.py` already puts `governor` on `sys.path`).
+
+**Governor API (from `services/memory-governor/src/governor/main.py`):**
+- `GET /memory?...` → list rows: `id, snippet, memory_class, memory_scope_kind, memory_scope_id, source_type, created_by_peer, created_at, last_confirmed_at, expires_at`.
+- `GET /memory/{id}` → full `documents` row (minus `embedding`): adds `content`, `verification_state`, `superseded_by`, `promotion_source_doc_id`, etc.
+- `POST /memory/{id}/action` with `{action, actor, note?, demote_to?, superseded_by?}`; `action ∈ {pin, demote, confirm, dispute, supersede, rm, reconfirm}`.
+- Auth: `X-Governor-Key` header (in-network, like `pc-memory.sh`) or the auth-proxy `/api/memory/*` Bearer path for a local operator. `GovernorClient` is configured from env so both work.
+
+**Scope note:** body/content edits → `supersede` (which needs an `admit` + supersede two-step) are **out of scope for this plan** — a documented follow-on. This plan ships the read projection and the frontmatter/deletion-driven write-back verbs.
+
+---
+
+## Task 1: Pure note renderer (export half)
+
+**Files:**
+- Create: `services/memory-governor/src/governor/vault.py`
+- Test: `tests/memory-governor/test_vault.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/memory-governor/test_vault.py`:
+
+```python
+"""Offline tests for the Obsidian memory-vault CLI: pure render/parse/diff plus
+mock-client export/sync. No network — GovernorClient is faked."""
+
+from governor import vault
+
+
+ENTRY = {
+    "id": "doc-1",
+    "content": "Michael prefers symptom-first triage.\n\nSurface what's broken first.",
+    "memory_class": "user_preference",
+    "verification_state": "confirmed",
+    "memory_scope_kind": "agent",
+    "memory_scope_id": "alfred",
+    "source_type": "operator",
+    "created_by_peer": "alfred",
+    "created_at": "2026-06-01T12:00:00Z",
+    "last_confirmed_at": "2026-06-10T09:00:00Z",
+    "expires_at": None,
+    "superseded_by": None,
+    "promotion_source_doc_id": None,
+}
+
+
+class TestRenderNote:
+    def test_has_frontmatter_delimiters_and_body(self):
+        out = vault.render_note(ENTRY)
+        assert out.startswith("---\n")
+        assert out.count("\n---\n") == 1  # exactly one closing delimiter
+        assert "Michael prefers symptom-first triage." in out
+
+    def test_frontmatter_fields(self):
+        out = vault.render_note(ENTRY)
+        assert "id: doc-1" in out
+        assert "class: user_preference" in out
+        assert "verification: confirmed" in out
+        assert "scope_kind: agent" in out
+        assert "scope_id: alfred" in out
+
+    def test_omits_empty_fields(self):
+        out = vault.render_note(ENTRY)
+        assert "expires_at:" not in out  # None → omitted
+
+    def test_renders_links_as_wikilinks(self):
+        e = {**ENTRY, "superseded_by": "doc-9"}
+        out = vault.render_note(e)
+        assert "links:" in out
+        assert '"[[doc-9]]"' in out
+
+    def test_round_trips_through_parse(self):
+        out = vault.render_note(ENTRY)
+        parsed = vault.parse_note(out)  # defined in Task 3 — keep this test xfail until then
+        assert parsed["id"] == "doc-1"
+```
+
+> The last test references `parse_note` (Task 3). Mark it skipped for now: add `import pytest` and decorate `test_round_trips_through_parse` with `@pytest.mark.skip(reason="parse_note lands in Task 3")`. Remove the skip in Task 3.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python -m pytest tests/memory-governor/test_vault.py::TestRenderNote -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'governor.vault'` (or `AttributeError: ... has no attribute 'render_note'`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `services/memory-governor/src/governor/vault.py`:
+
+```python
+"""memory ↔ Obsidian vault: project governed memory to a local Markdown vault
+and apply operator edits back. Pure render/parse/diff + a thin httpx client.
+
+The governed-memory six-class model maps 1:1 onto Markdown-note-with-frontmatter,
+so an Obsidian vault is the front-end with no UI to build."""
+
+from __future__ import annotations
+
+# Frontmatter key → source field on the governor `documents` row.
+_FIELD_MAP = [
+    ("id", "id"),
+    ("class", "memory_class"),
+    ("verification", "verification_state"),
+    ("scope_kind", "memory_scope_kind"),
+    ("scope_id", "memory_scope_id"),
+    ("source", "source_type"),
+    ("created_by", "created_by_peer"),
+    ("created_at", "created_at"),
+    ("last_confirmed_at", "last_confirmed_at"),
+    ("expires_at", "expires_at"),
+]
+
+
+def _scalar(value) -> str:
+    """Emit a frontmatter scalar; quote when it could be misread."""
+    s = str(value)
+    if s == "" or any(c in s for c in ':#"\n') or s.strip() != s:
+        return '"' + s.replace('"', '\\"') + '"'
+    return s
+
+
+def render_note(entry: dict) -> str:
+    """Render a governor memory entry as an Obsidian Markdown note (frontmatter
+    + body). Empty/None fields are omitted; relations become wikilinks."""
+    lines = ["---"]
+    for key, field in _FIELD_MAP:
+        val = entry.get(field)
+        if val is not None and val != "":
+            lines.append(f"{key}: {_scalar(val)}")
+
+    links = []
+    for field in ("superseded_by", "promotion_source_doc_id"):
+        ref = entry.get(field)
+        if ref and ref != entry.get("id"):
+            links.append(ref)
+    if links:
+        lines.append("links:")
+        lines.extend(f'  - "[[{ref}]]"' for ref in links)
+
+    lines.append("---")
+    lines.append("")
+    lines.append((entry.get("content") or "").rstrip())
+    lines.append("")
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `python -m pytest tests/memory-governor/test_vault.py::TestRenderNote -v`
+Expected: PASS (the round-trip test is skipped for now).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/memory-governor/src/governor/vault.py tests/memory-governor/test_vault.py
+git commit -m "feat(governor): vault render_note — memory entry to Obsidian note (Obsidian read)"
+```
+
+---
+
+## Task 2: Governor client + export
+
+**Files:**
+- Modify: `services/memory-governor/src/governor/vault.py`
+- Test: `tests/memory-governor/test_vault.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/memory-governor/test_vault.py`:
+
+```python
+import json
+
+
+class FakeClient:
+    """Stand-in for GovernorClient: serves canned list/show, records actions."""
+    def __init__(self, entries):
+        self._entries = {e["id"]: e for e in entries}
+        self.actions = []
+
+    def list_memory(self):
+        return [{"id": e["id"]} for e in self._entries.values()]
+
+    def show(self, doc_id):
+        return self._entries[doc_id]
+
+    def action(self, doc_id, body):
+        self.actions.append((doc_id, body))
+        return {"ok": True}
+
+
+class TestExport:
+    def test_writes_one_note_per_entry_plus_baseline(self, tmp_path):
+        client = FakeClient([ENTRY, {**ENTRY, "id": "doc-2", "content": "second"}])
+        written = vault.export(client, tmp_path)
+        assert written == 2
+        assert (tmp_path / "doc-1.md").exists()
+        assert (tmp_path / "doc-2.md").exists()
+        assert "symptom-first" in (tmp_path / "doc-1.md").read_text()
+        # baseline snapshot records id→{class,verification} for the diff later
+        baseline = json.loads((tmp_path / vault.BASELINE_FILE).read_text())
+        assert baseline["doc-1"]["class"] == "user_preference"
+        assert baseline["doc-1"]["verification"] == "confirmed"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python -m pytest tests/memory-governor/test_vault.py::TestExport -v`
+Expected: FAIL — `AttributeError: module 'governor.vault' has no attribute 'export'` (and `BASELINE_FILE`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `services/memory-governor/src/governor/vault.py`:
+
+```python
+import json
+import os
+from pathlib import Path
+
+import httpx
+
+BASELINE_FILE = ".governor-baseline.json"
+
+
+class GovernorClient:
+    """Thin client over the governor operator API. Configured from env so it
+    works both in-network (X-Governor-Key) and via the auth-proxy (Bearer)."""
+
+    def __init__(self, base_url: str, headers: dict, prefix: str = ""):
+        self._base = base_url.rstrip("/")
+        self._prefix = prefix
+        self._headers = headers
+
+    @classmethod
+    def from_env(cls) -> "GovernorClient":
+        # In-network default (mirrors pc-memory.sh). For a local operator, set
+        # MEMORY_API_BASE_URL (mission-control host) + MEMORY_API_TOKEN (JWT).
+        proxy = os.environ.get("MEMORY_API_BASE_URL")
+        if proxy:
+            return cls(proxy, {"Authorization": f"Bearer {os.environ['MEMORY_API_TOKEN']}"}, prefix="/api")
+        base = os.environ.get("GOVERNOR_BASE_URL", "http://ca-memory-governor-dev")
+        return cls(base, {"X-Governor-Key": os.environ.get("GOVERNOR_API_KEY", "")})
+
+    def _url(self, path: str) -> str:
+        return f"{self._base}{self._prefix}{path}"
+
+    def list_memory(self) -> list[dict]:
+        r = httpx.get(self._url("/memory"), headers=self._headers, timeout=30)
+        r.raise_for_status()
+        return r.json()
+
+    def show(self, doc_id: str) -> dict:
+        r = httpx.get(self._url(f"/memory/{doc_id}"), headers=self._headers, timeout=30)
+        r.raise_for_status()
+        return r.json()
+
+    def action(self, doc_id: str, body: dict) -> dict:
+        r = httpx.post(self._url(f"/memory/{doc_id}/action"), headers=self._headers, json=body, timeout=30)
+        r.raise_for_status()
+        return r.json()
+
+
+def _baseline_entry(entry: dict) -> dict:
+    return {"class": entry.get("memory_class"), "verification": entry.get("verification_state")}
+
+
+def export(client, vault_dir) -> int:
+    """Project all governed memory into vault_dir as Obsidian notes, and write a
+    baseline snapshot used by sync() to detect local edits. Returns the count."""
+    vault_dir = Path(vault_dir)
+    vault_dir.mkdir(parents=True, exist_ok=True)
+    baseline: dict[str, dict] = {}
+    count = 0
+    for ref in client.list_memory():
+        entry = client.show(ref["id"])
+        (vault_dir / f"{entry['id']}.md").write_text(render_note(entry), encoding="utf-8")
+        baseline[entry["id"]] = _baseline_entry(entry)
+        count += 1
+    (vault_dir / BASELINE_FILE).write_text(json.dumps(baseline, indent=2), encoding="utf-8")
+    return count
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `python -m pytest tests/memory-governor/test_vault.py::TestExport -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/memory-governor/src/governor/vault.py tests/memory-governor/test_vault.py
+git commit -m "feat(governor): vault GovernorClient + export with baseline snapshot (Obsidian read)"
+```
+
+---
+
+## Task 3: Note parser + edit→action diff (write-back core)
+
+**Files:**
+- Modify: `services/memory-governor/src/governor/vault.py`
+- Test: `tests/memory-governor/test_vault.py`
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/memory-governor/test_vault.py`, remove the `@pytest.mark.skip` from `test_round_trips_through_parse`, then append:
+
+```python
+class TestParseNote:
+    def test_extracts_frontmatter_fields(self):
+        note = vault.render_note({**ENTRY, "memory_class": "durable_fact",
+                                  "verification_state": "unverified"})
+        p = vault.parse_note(note)
+        assert p["id"] == "doc-1"
+        assert p["class"] == "durable_fact"
+        assert p["verification"] == "unverified"
+
+    def test_missing_frontmatter_returns_empty(self):
+        assert vault.parse_note("no frontmatter here") == {}
+
+
+class TestDiffToActions:
+    def _baseline(self):
+        return {
+            "doc-1": {"class": "user_preference", "verification": "unverified"},
+            "doc-2": {"class": "durable_fact", "verification": "confirmed"},
+        }
+
+    def test_deleted_note_becomes_rm(self):
+        # doc-2 absent from the vault → rm
+        actions = vault.diff_to_actions(self._baseline(), {"doc-1": {"id": "doc-1",
+            "class": "user_preference", "verification": "unverified"}})
+        assert {"doc_id": "doc-2", "action": "rm"} in actions
+
+    def test_confirm_when_verification_flipped(self):
+        current = {
+            "doc-1": {"id": "doc-1", "class": "user_preference", "verification": "confirmed"},
+            "doc-2": {"id": "doc-2", "class": "durable_fact", "verification": "confirmed"},
+        }
+        actions = vault.diff_to_actions(self._baseline(), current)
+        assert {"doc_id": "doc-1", "action": "confirm"} in actions
+
+    def test_pin_when_class_set_to_pinned(self):
+        current = {
+            "doc-1": {"id": "doc-1", "class": "pinned", "verification": "unverified"},
+            "doc-2": {"id": "doc-2", "class": "durable_fact", "verification": "confirmed"},
+        }
+        actions = vault.diff_to_actions(self._baseline(), current)
+        assert {"doc_id": "doc-1", "action": "pin"} in actions
+
+    def test_demote_records_target_class(self):
+        current = {
+            "doc-1": {"id": "doc-1", "class": "user_preference", "verification": "unverified"},
+            "doc-2": {"id": "doc-2", "class": "decaying", "verification": "confirmed"},
+        }
+        actions = vault.diff_to_actions(self._baseline(), current)
+        assert {"doc_id": "doc-2", "action": "demote", "demote_to": "decaying"} in actions
+
+    def test_no_change_yields_no_actions(self):
+        current = {
+            "doc-1": {"id": "doc-1", "class": "user_preference", "verification": "unverified"},
+            "doc-2": {"id": "doc-2", "class": "durable_fact", "verification": "confirmed"},
+        }
+        assert vault.diff_to_actions(self._baseline(), current) == []
+
+
+class TestDetectConflicts:
+    def test_flags_entry_changed_on_server_since_export(self):
+        baseline = {"doc-1": {"class": "durable_fact", "verification": "unverified"}}
+        server = {"doc-1": {"class": "durable_fact", "verification": "confirmed"}}  # moved
+        assert vault.detect_conflicts(baseline, server) == ["doc-1"]
+
+    def test_no_conflict_when_unchanged(self):
+        baseline = {"doc-1": {"class": "durable_fact", "verification": "unverified"}}
+        server = {"doc-1": {"class": "durable_fact", "verification": "unverified"}}
+        assert vault.detect_conflicts(baseline, server) == []
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python -m pytest tests/memory-governor/test_vault.py::TestParseNote tests/memory-governor/test_vault.py::TestDiffToActions tests/memory-governor/test_vault.py::TestDetectConflicts -v`
+Expected: FAIL — `parse_note` / `diff_to_actions` / `detect_conflicts` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `services/memory-governor/src/governor/vault.py`:
+
+```python
+_DEMOTE_TARGETS = ("durable_fact", "user_preference", "task_scoped", "decaying")
+
+
+def parse_note(text: str) -> dict:
+    """Inverse of render_note's frontmatter: returns the key→value scalar map.
+    Empty dict when the note has no leading frontmatter block."""
+    if not text.startswith("---\n"):
+        return {}
+    end = text.find("\n---", 4)
+    if end == -1:
+        return {}
+    out: dict[str, str] = {}
+    for line in text[4:end].splitlines():
+        if not line or line.startswith("  ") or line.rstrip() == "links:":
+            continue  # skip list items / the links header
+        if ":" not in line:
+            continue
+        key, _, val = line.partition(":")
+        val = val.strip()
+        if len(val) >= 2 and val[0] == '"' and val[-1] == '"':
+            val = val[1:-1].replace('\\"', '"')
+        out[key.strip()] = val
+    return out
+
+
+def diff_to_actions(baseline: dict, current: dict) -> list[dict]:
+    """Map vault edits to governor actions. `baseline` is id→{class,verification}
+    from the last export; `current` is id→parsed-note. Body/content edits are NOT
+    handled here (supersede is a documented follow-on)."""
+    actions: list[dict] = []
+    for doc_id, base in baseline.items():
+        cur = current.get(doc_id)
+        if cur is None:
+            actions.append({"doc_id": doc_id, "action": "rm"})
+            continue
+        cur_class = cur.get("class")
+        cur_verif = cur.get("verification")
+        if cur_class == "pinned" and base.get("class") != "pinned":
+            actions.append({"doc_id": doc_id, "action": "pin"})
+        elif cur_verif == "confirmed" and base.get("verification") != "confirmed":
+            actions.append({"doc_id": doc_id, "action": "confirm"})
+        elif cur_verif == "disputed" and base.get("verification") != "disputed":
+            actions.append({"doc_id": doc_id, "action": "dispute"})
+        elif cur_class != base.get("class") and cur_class in _DEMOTE_TARGETS:
+            actions.append({"doc_id": doc_id, "action": "demote", "demote_to": cur_class})
+    return actions
+
+
+def detect_conflicts(baseline: dict, server: dict) -> list[str]:
+    """Ids whose server state changed since export (class or verification differ
+    from baseline) — these are skipped at sync time to avoid clobbering."""
+    conflicts = []
+    for doc_id, base in baseline.items():
+        srv = server.get(doc_id)
+        if srv is None:
+            continue  # deleted server-side; a vault rm on it is a no-op/handled elsewhere
+        if srv.get("class") != base.get("class") or srv.get("verification") != base.get("verification"):
+            conflicts.append(doc_id)
+    return conflicts
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `python -m pytest tests/memory-governor/test_vault.py -v`
+Expected: PASS — including the now-unskipped round-trip test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/memory-governor/src/governor/vault.py tests/memory-governor/test_vault.py
+git commit -m "feat(governor): vault parse_note + diff_to_actions + detect_conflicts (Obsidian write-back core)"
+```
+
+---
+
+## Task 4: sync (apply write-back with conflict skipping)
+
+**Files:**
+- Modify: `services/memory-governor/src/governor/vault.py`
+- Test: `tests/memory-governor/test_vault.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/memory-governor/test_vault.py`:
+
+```python
+class TestSync:
+    def _seed_vault(self, tmp_path, entries):
+        client = FakeClient(entries)
+        vault.export(client, tmp_path)
+        return client
+
+    def test_deleting_a_note_applies_rm(self, tmp_path):
+        client = self._seed_vault(tmp_path, [ENTRY, {**ENTRY, "id": "doc-2", "content": "x"}])
+        (tmp_path / "doc-2.md").unlink()  # operator deletes the note
+        result = vault.sync(client, tmp_path, actor="operator")
+        assert ("doc-2", {"action": "rm", "actor": "operator"}) in client.actions
+        assert result["applied"] == 1
+        assert result["conflicts"] == []
+
+    def test_confirm_via_frontmatter_edit(self, tmp_path):
+        unconf = {**ENTRY, "verification_state": "unverified"}
+        client = self._seed_vault(tmp_path, [unconf])
+        # operator edits the note's frontmatter to confirmed
+        note = (tmp_path / "doc-1.md").read_text().replace(
+            "verification: unverified", "verification: confirmed")
+        (tmp_path / "doc-1.md").write_text(note)
+        vault.sync(client, tmp_path, actor="operator")
+        assert any(a == ("doc-1", {"action": "confirm", "actor": "operator"}) for a in client.actions)
+
+    def test_conflict_is_skipped_and_reported(self, tmp_path):
+        unconf = {**ENTRY, "verification_state": "unverified"}
+        client = self._seed_vault(tmp_path, [unconf])
+        # server moved doc-1 to confirmed AFTER export (someone else changed it)
+        client._entries["doc-1"]["verification_state"] = "confirmed"
+        # operator tries to dispute it locally
+        note = (tmp_path / "doc-1.md").read_text().replace(
+            "verification: unverified", "verification: disputed")
+        (tmp_path / "doc-1.md").write_text(note)
+        result = vault.sync(client, tmp_path, actor="operator")
+        assert result["conflicts"] == ["doc-1"]
+        assert client.actions == []  # nothing applied for the conflicted doc
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python -m pytest tests/memory-governor/test_vault.py::TestSync -v`
+Expected: FAIL — `AttributeError: module 'governor.vault' has no attribute 'sync'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `services/memory-governor/src/governor/vault.py`:
+
+```python
+def _read_baseline(vault_dir: Path) -> dict:
+    p = vault_dir / BASELINE_FILE
+    if not p.exists():
+        raise FileNotFoundError(f"no baseline at {p} — run `export` first")
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def _read_vault(vault_dir: Path) -> dict:
+    """id → parsed-note for every *.md in the vault (excludes the baseline)."""
+    current = {}
+    for md in vault_dir.glob("*.md"):
+        parsed = parse_note(md.read_text(encoding="utf-8"))
+        if parsed.get("id"):
+            current[parsed["id"]] = parsed
+    return current
+
+
+def sync(client, vault_dir, *, actor: str = "operator") -> dict:
+    """Apply vault edits back to the governor. Re-fetches current server state to
+    skip conflicts (entries changed since export). Returns {applied, conflicts}."""
+    vault_dir = Path(vault_dir)
+    baseline = _read_baseline(vault_dir)
+    current = _read_vault(vault_dir)
+
+    server = {ref["id"]: _baseline_entry(client.show(ref["id"]))
+              for ref in client.list_memory()}
+    conflicts = set(detect_conflicts(baseline, server))
+
+    applied = 0
+    for act in diff_to_actions(baseline, current):
+        if act["doc_id"] in conflicts:
+            continue
+        body = {"action": act["action"], "actor": actor}
+        if act["action"] == "demote":
+            body["demote_to"] = act["demote_to"]
+        client.action(act["doc_id"], body)
+        applied += 1
+    return {"applied": applied, "conflicts": sorted(conflicts)}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `python -m pytest tests/memory-governor/test_vault.py -v`
+Expected: PASS (all vault tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/memory-governor/src/governor/vault.py tests/memory-governor/test_vault.py
+git commit -m "feat(governor): vault sync — apply edits with conflict skipping (Obsidian write-back)"
+```
+
+---
+
+## Task 5: CLI entry point
+
+**Files:**
+- Modify: `services/memory-governor/src/governor/vault.py`
+- Test: `tests/memory-governor/test_vault.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/memory-governor/test_vault.py`:
+
+```python
+class TestCli:
+    def test_export_dispatch_calls_export(self, tmp_path, monkeypatch):
+        calls = {}
+        monkeypatch.setattr(vault, "_client_from_env", lambda: "CLIENT")
+        monkeypatch.setattr(vault, "export", lambda client, d: calls.setdefault("export", (client, str(d))) or 3)
+        rc = vault.main(["export", str(tmp_path)])
+        assert rc == 0
+        assert calls["export"] == ("CLIENT", str(tmp_path))
+
+    def test_unknown_command_returns_2(self):
+        assert vault.main(["frobnicate", "x"]) == 2
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python -m pytest tests/memory-governor/test_vault.py::TestCli -v`
+Expected: FAIL — `vault.main` / `vault._client_from_env` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `services/memory-governor/src/governor/vault.py`:
+
+```python
+def _client_from_env():
+    return GovernorClient.from_env()
+
+
+def main(argv: list[str] | None = None) -> int:
+    import sys
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) < 2 or args[0] not in ("export", "sync"):
+        print("usage: python -m governor.vault {export|sync} <vault-dir>", file=sys.stderr)
+        return 2
+    cmd, vault_dir = args[0], args[1]
+    client = _client_from_env()
+    if cmd == "export":
+        n = export(client, vault_dir)
+        print(f"exported {n} notes to {vault_dir}")
+    else:
+        result = sync(client, vault_dir)
+        print(f"applied {result['applied']} change(s); "
+              f"{len(result['conflicts'])} conflict(s) skipped: {result['conflicts']}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `python -m pytest tests/memory-governor/test_vault.py -v`
+Expected: PASS (all vault tests, incl. CLI).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/memory-governor/src/governor/vault.py tests/memory-governor/test_vault.py
+git commit -m "feat(governor): vault CLI entry (python -m governor.vault export|sync) (Obsidian)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (against §2.4 of the v1.3 design):
+- Pure renderer (entry → Markdown + frontmatter: class/verification/scope/source/timestamps + wikilinks) → Task 1. ✅
+- `export` → local Obsidian vault via a command, on the governor operator API → Tasks 2 + 5. ✅
+- `sync` write-back: delete → rm; trust/confirmed frontmatter → confirm/pin; class → demote → Tasks 3 + 4. ✅
+- Conflict policy: governor source-of-truth, conflicts reported and skipped, baseline snapshot taken at export → Tasks 2 (baseline) + 3 (`detect_conflicts`) + 4 (sync skips). ✅
+- Local CLI delivery (no Azure infra), env-configured for in-network or auth-proxy → Task 2 (`from_env`) + Task 5. ✅
+- Operator-gated / privileged (no agent path) → the CLI is operator-run and not imported by any agent/service code. ✅
+- **Documented out-of-scope:** body/content edits → `supersede` (needs admit + supersede) — called out in the File Structure note as a follow-on, consistent with the spec's "write-back may fast-follow".
+
+**Placeholder scan:** none — every function and test has complete code. The Task 1 round-trip test's temporary `@pytest.mark.skip` is explicitly removed in Task 3 (a real instruction, not a placeholder).
+
+**Type consistency:** `render_note(entry) -> str`, `parse_note(text) -> dict`, `diff_to_actions(baseline, current) -> list[dict]`, `detect_conflicts(baseline, server) -> list[str]`, `export(client, dir) -> int`, `sync(client, dir, *, actor) -> dict` are used identically in their tests and call sites. The baseline shape `{id: {"class", "verification"}}` is produced by `_baseline_entry` and consumed identically by `diff_to_actions`/`detect_conflicts`. The action dict keys (`doc_id`, `action`, `demote_to`) match between `diff_to_actions` and `sync`'s body construction, and the action strings match the governor's `VALID_ACTIONS`.

--- a/docs/superpowers/plans/2026-06-24-turnkey-scaffold-cicd-page.md
+++ b/docs/superpowers/plans/2026-06-24-turnkey-scaffold-cicd-page.md
@@ -1,0 +1,524 @@
+# Turnkey scaffold-3 — Forge Console CI/CD-Setup Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "CI/CD Setup" page to the Forge Console that runs the existing `scripts/scaffold-cicd.sh` (OIDC app + state backend + GitHub vars/secrets/deploy-destroy env) as a one-click, live-streamed operation — preview-first, with provider secrets passed via the subprocess environment (never the command line), and an explicit typed confirmation before `--apply`.
+
+**Architecture:** A pure `build_scaffold_command(params)` in `core.py` maps validated UI inputs to scaffold-cicd.sh flags (secrets excluded by construction). The existing one-at-a-time `Runner` is extended with an optional `env` so the endpoint can pass provider keys as environment variables. A new `POST /api/scaffold` endpoint builds the command, enforces an apply-confirmation gate (mirroring the destroy-approval pattern), and runs it through the Runner; output streams over the existing `/api/stream` SSE channel. The UI adds a form + Preview/Apply buttons.
+
+**Tech Stack:** Python 3, FastAPI, the Forge Console's `core.Runner` (subprocess streaming), pytest + FastAPI `TestClient`, vanilla HTML/JS.
+
+---
+
+## File Structure
+
+- **Modify** `installer/core.py`:
+  - add `build_scaffold_command(params, repo_root=REPO_ROOT)` (pure, validated).
+  - add an optional `env` parameter to `Runner.start` and `Runner._execute`.
+  - add a `"scaffold"` entry to `STEP_TIMEOUTS`.
+- **Modify** `installer/app.py`: add `ScaffoldBody`, `SCAFFOLD_APPLY_TOKEN`, and `POST /api/scaffold`.
+- **Modify** `installer/static/index.html`: add a "CI/CD Setup" section (form + Preview/Apply + stream).
+- **Create** `installer/tests/test_scaffold.py`: unit tests for `build_scaffold_command`, the Runner `env`, and the endpoint wiring/gate.
+
+scaffold-cicd.sh is **preview-first** (changes nothing without `--apply`), takes config via flags (`--repo`, `--subscription`, `--app-name`, `--location`, `--state-*`, `--grant-uaa`, `--environment-subject`, `--registry`, `--key-vault`, `--smoke-url`, `--reviewers`, `--skip-github`), and reads **provider-key secrets from like-named environment variables** — so secrets must travel as env, not args.
+
+---
+
+## Task 1: Pure scaffold command builder
+
+**Files:**
+- Modify: `installer/core.py` (after `build_step_command`, ~line 262)
+- Test: `installer/tests/test_scaffold.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `installer/tests/test_scaffold.py`:
+
+```python
+"""Offline tests for the scaffold-cicd Forge Console integration — no az/gh/network."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from installer import core  # noqa: E402
+
+
+class TestBuildScaffoldCommand:
+    def test_preview_has_no_apply_flag(self):
+        cmd = core.build_scaffold_command({"repo": "me/proj"})
+        assert cmd[0] == "bash"
+        assert cmd[1].endswith("scripts/scaffold-cicd.sh")
+        assert "--repo" in cmd and "me/proj" in cmd
+        assert "--apply" not in cmd
+
+    def test_apply_flag_when_requested(self):
+        cmd = core.build_scaffold_command({"repo": "me/proj", "apply": True})
+        assert "--apply" in cmd
+
+    def test_string_flags_only_included_when_set(self):
+        cmd = core.build_scaffold_command({
+            "repo": "me/proj", "subscription": "sub-123", "location": "westus2",
+        })
+        assert cmd[cmd.index("--subscription") + 1] == "sub-123"
+        assert cmd[cmd.index("--location") + 1] == "westus2"
+        assert "--registry" not in cmd  # not provided → absent
+
+    def test_bool_flags(self):
+        cmd = core.build_scaffold_command({
+            "repo": "me/proj", "grant_uaa": True, "skip_github": True,
+            "environment_subject": True,
+        })
+        assert "--grant-uaa" in cmd
+        assert "--skip-github" in cmd
+        assert "--environment-subject" in cmd
+
+    def test_invalid_repo_rejected(self):
+        with pytest.raises(ValueError, match="OWNER/REPO"):
+            core.build_scaffold_command({"repo": "not-a-repo"})
+
+    def test_secrets_never_placed_on_command_line(self):
+        # Even if a secret-shaped value sneaks into params, it must not appear as
+        # an argument — secrets go via env only (verified at the endpoint layer).
+        cmd = core.build_scaffold_command({"repo": "me/proj", "GPT4O_API_KEY": "super-secret"})
+        assert "super-secret" not in cmd
+        assert "--GPT4O_API_KEY" not in cmd
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python -m pytest installer/tests/test_scaffold.py::TestBuildScaffoldCommand -v`
+Expected: FAIL with `AttributeError: module 'installer.core' has no attribute 'build_scaffold_command'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `installer/core.py`, add near the top with the other imports (if `re` isn't already imported): `import re`. Then add after `build_step_command` (~line 262):
+
+```python
+_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+def build_scaffold_command(params: dict, repo_root: Path = REPO_ROOT) -> list[str]:
+    """Map validated UI params to a scripts/scaffold-cicd.sh invocation.
+
+    Preview-first: `--apply` is only added when params['apply'] is truthy.
+    Provider-key SECRETS are NOT handled here — they pass via the subprocess
+    environment (see /api/scaffold), so nothing secret ever lands on argv."""
+    repo = (params.get("repo") or "").strip()
+    if repo and not _REPO_RE.match(repo):
+        raise ValueError(f"invalid repo (want OWNER/REPO): {repo!r}")
+
+    cmd = ["bash", str((repo_root / "scripts" / "scaffold-cicd.sh").resolve())]
+
+    str_flags = {
+        "repo": "--repo", "subscription": "--subscription", "app_name": "--app-name",
+        "location": "--location", "state_rg": "--state-rg",
+        "state_account": "--state-account", "state_container": "--state-container",
+        "registry": "--registry", "key_vault": "--key-vault",
+        "smoke_url": "--smoke-url", "reviewers": "--reviewers",
+    }
+    for key, flag in str_flags.items():
+        val = (params.get(key) or "").strip()
+        if val:
+            cmd += [flag, val]
+
+    bool_flags = {
+        "grant_uaa": "--grant-uaa", "environment_subject": "--environment-subject",
+        "skip_github": "--skip-github", "apply": "--apply",
+    }
+    for key, flag in bool_flags.items():
+        if params.get(key):
+            cmd.append(flag)
+
+    return cmd
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `python -m pytest installer/tests/test_scaffold.py::TestBuildScaffoldCommand -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add installer/core.py installer/tests/test_scaffold.py
+git commit -m "feat(installer): pure build_scaffold_command (turnkey scaffold-3)"
+```
+
+---
+
+## Task 2: Runner env passthrough
+
+**Files:**
+- Modify: `installer/core.py` (`Runner.start`, `Runner._execute`, `STEP_TIMEOUTS`)
+- Test: `installer/tests/test_scaffold.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `installer/tests/test_scaffold.py`:
+
+```python
+import time
+
+
+def _wait_done(run, timeout=10.0):
+    deadline = time.time() + timeout
+    while run.status == "running" and time.time() < deadline:
+        time.sleep(0.02)
+    return run
+
+
+class TestRunnerEnv:
+    def test_env_reaches_subprocess(self):
+        runner = core.Runner()
+        run = runner.start(
+            "scaffold",
+            ["sh", "-c", 'printf %s "$FORGE_SCAFFOLD_TEST"'],
+            env={"FORGE_SCAFFOLD_TEST": "envvalue"},
+        )
+        _wait_done(run)
+        assert run.status == "succeeded"
+        assert any("envvalue" in line for line in run.lines)
+
+    def test_no_env_still_runs(self):
+        runner = core.Runner()
+        run = runner.start("scaffold", ["sh", "-c", "printf ok"])
+        _wait_done(run)
+        assert run.status == "succeeded"
+        assert any("ok" in line for line in run.lines)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python -m pytest installer/tests/test_scaffold.py::TestRunnerEnv -v`
+Expected: FAIL — `test_env_reaches_subprocess` fails because `Runner.start` doesn't accept `env=` yet (`TypeError: start() got an unexpected keyword argument 'env'`).
+
+- [ ] **Step 3: Add the env parameter**
+
+In `installer/core.py`, change `Runner.start` to accept and forward `env`:
+
+```python
+    def start(self, step: str, cmd: list[str], cwd: Path = REPO_ROOT,
+              timeout: Optional[float] = None, env: Optional[dict] = None) -> StepRun:
+        with self._lock:
+            if self.busy():
+                raise RuntimeError(f"a step is already running: {self.current.step}")
+            run = StepRun(step=step)
+            self.current = run
+        if timeout is None:
+            timeout = STEP_TIMEOUTS.get(step, DEFAULT_STEP_TIMEOUT)
+        thread = threading.Thread(target=self._execute, args=(run, cmd, cwd, timeout, env), daemon=True)
+        thread.start()
+        return run
+```
+
+Change `Runner._execute`'s signature and the `Popen` env to merge `env`:
+
+```python
+    def _execute(self, run: StepRun, cmd: list[str], cwd: Path,
+                 timeout: Optional[float] = None, env: Optional[dict] = None) -> None:
+        self._emit(run, f"$ {' '.join(cmd)}")
+        timer = None
+        timed_out = threading.Event()
+        proc_env = {**os.environ, "TF_IN_AUTOMATION": "1"}
+        if env:
+            proc_env.update(env)
+        try:
+            proc = subprocess.Popen(
+                cmd, cwd=str(cwd), stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                text=True, bufsize=1, env=proc_env,
+            )
+```
+
+(The rest of `_execute` — watchdog timer, read loop, status — is unchanged.)
+
+Add a `scaffold` timeout in `STEP_TIMEOUTS`:
+
+```python
+    "scaffold": 900,
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `python -m pytest installer/tests/test_scaffold.py::TestRunnerEnv -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Run the full installer suite (no regressions)**
+
+Run: `python -m pytest installer/tests -q`
+Expected: PASS — existing core/detect-destroy/smoke tests plus the new scaffold tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add installer/core.py installer/tests/test_scaffold.py
+git commit -m "feat(installer): Runner env passthrough + scaffold timeout (turnkey scaffold-3)"
+```
+
+---
+
+## Task 3: /api/scaffold endpoint + apply gate
+
+**Files:**
+- Modify: `installer/app.py` (new model + constant + endpoint, near `run_step`)
+- Test: `installer/tests/test_scaffold.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `installer/tests/test_scaffold.py`:
+
+```python
+from fastapi.testclient import TestClient
+
+from installer import app as appmod  # noqa: E402
+
+
+def _client_and_headers():
+    return TestClient(appmod.app), {"x-forge-token": appmod.SESSION_TOKEN}
+
+
+class TestScaffoldEndpoint:
+    def test_preview_wires_command_and_env(self, monkeypatch):
+        captured = {}
+
+        def fake_start(step, cmd, cwd=appmod.core.REPO_ROOT, timeout=None, env=None):
+            captured.update(step=step, cmd=cmd, env=env)
+            run = appmod.core.StepRun(step=step)
+            return run
+
+        monkeypatch.setattr(appmod.runner, "start", fake_start)
+        client, headers = _client_and_headers()
+        resp = client.post("/api/scaffold", headers=headers, json={
+            "params": {"repo": "me/proj"},
+            "secrets": {"GPT4O_API_KEY": "super-secret"},
+        })
+        assert resp.status_code == 200
+        assert resp.json()["preview"] is True
+        assert "--apply" not in captured["cmd"]
+        assert "super-secret" not in captured["cmd"]          # secret not on argv
+        assert captured["env"]["GPT4O_API_KEY"] == "super-secret"  # secret via env
+
+    def test_apply_requires_confirmation_token(self, monkeypatch):
+        def boom(*a, **k):
+            raise AssertionError("runner.start must not be called without confirmation")
+
+        monkeypatch.setattr(appmod.runner, "start", boom)
+        client, headers = _client_and_headers()
+        resp = client.post("/api/scaffold", headers=headers, json={
+            "params": {"repo": "me/proj"}, "apply": True,
+        })
+        assert resp.status_code == 428
+        assert appmod.SCAFFOLD_APPLY_TOKEN in resp.json()["detail"]
+
+    def test_apply_runs_with_correct_token(self, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(
+            appmod.runner, "start",
+            lambda step, cmd, cwd=appmod.core.REPO_ROOT, timeout=None, env=None:
+                (captured.update(cmd=cmd) or appmod.core.StepRun(step=step)),
+        )
+        client, headers = _client_and_headers()
+        resp = client.post("/api/scaffold", headers=headers, json={
+            "params": {"repo": "me/proj"}, "apply": True,
+            "confirm": appmod.SCAFFOLD_APPLY_TOKEN,
+        })
+        assert resp.status_code == 200
+        assert "--apply" in captured["cmd"]
+
+    def test_invalid_repo_returns_422(self, monkeypatch):
+        monkeypatch.setattr(appmod.runner, "start", lambda *a, **k: None)
+        client, headers = _client_and_headers()
+        resp = client.post("/api/scaffold", headers=headers, json={"params": {"repo": "bad"}})
+        assert resp.status_code == 422
+
+    def test_requires_session_token(self):
+        client, _ = _client_and_headers()
+        resp = client.post("/api/scaffold", json={"params": {"repo": "me/proj"}})
+        assert resp.status_code == 401
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python -m pytest installer/tests/test_scaffold.py::TestScaffoldEndpoint -v`
+Expected: FAIL — the `/api/scaffold` route returns 404 (not defined) / `appmod.SCAFFOLD_APPLY_TOKEN` is missing.
+
+- [ ] **Step 3: Add the endpoint**
+
+In `installer/app.py`, after the `run_step` handler, add:
+
+```python
+SCAFFOLD_APPLY_TOKEN = "scaffold-apply"
+
+
+class ScaffoldBody(BaseModel):
+    params: dict = {}
+    secrets: dict[str, str] = {}
+    apply: bool = False
+    confirm: str = ""
+
+
+@app.post("/api/scaffold")
+def scaffold(body: ScaffoldBody, request: Request) -> dict:
+    """Run scripts/scaffold-cicd.sh (CI/CD one-time setup), streamed.
+
+    Preview-first: without apply it changes nothing. An apply mutates Azure
+    identity/RBAC and GitHub repo config, so it requires a distinct typed token.
+    Provider-key secrets pass via the subprocess environment, never on argv."""
+    _guard(request)
+    if body.apply and body.confirm != SCAFFOLD_APPLY_TOKEN:
+        raise HTTPException(
+            428,
+            f"type '{SCAFFOLD_APPLY_TOKEN}' to run scaffold with --apply "
+            "(it mutates Azure identity/RBAC and GitHub config)",
+        )
+    params = {**body.params, "apply": body.apply}
+    try:
+        cmd = core.build_scaffold_command(params)
+    except ValueError as e:
+        raise HTTPException(422, str(e))
+    env = {k: str(v) for k, v in (body.secrets or {}).items() if v}
+    try:
+        run = runner.start("scaffold", cmd, env=env)
+    except RuntimeError as e:
+        raise HTTPException(409, str(e))
+    return {"started": run.step, "preview": not body.apply}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `python -m pytest installer/tests/test_scaffold.py::TestScaffoldEndpoint -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add installer/app.py installer/tests/test_scaffold.py
+git commit -m "feat(installer): /api/scaffold endpoint with preview-first apply gate (turnkey scaffold-3)"
+```
+
+---
+
+## Task 4: CI/CD Setup UI page
+
+**Files:**
+- Modify: `installer/static/index.html`
+
+The console is a single static page that drives the API + the `/api/stream` SSE channel. This task adds a "CI/CD Setup" section following the existing section/tab pattern. HTML isn't unit-tested; verification is manual.
+
+- [ ] **Step 1: Read the existing UI pattern**
+
+Run: `grep -n 'api/run\|api/stream\|x-forge-token\|<section\|data-tab\|addEventListener' installer/static/index.html | head -40`
+Read enough around an existing action (e.g. the deploy "Run" button) to match its fetch + token + streaming wiring.
+
+- [ ] **Step 2: Add the CI/CD Setup section**
+
+Insert a new section matching the page's existing markup style (reuse the existing CSS classes and the same token/stream helpers). The form collects the non-secret inputs and the provider-key secrets, then POSTs `/api/scaffold`:
+
+```html
+<section id="cicd-setup">
+  <h2>CI/CD Setup</h2>
+  <p>One-time setup for the reference deploy pipeline: an Entra OIDC app, the
+     Terraform state backend, and GitHub variables/secrets + the
+     <code>deploy-destroy</code> approval environment. <strong>Preview first;</strong>
+     apply mutates Azure identity/RBAC and GitHub config.</p>
+
+  <label>GitHub repo (OWNER/REPO) <input id="sc-repo" placeholder="me/AzureAgentForge"></label>
+  <label>Subscription ID <input id="sc-subscription" placeholder="(current az account)"></label>
+  <label>App name <input id="sc-app-name" placeholder="aaf-deploy"></label>
+  <label>Location <input id="sc-location" placeholder="eastus"></label>
+  <label><input type="checkbox" id="sc-grant-uaa"> Grant User Access Administrator</label>
+  <label><input type="checkbox" id="sc-skip-github"> Azure only (skip GitHub)</label>
+
+  <fieldset>
+    <legend>Provider secrets (sent via env, never logged)</legend>
+    <label>GPT4O_API_KEY <input id="sc-sec-gpt4o" type="password"></label>
+    <label>AI_FOUNDRY_API_KEY <input id="sc-sec-foundry" type="password"></label>
+  </fieldset>
+
+  <button id="sc-preview">Preview</button>
+  <button id="sc-apply">Apply…</button>
+  <pre id="sc-output"></pre>
+</section>
+
+<script>
+(function () {
+  function scaffoldBody(apply, confirm) {
+    const params = {
+      repo: document.getElementById("sc-repo").value,
+      subscription: document.getElementById("sc-subscription").value,
+      app_name: document.getElementById("sc-app-name").value,
+      location: document.getElementById("sc-location").value,
+      grant_uaa: document.getElementById("sc-grant-uaa").checked,
+      skip_github: document.getElementById("sc-skip-github").checked,
+    };
+    const secrets = {};
+    const g = document.getElementById("sc-sec-gpt4o").value;
+    const f = document.getElementById("sc-sec-foundry").value;
+    if (g) secrets.GPT4O_API_KEY = g;
+    if (f) secrets.AI_FOUNDRY_API_KEY = f;
+    return { params, secrets, apply, confirm };
+  }
+
+  async function runScaffold(apply) {
+    let confirm = "";
+    if (apply) {
+      confirm = window.prompt("Apply mutates Azure identity/RBAC and GitHub config.\n" +
+                              "Type 'scaffold-apply' to proceed:");
+      if (confirm !== "scaffold-apply") return;
+    }
+    // TOKEN and streamSubscribe are the page's existing session-token + SSE helpers.
+    const resp = await fetch("/api/scaffold", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-forge-token": TOKEN },
+      body: JSON.stringify(scaffoldBody(apply, confirm)),
+    });
+    if (!resp.ok) {
+      document.getElementById("sc-output").textContent =
+        "error: " + (await resp.text());
+      return;
+    }
+    streamSubscribe("sc-output"); // reuse the existing SSE stream consumer
+  }
+
+  document.getElementById("sc-preview").addEventListener("click", () => runScaffold(false));
+  document.getElementById("sc-apply").addEventListener("click", () => runScaffold(true));
+})();
+</script>
+```
+
+Adapt `TOKEN` and `streamSubscribe` to the page's actual helper names (found in Step 1). If the page renders output by reading `/api/stream` into a specific element, point the consumer at `#sc-output`.
+
+- [ ] **Step 3: Manual verification**
+
+Run the console and exercise the page:
+
+```bash
+python -m installer   # or the project's documented `./forge` launch
+```
+
+Then in the printed URL: open **CI/CD Setup**, fill the repo, click **Preview** — confirm the streamed output shows the scaffold plan and that no secret values appear in the streamed `$ …` command line. (Do not click Apply unless you intend to create real Azure/GitHub resources.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add installer/static/index.html
+git commit -m "feat(installer): CI/CD Setup page (turnkey scaffold-3)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (against §2.3 of the v1.3 design):
+- Forge Console page that streams `scaffold-cicd.sh` → Tasks 3 + 4. ✅
+- Inputs collected in the UI; secrets via stdin/env not echoed → Task 1 (secrets excluded from argv) + Task 3 (secrets via env) + Task 4 (password inputs). ✅
+- Same streamed-subprocess pattern as init→validate→plan→apply → reuses `Runner` + `/api/stream` (Tasks 2–4). ✅
+- Offline handler unit tests (command construction + validation) → Tasks 1–3. ✅
+- Optional connect-`<surface>` helper → out of scope for this plan (noted; a follow-on).
+
+**Placeholder scan:** none in the testable code. The UI task (Task 4) intentionally adapts to the page's existing `TOKEN`/`streamSubscribe` helpers discovered in Step 1 — that's a real instruction, not a placeholder, because the exact helper names live in the page being modified.
+
+**Type consistency:** `build_scaffold_command(params) -> list[str]` is used identically in Task 1 (tests) and Task 3 (endpoint). `Runner.start(..., env=None)` signature matches between Task 2 (definition) and Task 3 (call + the endpoint test's `fake_start`). `SCAFFOLD_APPLY_TOKEN` is referenced consistently in the endpoint and its tests. `StepRun(step=...)` construction in the tests matches the dataclass in `core.py`.

--- a/docs/superpowers/specs/2026-06-24-aaf-v1.3-release-design.md
+++ b/docs/superpowers/specs/2026-06-24-aaf-v1.3-release-design.md
@@ -1,0 +1,115 @@
+# AzureAgentForge v1.3 — Release Design
+
+_2026-06-24. Design for the v1.3 release (target: weekend of 2026-06-27/28). Status: approved design, pre-plan._
+_AAF is at v1.2.0 (`public/main`). Releases here = a git tag + a `## v1.x` ROADMAP section + the README release badge; features ship flag-gated-off and are activated by the operator, per the v1.1/v1.2 convention._
+
+## 1. Theme & shape
+
+v1.3 is a **mixed "observability + memory interface" release**: four features, sequenced by value with a weekend-honest cut-line.
+
+- **B3 observability** goes **fully live** (deployed, flag flipped, a real span verified in Application Insights).
+- **B2 ACA Sandboxes** ships as a **flag-off port** (seam + local adapter).
+- **Turnkey scaffold-3** adds a Forge Console page.
+- **Obsidian memory interface** adds a two-way `memory ↔ Obsidian vault` sync, decomposed read-first so the read projection ships even if write-back slips.
+
+This realizes the ROADMAP's "Later → fuller observability pipeline (distributed tracing…)" item (B3) and introduces a memory front-end that leverages the fact that governed memory is already Markdown-with-frontmatter shaped.
+
+### 1.1 Capacity & cut-line (honest scoping)
+
+The four features are ~3+ days of offline code plus a live B3 deploy, against a ~2-day weekend. The release is therefore built around an explicit priority order; lower items slip to an immediate fast-follow without compromising the release:
+
+1. **B3a + B3b** — headline observability port (offline). *Must.*
+2. **B2 sandbox port** — seam + local adapter, flag-off. *Must.*
+3. **Obsidian projection (read)** — the demo-able "memory interface". *Must.*
+4. **Turnkey scaffold-3** — Forge Console CI/CD page. *Should.*
+5. **B3c** — deploy + flip `OBSERVABILITY_ENABLED` + live KQL check. *Operator-run; the "fully live" step.*
+6. **Obsidian write-back (two-way)** — the richer half. *Target; first to slip → fast-follow.*
+
+A v1.3 that ships items 1–4 (+ B3c live) is a complete, coherent release; item 6 is the stretch.
+
+## 2. Feature designs
+
+### 2.1 B3 — GenAI-semconv observability (headline, goes live)
+
+Port of an internally-shipped GenAI-semconv router observability feature into AAF's `services/model-router`. The full file:line-grounded design is summarized here.
+
+**B3a — offline core.** Add to `services/model-router/main.py`:
+- `genai_semconv_attrs(...)` — pure mapping to OTel GenAI-semconv attributes. **Genericized for the public repo:** `gen_ai.*` standard attributes unchanged; the private platform's custom tier and run-id attributes map to `agent.tier` and `agent.run_id`. Emitted set: `gen_ai.operation.name="chat"`, `gen_ai.system` (`anthropic` | `az.ai.foundry` via a `_genai_system(tier)` helper), `gen_ai.request.model`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.usage.cost_usd` (6dp), `agent.tier`, `agent.run_id` (conditional).
+- `observe_genai(...)` — flag-gated on `OBSERVABILITY_ENABLED` (default off), lazy-imports the exporter, **fail-open** (a telemetry error must never break a model call).
+- `_init_tracer()` — isolates exporter setup: uses the `azure-monitor-opentelemetry` distro when `APPLICATIONINSIGHTS_CONNECTION_STRING` is set (the Azure case), and is a documented swap point for a raw OTLP exporter. The semconv mapping and span emit stay backend-neutral.
+- Widen `record_cost(tier, cost)` → `record_cost(tier, cost, *, model=None, input_tokens=0, output_tokens=0, run_id=None)`, keep the existing `_spend[tier]` accounting, and call `observe_genai(...)` at the end so both cost paths flow through one hook.
+- Dep: `azure-monitor-opentelemetry>=1.6.0` in `services/model-router/requirements.txt` (runtime-imported only when the flag is on; default image footprint unchanged).
+
+**B3b — close the Anthropic cost gap.** AAF currently records cost only on the litellm path (`main.py:1068`) and *skips* it on the Anthropic path (`:1064`). Add an Anthropic list-price estimator (input/output/cache tokens × per-MTok rates) and call the widened `record_cost(...)` on the Anthropic path. Claude-tier calls become both cost-tracked and observable. Mark the figure a **list-price estimate** (Anthropic doesn't return `response_cost`), not a billed amount.
+
+**B3c — go live (operator).** Add `OBSERVABILITY_ENABLED` (default off) + `APPLICATIONINSIGHTS_CONNECTION_STRING` env to the **router sidecar** container block in `hermes.tf` (the conn-string var is already in the module; the router has no standalone `model_router.tf` — it co-locates in the hermes pod). Deploy → flip the flag → confirm in App Insights: `dependencies | where name == "gen_ai.chat"`; Σ `gen_ai.usage.cost_usd` over a run ≈ that run's `record_cost` total.
+
+**Error handling / risk.** The router is on every model call: emit is fail-open, the exporter batched (`BatchSpanProcessor`); `run_id`/`tier` are span *attributes*, never metric label dimensions (`run_id` is unbounded). No prompt/response text in any attribute (content-redacted by design). Public-repo hygiene: no private Foundry endpoint constant rides along — only the pure functions + the `record_cost` change + the Anthropic estimator.
+
+**Tests.** Port the private platform's `tests/router/test_genai_observability.py` (field mapping, cost rounding, conditional `agent.run_id`); add Anthropic-estimator tests (known token counts → expected cost); extend the budget test for the new `record_cost` kwargs. `pytest services/model-router/tests` green.
+
+### 2.2 B2 — ACA Sandboxes (port, flag-off)
+
+Port the private platform's sandbox execution seam into AAF's vendored paperclip.
+- Add `services/paperclip/sandbox.mjs`: a provider factory + a local adapter (the execution seam), **unwired** — the public mirror of the private platform's B2-1.
+- Port the private platform's sandbox unit tests into AAF (`services/paperclip/` test layout or `tests/sandbox/`, matching repo convention).
+- Ships the seam + local adapter only; wiring it into the hot path (B2-2) and the `aca-job` / ACA dynamic-sessions adapter (B2-3) stay future, matching how the private platform shipped B2-1.
+- ROADMAP: advances the "ACA Sandboxes" item to "execution seam shipped (flag-off)".
+
+### 2.3 Turnkey scaffold-3 (Forge Console CI/CD page)
+
+A Forge Console page that runs the existing `scripts/scaffold-cicd.sh` as one click.
+- `installer/app.py`: a new route/handler that live-streams `scaffold-cicd.sh` (the same streamed-subprocess pattern the Console already uses for `init → validate → plan → apply`). Azure/GitHub inputs (subscription, repo, role-assignment options) collected in the UI; provider secrets piped via stdin, never echoed — the script already supports stdin secret input.
+- `installer/static/index.html`: a "CI/CD setup" page with the inputs + live-streamed output.
+- Tests in `installer/tests/test_core.py`: command construction + arg validation, offline (no real `az`/`gh` calls).
+- Optional, time permitting: a `connect-<surface>.sh` helper.
+
+### 2.4 Obsidian memory interface (two-way `memory ↔ vault`)
+
+A new, well-bounded unit that makes a local Obsidian vault the front-end for governed memory. Built on the fact that the six-class governed-memory model maps 1:1 onto Markdown-note-with-frontmatter (the same shape as the Claude memory store).
+
+**Projection (read) — the prerequisite, ships first.**
+- A **pure renderer** turns each governed-memory entry into a Markdown note: body = the fact text; frontmatter = `class`, `trust`, `provenance`, `links` (and id/scope/timestamps). Wikilinks (`[[other-note]]`) express memory relations so Obsidian's graph/backlinks work.
+- A `pc-memory vault export <dir>` command (on top of the governor's existing operator API — the same surface `apps/hermes/overrides/skills/playbooks/honcho-memory/scripts/pc-memory.sh` uses) populates a local vault the operator opens directly in Obsidian.
+- The renderer is pure → unit-tested offline (entry → expected Markdown + frontmatter).
+
+**Write-back (two-way) — the richer half, may fast-follow.**
+- A `pc-memory vault sync <dir>` command diffs the vault against an export baseline (a hidden `.baseline` snapshot taken at export) and applies governor verbs:
+  - note deleted → `forget`
+  - `trust`/`confirmed` frontmatter edited → `confirm` / `pin`
+  - body or `class` edited → `supersede` (writes a new version)
+- **Conflict policy:** the governor is source-of-truth. On a conflict (entry changed server-side since the baseline), `sync` reports it and skips that note rather than overwriting — no silent clobber. (Mirrors the file-share-staleness discipline from the platform's deploy tooling.)
+- Edit→verb mapping is a pure function → unit-tested offline; the apply step is integration-tested against a mock governor API.
+
+**Delivery decision.** A **local export/sync CLI** (operator-run, no new Azure infra) — chosen over (a) a governor-written vault on a mounted Azure File share, or (b) a custom Obsidian plugin calling the governor API. The CLI is simplest, most portable, keeps curation operator-gated, and mirrors how the Claude memory store already works. The vault never lives in Azure; the operator pulls/pushes on demand.
+
+**Flag / safety.** Opt-in and operator-gated (memory curation is privileged). No agent path touches `vault sync`.
+
+## 3. Release mechanics
+
+- Each feature is its own PR off `public/main`. Expected: B3 as two PRs (B3a+B3b core; then B3c TF wiring), B2 one, turnkey one, Obsidian one or two (projection; write-back).
+- After merges: tag `v1.3.0`; add a `## v1.3 — shipped` section to `ROADMAP.md` in the v1.2 format; bump the README release badge `v1.2 → v1.3`.
+- All CI green (each service's offline test suite); no new internal-ref leaks (run the repo's internal-refs scanner if present).
+
+## 4. Success criteria
+
+- B3: `pytest services/model-router/tests` green incl. the ported observability + Anthropic-estimator tests; **live** — a real model call produces a `gen_ai.chat` dependency in App Insights with model/token/cost attributes, and Σ cost ≈ the run's `record_cost` total.
+- B2: `services/paperclip` sandbox seam + local adapter present, ported tests green, flag-off (unwired).
+- Turnkey: the Forge Console "CI/CD setup" page streams `scaffold-cicd.sh`; handler unit tests green.
+- Obsidian: `vault export` produces a valid Obsidian vault (renderer tests green); `vault sync` applies the correct verbs on edits/deletes with conflict reporting (mapping tests green) — write-back may land as a fast-follow.
+- Release: `v1.3.0` tag + ROADMAP section + README badge.
+
+## 5. Open questions / decisions made
+
+- **B3 distro vs raw OTLP** — decided: `azure-monitor-opentelemetry` distro gated on the conn string, with `_init_tracer` as the documented swap point. (Raw-OTLP-only is more portable but more setup; not worth it for v1 of the port.)
+- **One router sidecar or two** — decided: wire the hermes-pod router (the agent-fleet, high-value target) first; the governor-pod router sidecar (mostly embeddings) is optional/later.
+- **Obsidian delivery** — decided: local CLI (see §2.4), not a file-share mount or an Obsidian plugin.
+- **Obsidian write-back depth** — two-way is the target; read projection is the committed deliverable and a prerequisite, so write-back can fast-follow without blocking the release.
+
+## 6. Risks
+
+- **Weekend over-capacity** — mitigated by the §1.1 cut-line; items 5–6 are operator/fast-follow.
+- **B3 hot path** — fail-open + batched exporter; never surface telemetry errors to callers (preserve the private platform's swallow-all behavior).
+- **B3 live deploy** — B3c needs a real AAF Azure deploy + flag flip; this is operator-run and gated, so it's sequenced after the offline work and not on the critical path for the other features.
+- **Anthropic cost is an estimate** — label list-price-derived so dashboards don't imply invoice accuracy.
+- **Obsidian write-back data-safety** — governor stays source-of-truth; conflicts are reported and skipped, never silently overwritten; export takes a baseline snapshot for the diff.


### PR DESCRIPTION
## What

Brings the five v1.3 planning artifacts into main, recovered from the now-removed `plan/v1.3-release` branch. They sit under `docs/superpowers/`, alongside the older June-19 plans already committed there.

- `plans/2026-06-24-b2-sandbox-port.md`
- `plans/2026-06-24-b3-observability.md`
- `plans/2026-06-24-obsidian-memory-interface.md`
- `plans/2026-06-24-turnkey-scaffold-cicd-page.md`
- `specs/2026-06-24-aaf-v1.3-release-design.md`

## Sanitization note

The four plan docs were already clean. The release-design spec named the private platform 8 times (internal test paths, the "public mirror of X" relationship, an internal PR number). I genericized those to "the private platform" to match how the public README and docs are written. The repo's `scan-internal-refs.sh` passed before and after (it scans for hostnames and secrets, not the platform name), so this is about posture, not a CI failure.

The original, unsanitized planning content remains recoverable from commit `a7626d1`.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)