### PR TITLE
feat(examples): governed-transaction-saga — event-sourced governance core (v1.7 P3)

### DIFF
--- a/examples/governed-transaction-saga/README.md
+++ b/examples/governed-transaction-saga/README.md
@@ -1,0 +1,95 @@
+# Governed Transaction Saga
+
+A compact, dependency-free **event-sourced governance core**. It shows the
+minimum machinery that makes an autonomous action *governable*: you can always
+say what happened, in what order, why, and whether every action that needed
+proof actually carries it.
+
+The worked scenario is a fictional **appliance-repair job** (all data invented,
+no real customers, phones, or keys). Everything is pure Python standard library
+and runs locally — no Azure subscription, no network, no secrets.
+
+```
+saga/
+  events.py     append-only, idempotent event log (tenant/correlation/causation ids)
+  machine.py    Stage enum + pure fold/apply state machine (IllegalTransition)
+  receipts.py   complete-at-write receipts (ReceiptStore refuses incomplete writes)
+  audit.py      chronological narrative + receipt-gap report (findings, not exceptions)
+tests/          pytest suite (15 tests)
+```
+
+## The four ideas
+
+1. **Append-only log (`events.py`).** State is never mutated in place. Every
+   change is an immutable `Event` carrying a `tenant_id` (isolation boundary), a
+   `correlation_id` (which job), and a `causation_id` (which event caused this
+   one). The log is **idempotent by event id**, so a redelivered message is a
+   safe no-op — the foundation for at-least-once delivery and clean replay.
+
+2. **Fold/apply machine (`machine.py`).** The current state is *derived* by
+   folding the event stream through a pure `apply(state, event)` function. The
+   legal life-cycle is `REQUESTED → SCHEDULED → DISPATCHED → IN_PROGRESS →
+   COMPLETED`, with `CANCELLED` reachable from any live stage; both terminals are
+   sinks. Any move off those edges raises `IllegalTransition`. Same events in,
+   same state out — always.
+
+3. **Complete-at-write receipts (`receipts.py`).** A receipt is durable proof
+   that a governed action happened *with* its required evidence. `ReceiptStore`
+   refuses — at write time, before anything is persisted — any receipt missing a
+   field it claims to require. There is no half-written receipt in the store.
+
+4. **Audit walk (`audit.py`).** `narrate()` produces a chronological,
+   human-readable story of the saga. `audit()` adds a **receipt-gap report** in
+   which a missing or incomplete receipt is a **named `Finding`**, never an
+   exception — because a report that throws on the first problem can't enumerate
+   the rest, and enumeration is the point of an audit.
+
+## How this maps to AzureAgentForge
+
+This example is the sanitized skeleton of the governance features the platform
+ships:
+
+- **HITL approval → receipts.** In AAF, a human-in-the-loop approval gate is
+  what lets a risky agent action proceed. The receipt here is exactly that
+  gate's durable artifact: the action does not count as governed until the
+  proof of approval (who, what, evidence) is written *completely*. The
+  complete-at-write rule is the code form of "no approval, no action."
+
+- **Memory governor → audit walk.** The governor's job is to scan the record of
+  what agents did and flag what falls short of policy. `audit()` is that scan in
+  miniature: it walks the append-only log and returns findings for every action
+  that should carry a receipt but doesn't — a gap becomes a reviewable line
+  item, not a crash.
+
+- **Tenant isolation → the id triplet.** Multi-tenant governance depends on
+  never crossing streams. `for_correlation(corr, tenant_id=...)` enforces the
+  boundary the same way the platform scopes every memory and event read.
+
+Feature-flag posture matches the release rules: there are no flags to flip here
+and nothing that reaches a live service — it is a read-and-test-locally
+reference for the pattern.
+
+## Run the tests
+
+```bash
+cd examples/governed-transaction-saga
+python3 -m pytest -q
+```
+
+## Try it
+
+```python
+from saga import Event, fold, audit, ReceiptStore, Receipt
+
+TENANT, JOB = "tenant_demo", "job_42"
+e = lambda t, **p: Event(t, TENANT, JOB, payload=p)
+
+events = [e("job.requested"), e("job.scheduled"), e("job.dispatched"),
+          e("job.started"), e("job.completed")]
+
+print(fold(events).stage)              # Stage.COMPLETED
+
+report = audit(events, ReceiptStore())  # no receipts filed yet
+for f in report.findings:
+    print(f.kind, f.event_type)         # MISSING_RECEIPT job.dispatched / job.completed
+```

