### PR TITLE
chore(vendor): Honcho 3.0.11 + PaperClip 2026.707.0 (Hermes 0.18.1 deferred)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,13 +94,15 @@ POSTGRES_DB=
 POSTGRES_PASSWORD_URLENC=
 
 # ── Honcho reasoning levels (memory service) ──────────────────────────────────
-# Honcho builds an LLM client for its summary/deriver specialists and for all
-# five dialectic reasoning levels (minimal/low/medium/high/max) at startup, and
-# crash-loops if any level lacks a provider+model. docker-compose.yml sets sane
-# OpenAI-compatible defaults; override here to change provider/model per level.
-SUMMARY_PROVIDER=openai
+# Honcho >= 3.0.7 configures each specialist (summary/deriver) and each of the
+# five dialectic reasoning levels via a nested MODEL_CONFIG (transport + model),
+# NOT the old flat *_PROVIDER / *_MODEL keys — those are now silently ignored and
+# fall back to openai/gpt-5.4-mini. These knobs feed docker-compose.yml's
+# SUMMARY_MODEL_CONFIG__* / DERIVER_MODEL_CONFIG__* env. `transport` is one of
+# openai|anthropic|gemini. See services/honcho/README.md for the migration note.
+SUMMARY_TRANSPORT=openai
 SUMMARY_MODEL=gpt-4o-mini
-DERIVER_PROVIDER=openai
+DERIVER_TRANSPORT=openai
 DERIVER_MODEL=gpt-4o-mini
 
 # ── Messaging / Bot surfaces ──────────────────────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,44 +114,45 @@ services:
       # userinfo (libpq/SQLAlchemy reject raw special chars there); defaults to
       # the plain password, which is safe for the local dev default.
       DB_CONNECTION_URI: postgresql+psycopg://${POSTGRES_USER:-aaf}:${POSTGRES_PASSWORD_URLENC:-${POSTGRES_PASSWORD:-localdev}}@postgres:5432/${POSTGRES_DB:-aaf}
-      # Honcho constructs an LLM client per specialist AT IMPORT (deriver/summary
-      # default to google, dream to anthropic) and raises "Missing client" if the
-      # key is absent. Placeholder keys let it BOOT with no creds; the deriver's
-      # actual memory processing needs real keys (override to drive it).
+      # Honcho resolves an LLM client per specialist from its MODEL_CONFIG
+      # (transport + model); the built-in 3.0.x defaults are openai/gpt-5.4-mini
+      # for every specialist. Placeholder keys let the API BOOT with no real
+      # creds (clients are built lazily at call time, not at import); the
+      # deriver's actual memory processing needs real keys (override to drive it).
       LLM_ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-localdev-honcho-placeholder}
       LLM_OPENAI_API_KEY: ${OPENAI_API_KEY:-localdev-honcho-placeholder}
       LLM_GEMINI_API_KEY: ${GEMINI_API_KEY:-localdev-honcho-placeholder}
