### PR TITLE
revert: python 3.14 bump for honcho (#98) — smoke suite fails on 3.14

### DIFF
--- a/services/honcho/Dockerfile
+++ b/services/honcho/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM ghcr.io/astral-sh/uv:0.11.28 AS uv
 
-FROM python:3.14-slim-bookworm AS base
+FROM python:3.13-slim-bookworm AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
PR #98 was merged in error while its two smoke checks were failing (my merge command didn't gate on check status). Reverting to keep main green for the v1.7 release; dependabot can re-propose once the honcho image supports 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)