--- a/examples/governed-transaction-saga/conftest.py
+++ b/examples/governed-transaction-saga/conftest.py
@@ -1,0 +1,5 @@
+"""Put the example root on sys.path so ``import saga`` works from any cwd."""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))

--- a/examples/governed-transaction-saga/saga/__init__.py
+++ b/examples/governed-transaction-saga/saga/__init__.py
@@ -1,0 +1,30 @@
+"""Governed transaction saga — an event-sourced governance core (example).
+
+A compact, dependency-free distillation of the pattern AzureAgentForge uses to
+make agent actions governable: an append-only event log, a fold/apply state
+machine, complete-at-write receipts, and an audit walk that names gaps instead
+of throwing. The worked scenario is a fictional appliance-repair job.
+"""
+from .audit import AuditReport, Finding, RECEIPTED_EVENTS, audit, narrate
+from .events import Event, EventLog, new_id
+from .machine import IllegalTransition, SagaState, Stage, apply, fold
+from .receipts import IncompleteReceipt, Receipt, ReceiptStore
+
+__all__ = [
+    "Event",
+    "EventLog",
+    "new_id",
+    "Stage",
+    "SagaState",
+    "IllegalTransition",
+    "apply",
+    "fold",
+    "Receipt",
+    "ReceiptStore",
+    "IncompleteReceipt",
+    "AuditReport",
+    "Finding",
+    "RECEIPTED_EVENTS",
+    "audit",
+    "narrate",
+]

