### PR TITLE
fix(deploy): pin postgres admin username via repo var (prevents destructive server replacement)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -226,6 +226,7 @@ jobs:
             -var="ai_foundry_deployment_id=${{ vars.AI_FOUNDRY_DEPLOYMENT_ID }}" \
             -var='keyvault_admin_object_ids=${{ vars.KEYVAULT_ADMIN_OBJECT_IDS }}' \
             -var="observability_enabled=${{ vars.OBSERVABILITY_ENABLED || 'false' }}" \
+            -var="postgres_admin_username=${{ vars.POSTGRES_ADMIN_USERNAME || 'dbadmin' }}" \
             ${{ steps.img.outputs.vars }} \
             -out=tfplan
 


### PR DESCRIPTION
The v1.4 sanitization changed the default `postgres_admin_username` from `vaultadmin` to `dbadmin`. On Azure, `administrator_login` forces **full PostgreSQL Flexible Server replacement** — deploy run 28752210051 planned to destroy and recreate `aaf-vault-dev-postgres` (including the honcho database). The destroy-aware gate caught it.

This threads `postgres_admin_username` through the plan step from an optional `POSTGRES_ADMIN_USERNAME` repo variable (same pattern as `OBSERVABILITY_ENABLED`), falling back to the sanitized `dbadmin` default for fresh installs. Existing deployments set the repo var to their original login and plan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)