### PR TITLE
docs: v1.6 port plan — MRTek dream-features into AAF (six waves)

### DIFF
--- a/docs/plans/v1.6-mrtek-feature-port.md
+++ b/docs/plans/v1.6-mrtek-feature-port.md
@@ -1,0 +1,68 @@
+# v1.6 port plan — MRTek dream-features → AAF
+
+**Written 2026-07-07** after the MRTek sprint shipped PRs #197–#220 (all merged
++ deployed there). AAF is at the ~mid-June platform state (migrations end at
+0008; v1.5 added governed-memory enablement, retrieval obs, aca-job contract,
+cost governance, HITL approval). Everything below exists, tested and
+live-proven, in `mrt-ai-agent-platform` — this is a PORT, not a design task.
+
+## Ground rules (from AAF's locked decisions)
+
+- Branch from `public/main`; PR per wave; NEVER genericize `ca-*-dev`
+  hostnames (PR #17 lesson); keep owner-name sanitization (no "Michael",
+  no client names, no mrtek.ai URLs — use `example.com` placeholders).
+- File-name mapping: MRTek `apps/paperclip/outbound-approval.mjs` ↔ AAF
+  `apps/paperclip/approval.mjs`; MRTek `services/watchdog/` ↔ AAF
+  `services/watchdog/` (verify per-file drift with diff before patching —
+  anchors may differ).
+- Strip MRTek-specific integrations: Lacy webhook → generic
+  `call-ended` webhook; BlueBubbles/iMessage → keep behind the existing
+  generic inbound webhook; Discord stays (AAF has Slack/Teams bridges too —
+  port Discord-only first, note bridge parity as follow-up).
+
+## Waves (each = one PR, tests green before the next)
+
+**Wave 1 — event spine + reads (governor only, cleanest port):**
+`timeline.py` (+ redaction allowlist), `/timeline`, `/memory/{id}/history`,
+`/tenant/memory/{id}/history`, migration `0009_agent_events_payload_index`
+(renumber from MRTek 0022), workspace-attributed memory_action events.
+Port tests 1:1 (`tests/memory-governor/test_timeline.py`).
+
+**Wave 2 — proof report + usage sink + morning brief + autonomy:**
+migration for `tenant_usage` + flags (from MRTek 0021), `proof_report*.py`,
+`morning_brief*.py`, `autonomy.py`, governor endpoints, router usage sink
+(`enqueue_usage` in `services/model-router`), `/run-cost`. Note: AAF's router
+may lack the §0.7 run ledger — port `_run_spend` machinery with it.
+
+**Wave 3 — pre-send eval + Commitment Firewall + approve-safe:**
+`presend-eval.mjs` (pure) + auth-proxy glue + `safe_rewrite` + the SAFE
+button in `approval.mjs` (adapt anchors — file diverged). Golden-drafts
+corpus ports as fixtures.
+
+**Wave 4 — tenant surfaces:** `tenant-memory.mjs` route additions
+(trust-room/timeline/history/ask), governor `/tenant/trust-room` + `/tenant/ask`,
+`trust-room.html` (rebrand: AAF logo/name, keep fragment-token contract +
+its 6 contract tests), `mint_tenant_jwt` + link CLI.
+
+**Wave 5 — reliability kit:** durable inbound GUID dedupe (`SeenGuidStore`),
+watchdog process-loss exclusion + error-field quoting, autonomy posture
+proposals, consent store (generic SMS webhook), assessment-handoff contract
+(genericize the agent name).
+
+**Wave 6 — simulation + packs:** `tenantconsole/simulate.py`, scenario
+schema, `validate-packs` CLI + CI step, one example vertical pack
+(sanitized), `patch-adapter-run-cost.mjs` (+ run-finished events; verify
+AAF's vendored adapter version matches the anchor — FATAL guard will tell).
+
+## Verification per wave
+
+Run the ported test files (they come with the port) + AAF's existing suites;
+Wave-by-wave the count should grow by ~roughly: W1 +12, W2 +25, W3 +45,
+W4 +15, W5 +25, W6 +15. Live smoke on the AAF dev deployment mirrors
+docs there; the MRTek smoke list is in that repo's plan doc.
+
+## Not ported (MRTek-specific)
+
+Mac-site deploy artifacts (LaunchAgents, nightly-sim.sh — AAF uses ACA jobs:
+write `aca-job` twins instead), Lacy/BlueBubbles specifics, Tyrion persona
+content, mrtek.ai website pieces.


### PR DESCRIPTION
Port map for everything shipped in the MRTek sprint (PRs #197–#220): event spine, proof/usage/morning-brief/autonomy, presend+firewall, tenant surfaces incl. Trust Room, reliability kit, simulation+packs. Each wave = one PR with its tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)