--- a/examples/governed-transaction-saga/saga/audit.py
+++ b/examples/governed-transaction-saga/saga/audit.py
@@ -1,0 +1,111 @@
+"""The audit walk: a chronological narrative plus a receipt-gap report.
+
+The auditor *describes* history; it never re-enforces the rules. So an illegal
+transition is written into the narrative as a line, and a missing receipt is
+returned as a named :class:`Finding` — never raised. A report that raises on
+the first problem cannot enumerate all the problems, and enumeration is the
+whole point of an audit.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Optional
+
+from .events import Event
+from .machine import IllegalTransition, SagaState, apply
+from .receipts import ReceiptStore
+
+# Policy: which event types MUST carry a receipt, and the evidence it must hold.
+# (The receipt independently records its own required fields; this is the
+# auditor's copy of the policy, so a gap is caught even if no receipt exists.)
+RECEIPTED_EVENTS: dict[str, tuple[str, ...]] = {
+    "job.dispatched": ("technician", "eta"),
+    "job.completed": ("technician", "work_summary", "customer_signature"),
+}
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A named audit problem. Data, not an exception."""
+
+    kind: str  # e.g. "MISSING_RECEIPT", "INCOMPLETE_RECEIPT", "ILLEGAL_TRANSITION"
+    event_id: str
+    event_type: str
+    detail: str
+
+
+@dataclass
+class AuditReport:
+    correlation_id: str
+    narrative: list[str] = field(default_factory=list)
+    findings: list[Finding] = field(default_factory=list)
+
+    @property
+    def clean(self) -> bool:
+        return not self.findings
+
+
+def narrate(events: Iterable[Event]) -> list[str]:
+    """Return a human-readable chronological narrative of the saga.
+
+    Walks events in order, re-deriving the stage at each step. An illegal
+    transition is recorded as a ``!!`` line rather than raised — the audit
+    reports what happened, warts and all.
+    """
+    lines: list[str] = []
+    state: Optional[SagaState] = None
+    for i, event in enumerate(events, 1):
+        try:
+            state = apply(state, event)
+            lines.append(
+                f"{i:>2}. [{event.occurred_at}] {event.event_type} -> {state.stage.value}"
+            )
+        except IllegalTransition as exc:
+            lines.append(f"{i:>2}. [{event.occurred_at}] {event.event_type} !! {exc}")
+    return lines
+
+
+def audit(events: Iterable[Event], receipts: ReceiptStore) -> AuditReport:
+    """Produce the full audit: narrative + receipt-gap findings.
+
+    A required receipt that is absent becomes a ``MISSING_RECEIPT`` finding; a
+    present-but-incomplete one becomes ``INCOMPLETE_RECEIPT``. Neither raises.
+    """
+    events = list(events)
+    correlation_id = events[0].correlation_id if events else ""
+    report = AuditReport(correlation_id=correlation_id, narrative=narrate(events))
+
+    # Detect illegal transitions as findings too (narrative shows them inline).
+    state: Optional[SagaState] = None
+    for event in events:
+        try:
+            state = apply(state, event)
+        except IllegalTransition as exc:
+            report.findings.append(
+                Finding("ILLEGAL_TRANSITION", event.event_id, event.event_type, str(exc))
+            )
+
+    for event in events:
+        required = RECEIPTED_EVENTS.get(event.event_type)
+        if required is None:
+            continue
+        receipt = receipts.get(event.event_id)
+        if receipt is None:
+            report.findings.append(
+                Finding(
+                    "MISSING_RECEIPT",
+                    event.event_id,
+                    event.event_type,
+                    f"{event.event_type} requires a receipt; none on file",
+                )
+            )
+        elif not receipt.is_complete:
+            report.findings.append(
+                Finding(
+                    "INCOMPLETE_RECEIPT",
+                    event.event_id,
+                    event.event_type,
+                    f"receipt missing {', '.join(receipt.missing_fields())}",
+                )
+            )
+    return report

--- a/examples/governed-transaction-saga/saga/events.py
+++ b/examples/governed-transaction-saga/saga/events.py
@@ -1,0 +1,87 @@
+"""Append-only event log — the substrate the whole saga is built on.
+
+Every meaningful change in a service transaction is recorded as an immutable
+:class:`Event`. Nothing mutates state directly; state is *derived* by folding
+the event stream (see ``machine.py``). Three ids travel with every event so an
+auditor can reconstruct not just *what* happened but *why*:
+
+* ``tenant_id``       — which tenant the fact belongs to (isolation boundary).
+* ``correlation_id``  — which saga instance (one repair job) it belongs to.
+* ``causation_id``    — the id of the event that caused this one (cause/effect).
+
+The log is **append-only** and **idempotent by event id**: appending the same
+event twice is a no-op. That is what makes replay and at-least-once delivery
+safe — a redelivered message can never double-apply.
+"""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterator, Optional
+
+
+def new_id(prefix: str = "evt") -> str:
+    """A short, collision-resistant id. Fictional/local — no external service."""
+    return f"{prefix}_{uuid.uuid4().hex[:12]}"
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class Event:
+    """An immutable fact. Once appended to the log it never changes."""
+
+    event_type: str
+    tenant_id: str
+    correlation_id: str
+    payload: dict = field(default_factory=dict)
+    causation_id: Optional[str] = None
+    event_id: str = field(default_factory=lambda: new_id("evt"))
+    occurred_at: str = field(default_factory=_utcnow)
+
+
+class EventLog:
+    """An ordered, append-only, idempotent collection of events."""
+
+    def __init__(self) -> None:
+        self._events: list[Event] = []
+        self._ids: set[str] = set()
+
+    def append(self, event: Event) -> bool:
+        """Append ``event``. Idempotent by ``event_id``.
+
+        Returns ``True`` if the event was newly stored, ``False`` if it was a
+        duplicate and therefore ignored. The append order is the log's source
+        of chronological truth (it never depends on wall-clock timestamps).
+        """
+        if event.event_id in self._ids:
+            return False
+        self._ids.add(event.event_id)
+        self._events.append(event)
+        return True
+
+    def extend(self, events: Iterator[Event]) -> int:
+        """Append many events; return how many were newly stored."""
+        return sum(1 for e in events if self.append(e))
+
+    def for_correlation(
+        self, correlation_id: str, tenant_id: Optional[str] = None
+    ) -> list[Event]:
+        """All events for one saga instance, optionally scoped to a tenant.
+
+        Passing ``tenant_id`` enforces the isolation boundary: even if two
+        tenants somehow shared a correlation id, you only ever see your own.
+        """
+        out = [e for e in self._events if e.correlation_id == correlation_id]
+        if tenant_id is not None:
+            out = [e for e in out if e.tenant_id == tenant_id]
+        return out
+
+    def __iter__(self) -> Iterator[Event]:
+        return iter(self._events)
+
+    def __len__(self) -> int:
+        return len(self._events)

