### PR TITLE
feat(router): provider-flexible /v1/embeddings with Azure Foundry path (A4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,19 @@ GPT4O_API_KEY=
 OPENAI_COMPAT_BASE_URL=
 OPENAI_COMPAT_API_KEY=
 
+# ── Model Router — embeddings (/v1/embeddings, optional) ─────────────────────
+# Provider-flexible upstream for the memory governor's vector retrieval.
+# Unset key -> the endpoint answers 503 (fail loud, never silently degrade
+# memory search). EMBEDDING_BASE_URL unset -> api.openai.com; point it at an
+# Azure AI Foundry /openai/v1 endpoint to drop the OpenAI billing dependency
+# entirely — full walkthrough: docs/walkthroughs/azure-foundry-embeddings.md.
+# NOTE: keep EMBEDDING_MODEL a bare model name; the router pins the openai/
+# LiteLLM prefix itself (azure.com base URLs otherwise trip LiteLLM's AZURE
+# provider detection -> api-key-header auth -> Foundry 400 unknown_model).
+EMBEDDING_API_KEY=
+EMBEDDING_BASE_URL=
+EMBEDDING_MODEL=text-embedding-3-small
+
 # ── Azure AI Foundry — grok-4-fast-reasoning (primary default model) ─────────
 # Key Vault secrets: platform-azure-ai-foundry-grok4-uri-target
 #                    platform-azure-ai-foundry-grok4-api-key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,15 @@ services:
       PHI_API_KEY: ${PHI_API_KEY:-}
       OPENAI_COMPAT_BASE_URL: ${OPENAI_COMPAT_BASE_URL:-}
       OPENAI_COMPAT_API_KEY: ${OPENAI_COMPAT_API_KEY:-}
+      # /v1/embeddings upstream (optional; 503 until the key is set). Base URL
+      # unset -> api.openai.com; point it at an Azure AI Foundry /openai/v1
+      # endpoint instead — docs/walkthroughs/azure-foundry-embeddings.md. Keep
+      # EMBEDDING_MODEL a bare model name: the router pins the openai/ LiteLLM
+      # prefix itself (azure.com base URL + bare model otherwise trips LiteLLM's
+      # AZURE provider -> api-key-header auth -> Foundry 400 unknown_model).
+      EMBEDDING_API_KEY: ${EMBEDDING_API_KEY:-}
+      EMBEDDING_BASE_URL: ${EMBEDDING_BASE_URL:-}
+      EMBEDDING_MODEL: ${EMBEDDING_MODEL:-text-embedding-3-small}
     ports: ["${ROUTER_PORT:-8080}:8080"]
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8080/health').status==200 else 1)\""]

--- a/docs/walkthroughs/azure-foundry-embeddings.md
+++ b/docs/walkthroughs/azure-foundry-embeddings.md
@@ -1,0 +1,140 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="../assets/azureagentforge-logo-dark.png">
+    <img alt="AzureAgentForge" src="../assets/azureagentforge-logo-light.png" width="440">
+  </picture>
+</p>
+
+# Embeddings from Azure AI Foundry, end to end
+
+The model-router exposes an OpenAI-compatible `POST /v1/embeddings` passthrough
+that the memory governor's vector retrieval uses for query embeddings. By
+default it points at `api.openai.com`, which quietly makes an OpenAI billing
+account a hard dependency of the memory system. This walkthrough moves that
+dependency onto Azure AI Foundry — the same place the rest of the platform's
+models already live — by deploying `text-embedding-3-small` in Foundry and
+pointing the router at it.
+
+Two properties make this a safe swap:
+
+- **Same model, same vector space.** A Foundry deployment of
+  `text-embedding-3-small` produces the same 1536-dimension embeddings as
+  OpenAI's hosted copy, so documents embedded before the switch remain
+  searchable after it. Do not swap in a *different* embedding model without
+  re-embedding your corpus.
+- **Fail loud.** The endpoint answers `503` until an embedding key is
+  configured, and `502` when the upstream errors. Memory search degrading
+  silently is the worst failure mode this design guards against — this
+  hardening is ported from the upstream private deployment's incident
+  learnings, where an exhausted embedding account (`429 insufficient_quota`)
+  silently emptied every memory lookup.
+
+## 1. Deploy `text-embedding-3-small` in Foundry
+
+In the [Azure AI Foundry portal](https://ai.azure.com): open your project →
+**Models + endpoints** → **Deploy model** → search for
+`text-embedding-3-small` → deploy it with the deployment name
+`text-embedding-3-small` (keeping the deployment name identical to the model
+name means `EMBEDDING_MODEL` needs no override).
+
+Or with the CLI, against the Azure OpenAI/AI Services resource that backs your
+Foundry project:
+
+```bash
+az cognitiveservices account deployment create \
+  --resource-group <your-rg> \
+  --name <your-ai-services-resource> \
+  --deployment-name text-embedding-3-small \
+  --model-name text-embedding-3-small \
+  --model-version "1" \
+  --model-format OpenAI \
+  --sku-name Standard \
+  --sku-capacity 120
+```
+
+You need two values from the resource:
+
+- **Endpoint**: `https://<your-resource>.services.ai.azure.com` — the router
+  wants the OpenAI-compatible route on it: `https://<your-resource>.services.ai.azure.com/openai/v1`
+- **API key**: portal → resource → *Keys and Endpoint*, or
+  `az cognitiveservices account keys list --resource-group <your-rg> --name <your-ai-services-resource>`
+
+## 2. Configure the router
+
+Set three env vars on the model-router service (in `.env` for the local
+compose stack, or as Container App secrets/env in Azure):
+
+```bash
+EMBEDDING_BASE_URL=https://<your-resource>.services.ai.azure.com/openai/v1
+EMBEDDING_API_KEY=<your-foundry-api-key>
+EMBEDDING_MODEL=text-embedding-3-small   # default; set only if your deployment name differs
+```
+
+That's the whole cutover. Leaving `EMBEDDING_BASE_URL` unset keeps the OpenAI
+path; unsetting `EMBEDDING_API_KEY` (with no `OPENAI_API_KEY` fallback)
+disables the endpoint with a clear `503`.
+
+## 3. Verify: a 1536-dim vector through the router
+
+```bash
+curl -s http://localhost:8080/v1/embeddings \
+  -H "Authorization: Bearer $ROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"input": "hello from foundry"}' \
+  | python3 -c "import json,sys; b=json.load(sys.stdin); print(b['model'], len(b['data'][0]['embedding']))"
+```
+
+Expected output:
+
+```
+text-embedding-3-small 1536
+```
+
+A `1536` there means the query embedding is landing in the same vector space
+as the stored document embeddings — retrieval keeps working across the
+provider switch.
+
+## Troubleshooting
+
+### `400 unknown_model` from Foundry
+
+This is the one that looks inexplicable — the deployment exists, the key is
+right, and Foundry still answers `unknown_model`. The cause is LiteLLM
+provider detection: when the `api_base` points at an **azure.com** host and
+the model string has no `provider/` prefix, LiteLLM flips to its AZURE
+provider, which authenticates with an `api-key` **header**. Foundry's
+OpenAI-compatible `/openai/v1` endpoint expects `Authorization: Bearer` and
+rejects the api-key-header request with `400 unknown_model`.
+
+The router pins this for you: `_pin_embedding_provider()` in
+[`services/model-router/main.py`](../../services/model-router/main.py)
+prepends `openai/` to a bare `EMBEDDING_MODEL` so LiteLLM stays on the
+OpenAI-compatible Bearer-auth path. (Lesson ported from the upstream private
+deployment's incident learnings.) If you hit `unknown_model` anyway, check
+that you haven't set `EMBEDDING_MODEL` to an explicit `azure/...` value — an
+explicit provider prefix is honored as-is, which re-exposes the api-key-header
+behavior. `azure/<deployment>` is only correct for a classic Azure OpenAI
+resource endpoint (`https://<name>.openai.azure.com`), not for Foundry's
+unified `/openai/v1` route.
+
+### `503 embeddings not configured`
+
+No embedding key reached the router. Set `EMBEDDING_API_KEY` (or rely on the
+`OPENAI_API_KEY` fallback) on the **model-router** service and restart it.
+This is deliberate fail-closed behavior — better a loud 503 than memory
+search quietly returning nothing.
+
+### `502 embedding provider error`
+
+The upstream call failed; the router logs the real provider error server-side
+(and deliberately does not echo it to callers). Check the router logs. Common
+causes: wrong `EMBEDDING_BASE_URL` (missing the `/openai/v1` suffix), a
+deployment name that doesn't match `EMBEDDING_MODEL`, an exhausted quota
+(`429 insufficient_quota` — the incident that motivated this endpoint), or
+Foundry capacity throttling.
+
+### Vector length isn't 1536
+
+You deployed a different embedding model. `text-embedding-3-small` is pinned
+throughout the platform (Honcho's document embeddings share the space);
+changing models means re-embedding every stored document.

--- a/services/model-router/README.md
+++ b/services/model-router/README.md
@@ -50,6 +50,20 @@ Shared timeout across all Foundry tiers: `MODEL_TIMEOUT_SECONDS` (default: `60`)
 
 Set `OLLAMA_BASE_URL` and `OLLAMA_MODELS` (comma-separated model tags) to register local inference tiers. Each model tag `<name>[:<variant>]` becomes a `<name>-local` tier. Ollama tiers fall back to `gpt4o-mini` (or the value of `OLLAMA_FALLBACK_TIER`) when the edge host is unreachable. Leaving `OLLAMA_BASE_URL` unset gives a clean Foundry-only stack.
 
+### Embeddings (optional — provider-flexible)
+
+`POST /v1/embeddings` is an OpenAI-compatible passthrough used by the memory governor's vector retrieval. It is **disabled (503) until a key is set** — it fails loud rather than silently degrading memory search. The upstream is provider-flexible: any OpenAI-compatible endpoint serving the same model works, so forks are not tied to OpenAI billing. The Azure AI Foundry path is documented end-to-end in [`docs/walkthroughs/azure-foundry-embeddings.md`](../../docs/walkthroughs/azure-foundry-embeddings.md).
+
+| Env var | Purpose |
+|---|---|
+| `EMBEDDING_API_KEY` | API key for the embeddings upstream (falls back to `OPENAI_API_KEY`; unset → endpoint answers 503) |
+| `EMBEDDING_BASE_URL` | OpenAI-compatible base URL. Unset → `api.openai.com`. Point it at an Azure AI Foundry `/openai/v1` endpoint to serve embeddings from Foundry |
+| `EMBEDDING_MODEL` | Model / deployment name (default: `text-embedding-3-small` — matches Honcho's 1536-dim document-embedding space) |
+| `EMBEDDING_TIMEOUT_SECONDS` | Upstream timeout (default: `20`) |
+| `EMBEDDING_MAX_INPUTS` | Max inputs per request (default: `256`) |
+
+**Provider-detection pin**: the router prepends `openai/` to a bare `EMBEDDING_MODEL` before handing it to LiteLLM. This is load-bearing for the Foundry path — with an `azure.com` `EMBEDDING_BASE_URL` and no provider prefix, LiteLLM flips to its AZURE provider (`api-key` header auth) and Foundry's OpenAI-compatible endpoint rejects the call with `400 unknown_model`. The `openai/` prefix keeps auth on `Authorization: Bearer`. An explicit `provider/` prefix in `EMBEDDING_MODEL` is honored unchanged.
+
 ## Routing
 
 ### How a tier is selected
@@ -96,3 +110,4 @@ Tiers that cannot fit the request (input + max_tokens > context_limit) are prune
 |---|---|---|
 | `POST` | `/v1/chat/completions` | OpenAI-compatible chat completions (streaming and non-streaming) |
 | `POST` | `/v1/messages` | Anthropic Messages API passthrough (Claude tiers only) |
+| `POST` | `/v1/embeddings` | OpenAI-compatible embeddings passthrough (503 until `EMBEDDING_API_KEY` is set; see [Embeddings](#embeddings-optional--provider-flexible)) |

--- a/services/model-router/main.py
+++ b/services/model-router/main.py
@@ -1693,13 +1693,43 @@ async def messages(request: Request):
 # The memory governor's Plane C vector retrieval embeds its query through here
 # so the "never call a provider directly" principle holds and the model is
 # pinned to match Honcho's document embeddings (same 1536-dim vector space).
-# Disabled (503) unless an embedding key is set. EMBEDDING_BASE_URL unset ->
-# OpenAI.com; set it to point at an Azure/Foundry deployment of the same model.
+# Disabled (503) unless an embedding key is set — fail LOUD, never degrade
+# silently. Provider-flexible: EMBEDDING_BASE_URL unset -> api.openai.com;
+# point it at any OpenAI-compatible deployment of the SAME model instead
+# (e.g. an Azure AI Foundry text-embedding-3-small deployment — see
+# docs/walkthroughs/azure-foundry-embeddings.md), so forks don't carry a hard
+# OpenAI-billing dependency.
 _EMBED_MODEL = os.environ.get("EMBEDDING_MODEL", "text-embedding-3-small")
 _EMBED_API_KEY = _tier_env("EMBEDDING_API_KEY") or _tier_env("OPENAI_API_KEY")
 _EMBED_API_BASE = os.environ.get("EMBEDDING_BASE_URL") or None
 _EMBED_TIMEOUT_S = int(os.environ.get("EMBEDDING_TIMEOUT_SECONDS", "20"))
 _EMBED_MAX_INPUTS = int(os.environ.get("EMBEDDING_MAX_INPUTS", "256"))
+
+
+def _pin_embedding_provider(model: str) -> str:
+    """Pin LiteLLM's provider detection to the OpenAI-compatible Bearer path.
+
+    LOAD-BEARING — ported from the upstream private deployment's incident
+    learnings. When EMBEDDING_BASE_URL points at an azure.com host and the
+    model string carries no ``provider/`` prefix, LiteLLM's provider detection
+    flips to its AZURE provider and authenticates with an ``api-key`` header.
+    Azure AI Foundry's OpenAI-compatible ``/openai/v1`` endpoint rejects that
+    request with ``400 unknown_model``. Prepending ``openai/`` pins detection
+    to the OpenAI-compatible provider, so auth stays ``Authorization: Bearer``
+    and the Foundry deployment resolves.
+
+    An explicit ``provider/`` prefix in EMBEDDING_MODEL is honored unchanged
+    (e.g. ``azure/<deployment>`` for a classic Azure OpenAI resource that
+    genuinely wants api-key-header auth).
+    """
+    if "/" in model:
+        return model
+    return f"openai/{model}"
+
+
+# What is actually handed to LiteLLM; _EMBED_MODEL stays the operator-facing
+# model name (and the `model` field reported back to callers).
+_EMBED_LITELLM_MODEL = _pin_embedding_provider(_EMBED_MODEL)
 
 
 @app.post("/v1/embeddings")
@@ -1723,8 +1753,10 @@ async def embeddings(request: Request):
     if isinstance(inp, list) and len(inp) > _EMBED_MAX_INPUTS:
         raise HTTPException(status_code=400, detail=f"too many inputs (max {_EMBED_MAX_INPUTS})")
     try:
+        # _EMBED_LITELLM_MODEL (not _EMBED_MODEL): the openai/ prefix pin is
+        # load-bearing against azure.com api_bases — see _pin_embedding_provider.
         resp = await litellm.aembedding(
-            model=_EMBED_MODEL,
+            model=_EMBED_LITELLM_MODEL,
             input=inp,
             api_key=_EMBED_API_KEY,
             api_base=_EMBED_API_BASE,

--- a/services/model-router/tests/test_embeddings.py
+++ b/services/model-router/tests/test_embeddings.py
@@ -1,6 +1,12 @@
 """Tests for the /v1/embeddings passthrough (governor Plane C vector retrieval).
 
 litellm.aembedding is monkeypatched — these never leave the process.
+
+The provider-prefix pin tests guard the load-bearing lesson ported from the
+upstream private deployment: a bare model name plus an azure.com api_base makes
+LiteLLM pick its AZURE provider (api-key header auth), which Azure AI Foundry's
+OpenAI-compatible endpoint rejects with 400 unknown_model. The router must pin
+the `openai/` prefix so provider detection stays on Bearer auth.
 """
 
 
@@ -17,7 +23,7 @@ def _ok_response(**_kwargs):
 
 class TestEmbeddingsEndpoint:
     def test_503_when_unconfigured(self, client, router, monkeypatch):
-        # default test env sets no embedding key
+        # default test env sets no embedding key — fail LOUD, not silent
         monkeypatch.setattr(router, "_EMBED_API_KEY", None)
         r = client.post("/v1/embeddings", json={"input": "hello world"})
         assert r.status_code == 503
@@ -27,7 +33,8 @@ class TestEmbeddingsEndpoint:
         monkeypatch.setattr(router, "_EMBED_API_KEY", "test-embed-key")
 
         async def fake(**kwargs):
-            assert kwargs["model"] == router._EMBED_MODEL
+            # The pinned LiteLLM model string is what goes upstream.
+            assert kwargs["model"] == router._EMBED_LITELLM_MODEL
             assert kwargs["input"] == "hello world"
             return _ok_response()
 
@@ -59,3 +66,71 @@ class TestEmbeddingsEndpoint:
         monkeypatch.setattr(router.litellm, "aembedding", boom)
         r = client.post("/v1/embeddings", json={"input": "hi"})
         assert r.status_code == 502
+
+
+class TestProviderPrefixPin:
+    """The openai/ prefix pin — see _pin_embedding_provider in main.py."""
+
+    def test_bare_model_gets_openai_prefix(self, router):
+        assert (
+            router._pin_embedding_provider("text-embedding-3-small")
+            == "openai/text-embedding-3-small"
+        )
+
+    def test_explicit_provider_prefix_honored(self, router):
+        # An operator who really wants api-key-header auth (classic Azure
+        # OpenAI resource) can say so explicitly; the pin must not stack.
+        assert router._pin_embedding_provider("azure/my-deployment") == "azure/my-deployment"
+        assert (
+            router._pin_embedding_provider("openai/text-embedding-3-small")
+            == "openai/text-embedding-3-small"
+        )
+
+    def test_module_default_is_pinned(self, router):
+        # Import-time wiring: the string handed to LiteLLM carries a provider
+        # prefix even though EMBEDDING_MODEL defaults to a bare model name.
+        assert router._EMBED_LITELLM_MODEL == router._pin_embedding_provider(router._EMBED_MODEL)
+        assert "/" in router._EMBED_LITELLM_MODEL
+
+    def test_pinned_model_and_base_reach_litellm(self, client, router, monkeypatch):
+        # The Foundry scenario end-to-end (mocked upstream): azure.com api_base
+        # + bare model must reach litellm.aembedding with the openai/ prefix,
+        # or Foundry answers 400 unknown_model (api-key-header auth).
+        monkeypatch.setattr(router, "_EMBED_API_KEY", "test-foundry-key")
+        monkeypatch.setattr(
+            router, "_EMBED_API_BASE", "https://example-foundry.services.azure.com/openai/v1"
+        )
+        monkeypatch.setattr(router, "_EMBED_MODEL", "text-embedding-3-small")
+        monkeypatch.setattr(
+            router,
+            "_EMBED_LITELLM_MODEL",
+            router._pin_embedding_provider("text-embedding-3-small"),
+        )
+        seen = {}
+
+        async def fake(**kwargs):
+            seen.update(kwargs)
+            return _ok_response()
+
+        monkeypatch.setattr(router.litellm, "aembedding", fake)
+        r = client.post("/v1/embeddings", json={"input": "hello world"})
+        assert r.status_code == 200
+        assert seen["model"] == "openai/text-embedding-3-small"
+        assert seen["api_base"] == "https://example-foundry.services.azure.com/openai/v1"
+        assert seen["api_key"] == "test-foundry-key"
+
+    def test_response_model_field_stays_unprefixed(self, client, router, monkeypatch):
+        # When the upstream omits `model`, the fallback is the operator-facing
+        # name — callers must never see the internal openai/ routing prefix.
+        monkeypatch.setattr(router, "_EMBED_API_KEY", "test-embed-key")
+
+        async def fake(**kwargs):
+            resp = _ok_response()
+            del resp["model"]
+            return resp
+
+        monkeypatch.setattr(router.litellm, "aembedding", fake)
+        r = client.post("/v1/embeddings", json={"input": "hi"})
+        assert r.status_code == 200
+        assert r.json()["model"] == router._EMBED_MODEL
+        assert not r.json()["model"].startswith("openai/")


### PR DESCRIPTION
## What

Kills the memory system's hard OpenAI-billing dependency: the router's `/v1/embeddings` passthrough is now provider-flexible with a documented, end-to-end Azure AI Foundry deployment path — and it bakes in the load-bearing LiteLLM provider-detection pin so forks can't rediscover the `400 unknown_model` failure mode. Ported from the upstream private deployment's incident learnings.

## Design

- **`openai/` LiteLLM prefix pin (`_pin_embedding_provider`, `services/model-router/main.py`)** — when `EMBEDDING_BASE_URL` points at an azure.com host and the model string has no `provider/` prefix, LiteLLM flips to its AZURE provider and authenticates with an `api-key` header; Foundry's OpenAI-compatible `/openai/v1` endpoint rejects that with `400 unknown_model`. The router now prefixes a bare `EMBEDDING_MODEL` with `openai/` before the `litellm.aembedding` call, pinning detection to the Bearer-auth OpenAI-compatible path. An explicit `provider/` prefix (e.g. `azure/<deployment>` for a classic Azure OpenAI resource) is honored unchanged.
- **Operator-facing vs wire model split** — `_EMBED_MODEL` stays the reported model name; only `_EMBED_LITELLM_MODEL` (pinned) goes upstream. Callers never see the routing prefix.
- **Fail loud, stay optional** — unchanged semantics, now documented: `503` until `EMBEDDING_API_KEY` (or the `OPENAI_API_KEY` fallback) is set, `502` on upstream failure with the real error logged server-side only. No new required config; a clean fork boots exactly as before.
- **Config surface** (env-driven, all optional): `EMBEDDING_API_KEY`, `EMBEDDING_BASE_URL`, `EMBEDDING_MODEL` (default `text-embedding-3-small`), `EMBEDDING_TIMEOUT_SECONDS`, `EMBEDDING_MAX_INPUTS` — wired through `docker-compose.yml` and `.env.example`.

## Test evidence

`pytest -q services/model-router/tests` (same invocation as CI's model-router step): **200 passed** locally on Python 3.13.

New/updated coverage in `services/model-router/tests/test_embeddings.py` (10 passed):
- prefix pin: bare model → `openai/text-embedding-3-small`; explicit `azure/...` and `openai/...` honored without stacking; import-time default is pinned
- Foundry-shaped end-to-end (mocked upstream): pinned model + azure.com `api_base` + key all reach `litellm.aembedding`
- response `model` field stays unprefixed when the upstream omits it
- fail-loud paths: `503` unconfigured, `400` missing/oversized input, `502` provider error

## Docs

- **`docs/walkthroughs/azure-foundry-embeddings.md`** — end to end: create the Foundry `text-embedding-3-small` deployment (portal + `az` CLI), set the three env vars, verify a 1536-dim vector with curl, and a troubleshooting section that explains the `unknown_model` mechanism, plus `503`/`502`/wrong-dimension cases.
- `services/model-router/README.md` — embeddings provider-config section + `/v1/embeddings` endpoint row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)