-      # Reasoning-level config. Honcho's summary/deriver specialists and its five
-      # dialectic reasoning levels each build an LLM client from a PROVIDER+MODEL
-      # pair at startup; if ANY of the five levels (minimal/low/medium/high/max)
-      # is missing its provider+model the service crash-loops on boot. Point them
-      # all at the OpenAI-compatible provider with a small default model so the
-      # stack comes up; override per level to tune cost/latency.
-      SUMMARY_PROVIDER: ${SUMMARY_PROVIDER:-openai}
-      SUMMARY_MODEL: ${SUMMARY_MODEL:-gpt-4o-mini}
-      DERIVER_PROVIDER: ${DERIVER_PROVIDER:-openai}
-      DERIVER_MODEL: ${DERIVER_MODEL:-gpt-4o-mini}
-      # Nested pydantic-settings path (env_prefix DIALECTIC_ + "__" delimiter);
-      # the flat DIALECTIC_MINIMAL_PROVIDER form is silently ignored.
-      DIALECTIC_LEVELS__minimal__PROVIDER: openai
-      DIALECTIC_LEVELS__minimal__MODEL: gpt-4o-mini
-      DIALECTIC_LEVELS__minimal__THINKING_BUDGET_TOKENS: "0"
+      # ── Per-specialist model config (Honcho >= 3.0.7 schema) ─────────────────
+      # 3.0.7 REPLACED the flat SUMMARY_PROVIDER / DERIVER_PROVIDER /
+      # DIALECTIC_LEVELS__<lvl>__PROVIDER form with a nested MODEL_CONFIG
+      # (fields: transport + model). The old flat keys are now SILENTLY IGNORED
+      # (pydantic-settings extra="ignore"), so an un-migrated config falls back to
+      # the built-in default (openai/gpt-5.4-mini) instead of your intended model.
+      # `transport` is one of openai|anthropic|gemini; to reach an OpenAI-compatible
+      # proxy set <SECTION>_MODEL_CONFIG__OVERRIDES__BASE_URL. See
+      # services/honcho/README.md for the full migration note.
+      SUMMARY_MODEL_CONFIG__TRANSPORT: ${SUMMARY_TRANSPORT:-openai}
+      SUMMARY_MODEL_CONFIG__MODEL: ${SUMMARY_MODEL:-gpt-4o-mini}
+      DERIVER_MODEL_CONFIG__TRANSPORT: ${DERIVER_TRANSPORT:-openai}
+      DERIVER_MODEL_CONFIG__MODEL: ${DERIVER_MODEL:-gpt-4o-mini}
+      # All five dialectic reasoning levels (minimal/low/medium/high/max) carry
+      # built-in openai/gpt-5.4-mini defaults in 3.0.11, but we pin them to the
+      # same small model for a predictable, low-cost local default. Nested path:
+      # env_prefix DIALECTIC_ + "__" delimiter + the MODEL_CONFIG sub-model.
+      DIALECTIC_LEVELS__minimal__MODEL_CONFIG__TRANSPORT: openai
+      DIALECTIC_LEVELS__minimal__MODEL_CONFIG__MODEL: gpt-4o-mini
       DIALECTIC_LEVELS__minimal__MAX_TOOL_ITERATIONS: "1"
-      DIALECTIC_LEVELS__low__PROVIDER: openai
-      DIALECTIC_LEVELS__low__MODEL: gpt-4o-mini
-      DIALECTIC_LEVELS__low__THINKING_BUDGET_TOKENS: "0"
+      DIALECTIC_LEVELS__low__MODEL_CONFIG__TRANSPORT: openai
+      DIALECTIC_LEVELS__low__MODEL_CONFIG__MODEL: gpt-4o-mini
       DIALECTIC_LEVELS__low__MAX_TOOL_ITERATIONS: "2"
-      DIALECTIC_LEVELS__medium__PROVIDER: openai
-      DIALECTIC_LEVELS__medium__MODEL: gpt-4o-mini
-      DIALECTIC_LEVELS__medium__THINKING_BUDGET_TOKENS: "0"
+      DIALECTIC_LEVELS__medium__MODEL_CONFIG__TRANSPORT: openai
+      DIALECTIC_LEVELS__medium__MODEL_CONFIG__MODEL: gpt-4o-mini
       DIALECTIC_LEVELS__medium__MAX_TOOL_ITERATIONS: "3"
-      DIALECTIC_LEVELS__high__PROVIDER: openai
-      DIALECTIC_LEVELS__high__MODEL: gpt-4o-mini
-      DIALECTIC_LEVELS__high__THINKING_BUDGET_TOKENS: "0"
+      DIALECTIC_LEVELS__high__MODEL_CONFIG__TRANSPORT: openai
+      DIALECTIC_LEVELS__high__MODEL_CONFIG__MODEL: gpt-4o-mini
       DIALECTIC_LEVELS__high__MAX_TOOL_ITERATIONS: "4"
-      DIALECTIC_LEVELS__max__PROVIDER: openai
-      DIALECTIC_LEVELS__max__MODEL: gpt-4o-mini
-      DIALECTIC_LEVELS__max__THINKING_BUDGET_TOKENS: "0"
+      DIALECTIC_LEVELS__max__MODEL_CONFIG__TRANSPORT: openai
+      DIALECTIC_LEVELS__max__MODEL_CONFIG__MODEL: gpt-4o-mini
       DIALECTIC_LEVELS__max__MAX_TOOL_ITERATIONS: "5"
     ports: ["${HONCHO_PORT:-8000}:8000"]
 
@@ -162,8 +163,8 @@ services:
       context: .
       dockerfile: services/paperclip/Dockerfile
       args:
-        PAPERCLIP_VERSION: ${PAPERCLIP_VERSION:-v2026.517.0}
-        PAPERCLIP_EXPECTED_SHA: ${PAPERCLIP_EXPECTED_SHA:-3e6610fb938d04638fa578a1fc0d119b434fa2e4}
+        PAPERCLIP_VERSION: ${PAPERCLIP_VERSION:-v2026.707.0}
+        PAPERCLIP_EXPECTED_SHA: ${PAPERCLIP_EXPECTED_SHA:-390627b46eb333309d357004384b220ecf8a65af}
     depends_on:
       postgres:
         condition: service_healthy

--- a/services/honcho/README.md
+++ b/services/honcho/README.md
@@ -1,0 +1,78 @@
+# Honcho memory service
+
+Vendored build of [plastic-labs/honcho](https://github.com/plastic-labs/honcho)
+(AGPL-3.0), pinned as a git submodule at `apps/honcho/src`.
+
+| | |
+|---|---|
+| **Pinned version** | `v3.0.11` (`14538cfc906c1d209983f69c3a703485b452f3c4`) |
+| **Upstream** | `github.com/plastic-labs/honcho` |
+| **License** | AGPL-3.0 (isolated to this image via the submodule boundary — no source-level mixing with AAF's MIT code; see repo `NOTICE`) |
+| **Port** | 8000 (health: `GET /openapi.json`) |
+| **Build** | `services/honcho/Dockerfile` (uv, Python 3.13, alembic-on-boot) |
+
+The Dockerfile installs from the submodule and runs `alembic upgrade head` on
+start, then `fastapi run src/main.py`. A **fresh database** is assumed (the AAF
+local stack starts an empty Postgres); migrating an existing pre-3.0 Honcho
+database is a larger, out-of-scope migration.
+
+---
+
+## ⚠️ NOTE — model config changed in Honcho 3.0.7 (flat `PROVIDER`/`MODEL` is gone)
+
+**If you copy an older Honcho env, the service will boot but silently use the
+wrong model.** As of **3.0.7** (upstream #459), the flat per-specialist keys were
+**removed** in favor of a nested `MODEL_CONFIG` sub-model:
+
+| Removed (pre-3.0.7, now **silently ignored**) | Replacement (3.0.7+) |
+|---|---|
+| `SUMMARY_PROVIDER` | `SUMMARY_MODEL_CONFIG__TRANSPORT` |
+| `SUMMARY_MODEL` | `SUMMARY_MODEL_CONFIG__MODEL` |
+| `DERIVER_PROVIDER` | `DERIVER_MODEL_CONFIG__TRANSPORT` |
+| `DERIVER_MODEL` | `DERIVER_MODEL_CONFIG__MODEL` |
+| `DIALECTIC_LEVELS__<lvl>__PROVIDER` | `DIALECTIC_LEVELS__<lvl>__MODEL_CONFIG__TRANSPORT` |
+| `DIALECTIC_LEVELS__<lvl>__MODEL` | `DIALECTIC_LEVELS__<lvl>__MODEL_CONFIG__MODEL` |
+| `DIALECTIC_LEVELS__<lvl>__THINKING_BUDGET_TOKENS` | `DIALECTIC_LEVELS__<lvl>__MODEL_CONFIG__THINKING_BUDGET_TOKENS` |
+
+**Why this bites silently:** every settings model uses pydantic-settings
+`extra="ignore"`, so the removed keys don't error — they're dropped. The
+per-specialist defaults are all `transport="openai"`, `model="gpt-5.4-mini"`
+(`src/config.py`). So an un-migrated deployment **falls back to direct-OpenAI
+`gpt-5.4-mini`** rather than the provider/model you thought you set. There is no
+warning; you find out from your OpenAI bill or from wrong answers.
+
+Notes on the new shape:
+- **`transport`** is a closed set: `openai` | `anthropic` | `gemini`. There is no
+  `custom` transport. To reach an **OpenAI-compatible proxy** (OpenRouter, vLLM,
+  a gateway, etc.), keep `transport=openai` and set the base URL:
+  `<SECTION>_MODEL_CONFIG__OVERRIDES__BASE_URL=https://your-proxy/v1`
+  (per-specialist) or `LLM_OPENAI_BASE_URL=...` (global default).
+- **All five** dialectic levels (`minimal`/`low`/`medium`/`high`/`max`) must
+  resolve; 3.0.11 fills any level you omit from built-in defaults, so a partial
+  config no longer crash-loops — it just uses defaults for the gaps.
+- The nested env format is `env_prefix` + `__` delimiter, e.g.
+  `DERIVER_MODEL_CONFIG__MODEL`, `DIALECTIC_LEVELS__high__MODEL_CONFIG__MODEL`.
+  A TOML equivalent (`config.toml`, `[deriver.model_config]` etc.) is also
+  supported — see the upstream `config.toml.example`.
+
+The AAF `docker-compose.yml` honcho service and `.env.example` already use the
+migrated shape (pinned to a small `gpt-4o-mini` default for cheap local runs).
+
+---
+
+## Operator notes
+
+- **API-only in this compose.** The Dockerfile runs the Honcho **API server**
+  only. Honcho's background **deriver** (memory formation) and reconciler run in
+  a separate process (`python -m src.deriver`) in upstream's own compose. The
+  local AAF stack serves the memory API and applies migrations, but does not run
+  the deriver — real memory derivation needs a deriver process **and** real LLM
+  keys.
+- **Placeholder keys boot fine.** `LLM_*_API_KEY` placeholders let the API start;
+  clients are constructed lazily at call time (not at import), so no key is
+  required just to bring the service up. Set real keys to actually drive
+  summary/deriver/dialectic work.
+- **Redis is optional.** Caching is off by default (`CACHE_ENABLED=false`); the
+  queue is Postgres-backed, so no Redis is required for the API to run.
+- **DB connection** uses `DB_CONNECTION_URI` (pydantic `env_prefix=DB_`) with the
+  psycopg3 scheme (`postgresql+psycopg://...`) — not `DATABASE_URL`.

--- a/services/paperclip/Dockerfile
+++ b/services/paperclip/Dockerfile
@@ -11,11 +11,11 @@
 # Port: 3100 (Paperclip default)
 # Data: /paperclip (mount an Azure File Share here for persistence)
 
-ARG PAPERCLIP_VERSION=v2026.517.0
+ARG PAPERCLIP_VERSION=v2026.707.0
 # Guard against git-tag drift: the build fails if the cloned tag resolves to a
 # commit other than this. Resolve with:
 #   git ls-remote https://github.com/paperclipai/paperclip refs/tags/<tag>
-ARG PAPERCLIP_EXPECTED_SHA=3e6610fb938d04638fa578a1fc0d119b434fa2e4
+ARG PAPERCLIP_EXPECTED_SHA=390627b46eb333309d357004384b220ecf8a65af
 ARG NODE_VERSION=lts-trixie-slim
 
 # ── Stage 0: upstream-style base image ────────────────────────────────────────
@@ -54,7 +54,7 @@ WORKDIR /app
 # Clone the pinned release tag, then verify the resolved commit matches the
 # expected SHA. A git tag is not immutable; this fails the build on tag drift.
 # CACHE_BUST invalidates Docker layer cache so a version change actually takes effect.
-ARG CACHE_BUST=2026-05-23
+ARG CACHE_BUST=2026-07-11
 RUN echo "cache-bust=${CACHE_BUST}" \
  && git clone --depth=1 --branch ${PAPERCLIP_VERSION} \
     https://github.com/paperclipai/paperclip.git . \


### PR DESCRIPTION
## v1.7 expansion package V1 — vendored-service upgrades

Brings AAF's vendored services toward this week's proven platform versions. **CI smoke gates this — do not merge until green.**

### Versions achieved

| Service | From | To | How | Status |
|---|---|---|---|---|
| **Honcho** | pre-3.0 archive pin | **v3.0.11** (`14538cfc`) | submodule `apps/honcho/src` bump + config migration | ✅ done |
| **PaperClip** | v2026.517.0 | **v2026.707.0** (`390627b4`) | Dockerfile + compose build-arg bump; patches re-validated | ✅ done |
| **Hermes** | v2026.5.16 (0.14.0) | ~~v2026.7.7 (0.18.1)~~ | — | ⛔ **deferred** (see below) |

### Honcho 3.0.11 — the load-bearing change

3.0.7 (upstream #459) **removed** the flat `SUMMARY_PROVIDER` / `DERIVER_PROVIDER` / `DIALECTIC_LEVELS__<lvl>__PROVIDER|MODEL` keys in favor of a nested `MODEL_CONFIG` (`transport` + `model`). Because every settings model uses pydantic `extra="ignore"`, the old keys are **silently dropped** and the service falls back to the built-in default **`openai/gpt-5.4-mini`** — no error, no warning. Verified directly against `apps/honcho/src/src/config.py` @ v3.0.11.

Migrated:
- `docker-compose.yml` honcho env → `SUMMARY_MODEL_CONFIG__*`, `DERIVER_MODEL_CONFIG__*`, `DIALECTIC_LEVELS__<lvl>__MODEL_CONFIG__*`
- `.env.example` honcho knobs (`*_TRANSPORT` / `*_MODEL`)
- **New `services/honcho/README.md`** with the migration NOTE + the removed→replacement table + the OpenAI-compatible-proxy (`…MODEL_CONFIG__OVERRIDES__BASE_URL`) path

Dockerfile compatibility confirmed against 3.0.11: all `COPY` targets present (`uv.lock`, `pyproject.toml`, `src/`, `migrations/`, `alembic.ini`), `[dependency-groups] dev` exists, `requires-python >=3.10` (image is 3.13), `fastapi run src/main.py` valid.

### PaperClip 2026.707.0 — patches re-validated

Bumped `PAPERCLIP_VERSION` + `PAPERCLIP_EXPECTED_SHA` + `CACHE_BUST`. Every vendored build patch was re-checked against a clean checkout of the 707 source (`390627b4…`):
- **Build-failing sed guards:** `Board mutation requires trusted browser origin` (board-mutation-guard.ts:72) ✓, `"--save", "--ignore-scripts"` (plugin-loader.ts:1175) ✓
- **Hard-failing (`process.exit(1)`) plugin patches:** `plugin-host-services.ts` (issuesTable import L10, sendMessage anchor L2626) ✓, `plugin-secrets-handler.ts` (`invalidSecretRef` L50, `PLUGIN_SECRET_REFS_DISABLED_MESSAGE` L235) ✓, `plugin-worker-manager.ts` ✓
- **Workspace filters** `@paperclipai/{ui,server,plugin-sdk,db}` present ✓

This matches the reference platform's proven 707 build; the extra patches that build uses (wake-kick, comment-bridge, agent-remove-cascade, adapter-route/run-cost) are exactly the §0.3/§0.7/§2.2 features AAF intentionally does **not** vendor.

### Hermes 0.18.1 — deferred (honest gap)

Target is `v2026.7.7` = `f9eca7e15f1c2bfe5194aae5aa489af53c0a1a23` (pyproject `0.18.1`). **Not bumped** in this PR because it cannot be landed cleanly within the files this change owns:

1. **Out-of-lane hard build break.** 0.18.1 shrank `_WAL_INCOMPAT_MARKERS` to `("locking protocol", "not authorized")` — the `"disk i/o error"` anchor that `services/agent-runtime/patch-hermes-wal-markers.py` requires is gone, and that patch **`raise SystemExit`s** on a missing anchor → the agent-runtime image build fails. `services/agent-runtime/**` is outside this change's ownership.
2. **`import os` dropped** from `hermes_state.py`, which `apps/paperclip/patch-hermes-src.py` (P1) injects a use of.
3. The reference platform's own 0.18.1 Hermes port uses a substantially different patch pipeline (`patch_memory_planner`, `patch_usage_emit`, `patch-hermes-cost-envelope`, `patch-hermes-route`, extras `[messaging,honcho,anthropic]`) — a bigger change than a pin bump, and no full container build is runnable here to verify it.

**Remediation for a follow-up (agent-runtime owner):** update `patch-hermes-wal-markers.py` to anchor after `"not authorized"` (or make it fail-safe), have `patch-hermes-src.py` ensure `import os` in `hermes_state.py`, refresh `services/agent-runtime/constraints.txt` against 0.18.1's pins, then bump the `apps/hermes/src` submodule to `f9eca7e`.

### Verification run
- `docker compose config -q` — **passes** (default + `full` profiles)
- Honcho 3.0.11 config schema read from source (authoritative)
- PaperClip 707 patch anchors grepped against a clean tag checkout
- Static sanitization scan of all changed files — no private hostnames/keys/tenant data
- **Not run** (no Docker/cloud creds in this environment): full `az acr build` / image build / container smoke. This is what the CI smoke gate covers.

### Sanitization / safety
No MRTek hostnames, keys, or tenant data. Flags unchanged (OFF). `deploy.yml` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)