--- a/examples/governed-transaction-saga/saga/machine.py
+++ b/examples/governed-transaction-saga/saga/machine.py
@@ -1,0 +1,107 @@
+"""Fold/apply state machine for one service transaction (an appliance-repair job).
+
+The current state is never stored; it is *computed* by folding the event stream
+through a pure ``apply`` function. Because ``apply`` is pure and total over its
+declared edges, the same events always produce the same state — the property
+that makes an event-sourced system auditable and replay-safe.
+
+The legal life-cycle of a repair job::
+
+    REQUESTED -> SCHEDULED -> DISPATCHED -> IN_PROGRESS -> COMPLETED
+        \\___________\\____________\\_____________\\-------> CANCELLED
+
+Any move off those edges raises :class:`IllegalTransition`. COMPLETED and
+CANCELLED are terminal.
+"""
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, replace
+from typing import Iterable, Optional
+
+from .events import Event
+
+
+class Stage(enum.Enum):
+    REQUESTED = "requested"
+    SCHEDULED = "scheduled"
+    DISPATCHED = "dispatched"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+
+
+class IllegalTransition(Exception):
+    """Raised when an event would traverse an edge the machine does not allow."""
+
+
+# Which stage each event type drives the saga toward.
+_EVENT_STAGE: dict[str, Stage] = {
+    "job.requested": Stage.REQUESTED,
+    "job.scheduled": Stage.SCHEDULED,
+    "job.dispatched": Stage.DISPATCHED,
+    "job.started": Stage.IN_PROGRESS,
+    "job.completed": Stage.COMPLETED,
+    "job.cancelled": Stage.CANCELLED,
+}
+
+# Legal outgoing edges. ``None`` is the pre-creation state.
+_ALLOWED: dict[Optional[Stage], set[Stage]] = {
+    None: {Stage.REQUESTED},
+    Stage.REQUESTED: {Stage.SCHEDULED, Stage.CANCELLED},
+    Stage.SCHEDULED: {Stage.DISPATCHED, Stage.CANCELLED},
+    Stage.DISPATCHED: {Stage.IN_PROGRESS, Stage.CANCELLED},
+    Stage.IN_PROGRESS: {Stage.COMPLETED, Stage.CANCELLED},
+    Stage.COMPLETED: set(),
+    Stage.CANCELLED: set(),
+}
+
+_TERMINAL = {Stage.COMPLETED, Stage.CANCELLED}
+
+
+@dataclass(frozen=True)
+class SagaState:
+    """The derived state of one job. Immutable; ``apply`` returns a new one."""
+
+    correlation_id: str
+    tenant_id: str
+    stage: Optional[Stage] = None
+    history: tuple[Stage, ...] = ()
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.stage in _TERMINAL
+
+
+def apply(state: Optional[SagaState], event: Event) -> SagaState:
+    """Pure transition: ``(state, event) -> next state``.
+
+    Raises :class:`IllegalTransition` if the event's target stage is not
+    reachable from the current stage (including unknown event types).
+    """
+    target = _EVENT_STAGE.get(event.event_type)
+    if target is None:
+        raise IllegalTransition(f"unknown event type {event.event_type!r}")
+
+    current = state.stage if state is not None else None
+    if target not in _ALLOWED[current]:
+        raise IllegalTransition(
+            f"cannot move {current.value if current else 'START'} -> "
+            f"{target.value} via {event.event_type!r}"
+        )
+
+    if state is None:
+        state = SagaState(event.correlation_id, event.tenant_id)
+    return replace(state, stage=target, history=state.history + (target,))
+
+
+def fold(events: Iterable[Event]) -> Optional[SagaState]:
+    """Reduce an event stream to its final state by folding ``apply`` over it.
+
+    Returns ``None`` for an empty stream. Raises :class:`IllegalTransition` at
+    the first event that violates the machine.
+    """
+    state: Optional[SagaState] = None
+    for event in events:
+        state = apply(state, event)
+    return state

--- a/examples/governed-transaction-saga/saga/receipts.py
+++ b/examples/governed-transaction-saga/saga/receipts.py
@@ -1,0 +1,79 @@
+"""Complete-at-write receipts.
+
+A *receipt* is the durable proof that a governed action really happened with
+all of its required evidence — the technician who was dispatched, the work
+summary and customer signature captured at completion. The governing rule is
+**complete-at-write**: the store refuses to persist a receipt that is missing
+any field it claims to require. There is no such thing as a half-written
+receipt sitting in the store waiting to be finished later. Either the evidence
+exists at the moment of writing, or nothing is written.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Mapping, Optional
+
+from .events import new_id
+
+
+class IncompleteReceipt(Exception):
+    """Raised at write time when a receipt is missing one or more required fields."""
+
+
+@dataclass(frozen=True)
+class Receipt:
+    """Proof attached to a specific event. Records the fields it requires."""
+
+    receipt_type: str
+    event_id: str  # the event this receipt attests to
+    tenant_id: str
+    required_fields: tuple[str, ...] = ()
+    fields: Mapping[str, object] = field(default_factory=dict)
+    receipt_id: str = field(default_factory=lambda: new_id("rcpt"))
+    issued_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+    def missing_fields(self) -> list[str]:
+        """Required fields that are absent or empty (``None`` / ``""``)."""
+        return [
+            name
+            for name in self.required_fields
+            if name not in self.fields or self.fields[name] in (None, "")
+        ]
+
+    @property
+    def is_complete(self) -> bool:
+        return not self.missing_fields()
+
+
+class ReceiptStore:
+    """Keyed by the event id a receipt attests to; refuses incomplete writes."""
+
+    def __init__(self) -> None:
+        self._by_event: dict[str, Receipt] = {}
+
+    def put(self, receipt: Receipt) -> Receipt:
+        """Persist ``receipt`` — or refuse it.
+
+        Raises :class:`IncompleteReceipt` (before any state is written) if the
+        receipt is missing required fields. This is the complete-at-write gate.
+        """
+        missing = receipt.missing_fields()
+        if missing:
+            raise IncompleteReceipt(
+                f"receipt {receipt.receipt_type!r} for event {receipt.event_id} "
+                f"missing required field(s): {', '.join(missing)}"
+            )
+        self._by_event[receipt.event_id] = receipt
+        return receipt
+
+    def get(self, event_id: str) -> Optional[Receipt]:
+        return self._by_event.get(event_id)
+
+    def has(self, event_id: str) -> bool:
+        return event_id in self._by_event
+
+    def __len__(self) -> int:
+        return len(self._by_event)

--- a/examples/governed-transaction-saga/tests/test_saga.py
+++ b/examples/governed-transaction-saga/tests/test_saga.py
@@ -1,0 +1,201 @@
+"""Tests for the governed-transaction-saga example. Pure stdlib + pytest."""
+import pytest
+
+from saga import (
+    AuditReport,
+    Event,
+    EventLog,
+    IllegalTransition,
+    IncompleteReceipt,
+    Receipt,
+    ReceiptStore,
+    Stage,
+    apply,
+    audit,
+    fold,
+    narrate,
+    new_id,
+)
+
+TENANT = "tenant_acme"
+CORR = "job_0001"
+
+
+def _event(event_type, causation_id=None, **payload):
+    return Event(
+        event_type=event_type,
+        tenant_id=TENANT,
+        correlation_id=CORR,
+        causation_id=causation_id,
+        payload=payload,
+    )
+
+
+def _happy_events():
+    """A full, legal life-cycle: requested -> ... -> completed, causation-linked."""
+    e1 = _event("job.requested", appliance="dishwasher")
+    e2 = _event("job.scheduled", causation_id=e1.event_id, window="Tue AM")
+    e3 = _event("job.dispatched", causation_id=e2.event_id, technician="Dana")
+    e4 = _event("job.started", causation_id=e3.event_id)
+    e5 = _event("job.completed", causation_id=e4.event_id)
+    return [e1, e2, e3, e4, e5]
+
+
+def _complete_store(events):
+    """A receipt store satisfying the audit policy for the happy path."""
+    store = ReceiptStore()
+    by_type = {e.event_type: e for e in events}
+    store.put(
+        Receipt(
+            "dispatch",
+            by_type["job.dispatched"].event_id,
+            TENANT,
+            ("technician", "eta"),
+            {"technician": "Dana", "eta": "09:30"},
+        )
+    )
+    store.put(
+        Receipt(
+            "completion",
+            by_type["job.completed"].event_id,
+            TENANT,
+            ("technician", "work_summary", "customer_signature"),
+            {
+                "technician": "Dana",
+                "work_summary": "Replaced inlet valve",
+                "customer_signature": "R. Kim",
+            },
+        )
+    )
+    return store
+
+
+# --- event log -------------------------------------------------------------
+
+
+def test_happy_path_folds_to_completed():
+    state = fold(_happy_events())
+    assert state.stage is Stage.COMPLETED
+    assert state.is_terminal
+    assert state.history[0] is Stage.REQUESTED
+    assert state.history[-1] is Stage.COMPLETED
+
+
+def test_duplicate_event_is_idempotent_noop():
+    log = EventLog()
+    e = _event("job.requested")
+    assert log.append(e) is True
+    assert log.append(e) is False  # same event id -> ignored
+    assert len(log) == 1
+
+
+def test_for_correlation_scopes_by_tenant():
+    log = EventLog()
+    mine = _event("job.requested")
+    theirs = Event("job.requested", "tenant_other", CORR)
+    log.append(mine)
+    log.append(theirs)
+    scoped = log.for_correlation(CORR, tenant_id=TENANT)
+    assert scoped == [mine]  # the other tenant's event is invisible
+
+
+def test_causation_chain_preserved():
+    events = _happy_events()
+    for parent, child in zip(events, events[1:]):
+        assert child.causation_id == parent.event_id
+
+
+# --- state machine ---------------------------------------------------------
+
+
+def test_illegal_transition_raises():
+    e1 = _event("job.requested")
+    e_bad = _event("job.completed")  # can't jump requested -> completed
+    with pytest.raises(IllegalTransition):
+        fold([e1, e_bad])
+
+
+def test_unknown_event_type_is_illegal():
+    with pytest.raises(IllegalTransition):
+        apply(None, _event("job.teleported"))
+
+
+def test_cancelled_is_terminal_no_further_moves():
+    e1 = _event("job.requested")
+    e2 = _event("job.cancelled")
+    state = fold([e1, e2])
+    assert state.stage is Stage.CANCELLED
+    with pytest.raises(IllegalTransition):
+        apply(state, _event("job.scheduled"))
+
+
+def test_fold_empty_stream_is_none():
+    assert fold([]) is None
+
+
+# --- receipts (complete-at-write) ------------------------------------------
+
+
+def test_incomplete_receipt_refused_at_write():
+    store = ReceiptStore()
+    r = Receipt(
+        "completion",
+        new_id("evt"),
+        TENANT,
+        ("technician", "work_summary", "customer_signature"),
+        {"technician": "Dana"},  # missing two required fields
+    )
+    with pytest.raises(IncompleteReceipt):
+        store.put(r)
+    assert len(store) == 0  # nothing partial was written
+
+
+def test_complete_receipt_is_accepted_and_stored():
+    store = ReceiptStore()
+    eid = new_id("evt")
+    r = Receipt("dispatch", eid, TENANT, ("technician", "eta"),
+                {"technician": "Dana", "eta": "09:30"})
+    store.put(r)
+    assert store.has(eid)
+    assert store.get(eid).is_complete
+
+
+def test_empty_string_counts_as_missing():
+    r = Receipt("dispatch", new_id("evt"), TENANT, ("technician", "eta"),
+                {"technician": "Dana", "eta": ""})
+    assert r.missing_fields() == ["eta"]
+
+
+# --- audit walk ------------------------------------------------------------
+
+
+def test_audit_clean_when_all_receipts_present():
+    events = _happy_events()
+    report = audit(events, _complete_store(events))
+    assert isinstance(report, AuditReport)
+    assert report.clean, report.findings
+
+
+def test_gap_report_on_stripped_log_is_a_finding_not_an_exception():
+    events = _happy_events()
+    store = _complete_store(events)
+    # Strip the completion receipt to simulate a governance gap.
+    completed = next(e for e in events if e.event_type == "job.completed")
+    del store._by_event[completed.event_id]
+    report = audit(events, store)  # must NOT raise
+    kinds = [(f.kind, f.event_type) for f in report.findings]
+    assert ("MISSING_RECEIPT", "job.completed") in kinds
+    assert not report.clean
+
+
+def test_narrative_is_chronological():
+    lines = narrate(_happy_events())
+    assert len(lines) == 5
+    assert "-> requested" in lines[0]
+    assert "-> completed" in lines[-1]
+    assert lines[0].startswith(" 1.") and lines[4].startswith(" 5.")
+
+
+def test_narrative_records_illegal_transition_without_raising():
+    lines = narrate([_event("job.requested"), _event("job.completed")])
+    assert "!!" in lines[1]  # illegal move noted, not raised


### PR DESCRIPTION
## What

v1.7 release package **P3**: `examples/governed-transaction-saga/` — a compact (~380 lines + tests), dependency-free distillation of the platform's governed-transaction pattern, written fresh for a fictional appliance-repair job.

## Modules (pure Python stdlib)

- **`events.py`** — append-only event log; immutable `Event` carries tenant / correlation / causation ids; **idempotent by event id** (redelivery is a no-op).
- **`machine.py`** — `Stage` enum + pure `fold`/`apply` state machine; illegal edges raise `IllegalTransition`.
- **`receipts.py`** — **complete-at-write** receipts; `ReceiptStore.put()` refuses an incomplete receipt before persisting anything.
- **`audit.py`** — chronological `narrate()` + `audit()` receipt-gap report where a missing receipt is a named `Finding`, never an exception.

## Tests

`python3 -m pytest -q` → **15 passed**. Covers happy-path fold, idempotent duplicate append, illegal transition, incomplete-receipt refusal, and the gap report on a stripped log (a finding, not a raise).

## README

Ties the pattern to AAF's **HITL-approval** (receipt = the approval gate's durable artifact; complete-at-write = "no approval, no action") and **memory-governor** (the audit walk is the governor's policy scan in miniature) features.

## Sanitization

All data fictional and labeled; no MRTek/tenant names, phones, keys, or internal hostnames; no feature flags; no `deploy.yml` touched; nothing requires a live Azure subscription — reads and tests entirely locally. Owns only `examples/governed-transaction-saga/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)