### PR TITLE
feat(identity): canonical user-peer deploy input (A5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,14 @@ DISCORD_BOT_TOKEN=
 HONCHO_BASE_URL=
 HONCHO_API_KEY=
 HONCHO_APP_ID=
+# Canonical user peer (A5) — the ONE memory-peer id representing the human
+# principal, everywhere: the pc-memory/pc-honcho helpers write and query it and
+# the governor's /admit defaults `observed` to it. Every component falls back
+# to "user" when unset; change it HERE (one input), never per component —
+# per-component defaults drifting apart is how one human fragments across
+# several peers and recall goes quiet.
+# See docs/design/memory-system.md §18 ("Identity: the canonical user peer").
+HONCHO_USER_PEER_ID=user
 HERMES_HOME=
 HERMES_DB_PATH=
 GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,5 +123,7 @@ jobs:
           pytest -q tests/memory-governor
       - name: watchdog
         run: pytest -q services/watchdog/tests
+      - name: skill helpers (canonical user-peer threading, A5)
+        run: pytest -q tests/skills
       - name: compileall
         run: python -m compileall services installer

--- a/apps/hermes/overrides/skills/playbooks/honcho-memory/scripts/pc-honcho.sh
+++ b/apps/hermes/overrides/skills/playbooks/honcho-memory/scripts/pc-honcho.sh
@@ -10,28 +10,37 @@
 #     List every peer in the workspace. Use this to discover the peer ID
 #     that the Telegram bot writes to.
 #
-#   ask --peer <peer_id> --query "..."
+#   ask [--peer <peer_id>] --query "..."
 #     Query the dialectic API. Returns Honcho's natural-language answer.
+#     --peer defaults to the canonical user peer (HONCHO_USER_PEER_ID).
 #
 # Required env vars (already set on ca-orchestrator):
 #   HONCHO_BASE_URL  — e.g. https://ca-memory.internal.<env>.azurecontainerapps.io
 #   HONCHO_API_KEY   — auth token (defaults to "self-hosted" in dev)
 #   HONCHO_APP_ID    — Honcho workspace name (e.g. "hermes-dev")
+#   HONCHO_USER_PEER_ID — canonical user peer; the default for --peer when
+#     omitted (falls back to "user"; see docs/design/memory-system.md §18)
 
 set -e
 
 WORKSPACE="${HONCHO_APP_ID:-hermes-dev}"
 BASE="${HONCHO_BASE_URL:-http://ca-memory}"
 KEY="${HONCHO_API_KEY:-self-hosted}"
+# A5: canonical user peer. `ask`/`record` default --peer to this SAME
+# deploy-time input the rest of the stack resolves (compose env, Terraform,
+# the governor's /admit default) so a caller that forgets --peer still reads
+# and writes the peer everyone else uses instead of inventing a new one.
+DEFAULT_PEER="${HONCHO_USER_PEER_ID:-user}"
 
 usage() {
   cat <<EOF
 Usage:
   pc-honcho list-peers
-  pc-honcho ask --peer <peer_id> --query "<question>"
-  pc-honcho record --peer <peer_id> --content "<text>" [--session-id <id>]
+  pc-honcho ask [--peer <peer_id>] --query "<question>"
+  pc-honcho record [--peer <peer_id>] --content "<text>" [--session-id <id>]
 
-Env: HONCHO_BASE_URL=$BASE  HONCHO_APP_ID=$WORKSPACE
+--peer defaults to the canonical user peer (HONCHO_USER_PEER_ID, fallback "user").
+Env: HONCHO_BASE_URL=$BASE  HONCHO_APP_ID=$WORKSPACE  peer default=$DEFAULT_PEER
 EOF
   exit 2
 }
@@ -63,7 +72,7 @@ case "$CMD" in
     ;;
 
   ask)
-    PEER=""
+    PEER="$DEFAULT_PEER"
     QUERY=""
     while [ "$#" -gt 0 ]; do
       case "$1" in
@@ -73,7 +82,7 @@ case "$CMD" in
         *) echo "Unknown arg: $1" >&2; exit 2 ;;
       esac
     done
-    [ -z "$PEER" ]  && { echo "--peer is required" >&2; exit 2; }
+    [ -z "$PEER" ]  && { echo "--peer is required (or set HONCHO_USER_PEER_ID)" >&2; exit 2; }
     [ -z "$QUERY" ] && { echo "--query is required" >&2; exit 2; }
 
     BODY=$(python3 -c "import json,sys; print(json.dumps({'query': sys.argv[1], 'reasoning_level': 'low'}))" "$QUERY")
@@ -88,7 +97,7 @@ case "$CMD" in
     # Post a message into a Honcho session, attributed to a peer. This is how
     # Orchestrator contributes new content (issue bodies, etc.) back to the user's
     # representation — without it, Orchestrator is read-only against upstream-built memory.
-    PEER=""
+    PEER="$DEFAULT_PEER"
     CONTENT=""
     SESSION_ID="${HONCHO_DEFAULT_SESSION_ID:-orchestrator-paperclip}"
     while [ "$#" -gt 0 ]; do
@@ -100,7 +109,7 @@ case "$CMD" in
         *) echo "Unknown arg: $1" >&2; exit 2 ;;
       esac
     done
-    [ -z "$PEER" ]    && { echo "--peer is required" >&2; exit 2; }
+    [ -z "$PEER" ]    && { echo "--peer is required (or set HONCHO_USER_PEER_ID)" >&2; exit 2; }
     [ -z "$CONTENT" ] && { echo "--content is required" >&2; exit 2; }
 
     # Idempotently ensure the session exists with the peer attached.

--- a/apps/hermes/overrides/skills/playbooks/honcho-memory/scripts/pc-memory.sh
+++ b/apps/hermes/overrides/skills/playbooks/honcho-memory/scripts/pc-memory.sh
@@ -30,6 +30,8 @@
 #   GOVERNOR_API_KEY  — shared key (KV: memory-governor-api-key)
 #   GOVERNOR_WORKSPACE — workspace name (defaults to HONCHO_APP_ID or hermes-dev)
 #   PAPERCLIP_AGENT_SLUG — used as observer/created_by identity
+#   HONCHO_USER_PEER_ID — canonical user peer `record` writes facts about
+#     (defaults to "user"; see docs/design/memory-system.md §18)
 
 set -e
 
@@ -37,6 +39,12 @@ BASE="${GOVERNOR_BASE_URL:-http://ca-memory-governor-dev}"
 KEY="${GOVERNOR_API_KEY:-}"
 WORKSPACE="${GOVERNOR_WORKSPACE:-${HONCHO_APP_ID:-hermes-dev}}"
 AGENT="${PAPERCLIP_AGENT_SLUG:-${GOVERNOR_AGENT_SLUG:-operator}}"
+# A5: canonical user peer. `record` sends `observed` EXPLICITLY instead of
+# leaning on the governor's server-side default — an omitted field is how
+# writes fragment across peers when any component's default drifts. The same
+# deploy-time input (HONCHO_USER_PEER_ID) feeds compose, Terraform, and the
+# governor, so writer and reader always name the same peer.
+OBSERVED="${HONCHO_USER_PEER_ID:-user}"
 
 jpost() {
   curl -sS -X POST "$BASE$1" \
@@ -84,7 +92,7 @@ case "$CMD" in
       esac
     done
     [ -z "$CONTENT" ] && { echo "ERROR: --content required" >&2; exit 2; }
-    BODY="{\"content\":\"$(jstr "$CONTENT")\",\"workspace_name\":\"$WORKSPACE\",\"observer\":\"$AGENT\",\"created_by_peer\":\"$AGENT\",\"pin_request\":$PIN"
+    BODY="{\"content\":\"$(jstr "$CONTENT")\",\"workspace_name\":\"$WORKSPACE\",\"observer\":\"$AGENT\",\"observed\":\"$(jstr "$OBSERVED")\",\"created_by_peer\":\"$AGENT\",\"pin_request\":$PIN"
     [ -n "$CLASS" ]      && BODY="$BODY,\"memory_class\":\"$CLASS\""
     [ -n "$SCOPE_KIND" ] && BODY="$BODY,\"scope_kind\":\"$SCOPE_KIND\""
     [ -n "$SCOPE_ID" ]   && BODY="$BODY,\"scope_id\":\"$(jstr "$SCOPE_ID")\""

--- a/deploy/mac-site/.env.example
+++ b/deploy/mac-site/.env.example
@@ -49,6 +49,13 @@ PAPERCLIP_ADMIN_PASSWORD=
 BETTER_AUTH_SECRET=
 GOVERNOR_API_KEY=
 GOVERNOR_WORKSPACE=
+# Canonical user peer (A5) [fixed] — ONE deploy-time id for the human
+# principal's memory peer; compose threads it into the governor (its /admit
+# `observed` default) and paperclip (the pc-memory/pc-honcho helpers). Leave
+# empty to take the platform-wide "user" default; if this site's memory was
+# built under a different peer id, set it here ONCE — never per service.
+# docs/design/memory-system.md §18.
+HONCHO_USER_PEER_ID=
 # aaf-0005: model-router fails closed without this; paperclip's OPENAI_API_KEY
 # (docker-compose.yml) reuses the same value as its bearer to the router.
 ROUTER_API_KEY=

--- a/deploy/mac-site/docker-compose.yml
+++ b/deploy/mac-site/docker-compose.yml
@@ -124,6 +124,11 @@ services:
       DATABASE_URL: "postgresql+psycopg://${POSTGRES_USER:-dbadmin}:${POSTGRES_PASSWORD_URLENC:?run secrets-pull.sh}@${AZURE_PG_HOST:?set in .env}:5432/honcho?sslmode=require"
       ROUTER_BASE_URL: "http://model-router:8080/v1"
       HONCHO_BASE_URL: "http://honcho:8000"
+      # A5: canonical user peer — /admit defaults `observed` to this when a
+      # writer omits it. Same input + same "user" fallback as paperclip below;
+      # a site that overrides it does so ONCE in .env for every service.
+      # docs/design/memory-system.md §18.
+      HONCHO_USER_PEER_ID: "${HONCHO_USER_PEER_ID:-user}"
 
   # ── PaperClip (auth-proxy + UI/API + agent runtime) ────────────────────────
   paperclip:
@@ -144,6 +149,10 @@ services:
       OPENAI_API_KEY: "${ROUTER_API_KEY:?run secrets-pull.sh}"
       GOVERNOR_BASE_URL: "http://memory-governor:8090"
       HONCHO_BASE_URL: "http://honcho:8000"
+      # A5: canonical user peer — the pc-memory/pc-honcho helpers agents run in
+      # this container write and query it. Must equal the governor's value
+      # above; both resolve the same ${HONCHO_USER_PEER_ID} from .env.
+      HONCHO_USER_PEER_ID: "${HONCHO_USER_PEER_ID:-user}"
       # Agents run inside this container and authenticate with a local agent JWT
       # that only the backend on :3099 validates; the auth-proxy on :3100 accepts
       # only automation tokens. Point in-container agent calls at the backend so

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,6 +182,12 @@ services:
       OPENAI_API_KEY: ${ROUTER_API_KEY:-localdev-router-key}
       HONCHO_BASE_URL: http://honcho:8000
       GOVERNOR_BASE_URL: http://memory-governor:8090
+      # A5: canonical user peer — the ONE deploy-time identity every writer and
+      # reader of user-scoped memory resolves (pc-memory/pc-honcho helpers in
+      # this container, the governor's /admit default, Terraform's
+      # honcho_user_peer_id). Keep the value identical across services or one
+      # human fragments across peers. docs/design/memory-system.md §18.
+      HONCHO_USER_PEER_ID: ${HONCHO_USER_PEER_ID:-user}
       PAPERCLIP_AUTOMATION_JWT_SECRET: ${PAPERCLIP_AUTOMATION_JWT_SECRET:-localdev-automation-secret-change-me}
       PAPERCLIP_AGENT_JWT_SECRET: ${PAPERCLIP_AGENT_JWT_SECRET:-localdev-agent-secret-change-me}
       PAPERCLIP_ADMIN_EMAIL: ${PAPERCLIP_ADMIN_EMAIL:-admin@localhost}
@@ -213,6 +219,11 @@ services:
       ROUTER_API_KEY: ${ROUTER_API_KEY:-localdev-router-key}
       HONCHO_BASE_URL: http://honcho:8000
       GOVERNOR_API_KEY: ${GOVERNOR_API_KEY:-localdev}
+      # A5: canonical user peer — /admit defaults `observed` to this when a
+      # writer omits it. Must equal the value the writers (paperclip above)
+      # resolve, hence the same ${HONCHO_USER_PEER_ID} input with the same
+      # "user" fallback. docs/design/memory-system.md §18.
+      HONCHO_USER_PEER_ID: ${HONCHO_USER_PEER_ID:-user}
     ports: ["${GOVERNOR_PORT:-8090}:8090"]
 
   # Self-improvement watchdog. A one-shot: it self-mints a JWT from the secret,

--- a/docs/design/memory-system.md
+++ b/docs/design/memory-system.md
@@ -655,6 +655,10 @@ Grounded in the absence of implementing code, not any doc's aspiration:
   (Plane A includes confirmed always-on candidates), but there is no automated
   promotion job — promotion to Plane A is operator `pin` or a manually-confirmed
   candidate.
+- **Identity map + peer re-consolidation sweep.** The canonical user peer is a
+  deploy-time input threaded everywhere (§18), but there is no alias table at
+  admission and no sweep that detects/merges unexpected peers — the production
+  backstop described in §18 is a separate enhancement.
 
 ---
 
@@ -735,3 +739,92 @@ sidecar (`EMBEDDING_API_KEY`); without it, Plane C stays trigram-only.
 Every step is reversible: set a flag back to `false` and the corresponding
 behavior stops on the next flag-cache cycle (≤60s); set `memory_governor_enabled
 = false` to remove the service entirely.
+
+---
+
+## 18. Identity: the canonical user peer
+
+### The failure mode: one human, four peers, zero recall
+
+Peer-scoped memory has a quiet failure mode that produces no errors, only
+silence. Every store keyed by peer id trusts its writers to agree on what the
+user is called — and writers drift:
+
+- a **chat gateway** auto-derives a peer name from the channel session id
+  (`user-<bot-id>-<channel>-<chat-id>`), minting a fresh peer per surface;
+- a **helper script** omits the `observed` field on writes and inherits
+  whatever the service happens to default to;
+- a **service default** points at a legacy alias (`operator`) that nothing
+  writes to anymore;
+- an **operator tool** seeds facts under a third spelling.
+
+Each component is locally reasonable. Globally, one human is now sharded
+across `user-agent-main-telegram-dm-<id>`, `user`, and `operator` — and the
+reader queries exactly one of them. Facts are stored, dutifully, under peers
+nobody asks about. The user experience is an agent that says "I don't have any
+information about that" moments after being told the fact, which reads as
+total memory failure even though every write succeeded. This is a distilled
+real incident, not a hypothetical: recall failed user-visibly while the store
+held the answer under a peer the reader never named.
+
+The trap generalizes: it is the workspace-scoping trap (aaf-0015,
+`honcho_workspace_name` in §17) one level down. Workspace answers *which
+memory universe*; peer answers *who inside it*. Both must be single,
+deploy-time, explicit inputs — a per-component default for either is a
+fragmentation bug waiting for its second component.
+
+### The fix: one deploy-time input, defaulted identically everywhere
+
+`HONCHO_USER_PEER_ID` names the canonical peer for the human principal. One
+value, set at deploy time, resolved by **every** component that writes or
+queries user-scoped memory — and every component falls back to the **same**
+default (`user`) when it is unset. The consistency of the fallback matters as
+much as the variable: two components with different fallbacks fragment a
+fresh deployment out of the box.
+
+Where it threads:
+
+| Surface | Component | How it resolves |
+|---|---|---|
+| Compose (local) | `docker-compose.yml` → `paperclip`, `memory-governor` | `${HONCHO_USER_PEER_ID:-user}` from `.env` |
+| Compose (self-hosted site) | `deploy/mac-site/docker-compose.yml` → same two services | same input, set once in the site `.env` |
+| Terraform (Azure) | `var.honcho_user_peer_id` → `hermes.tf`, `paperclip.tf`, `memory_governor.tf` | one tfvars input, default `user` |
+| Governor `/admit` | `AdmitBody.observed` default | `config.user_peer_id()` — env, fallback `user` |
+| Helper scripts | `pc-memory record` (`observed`), `pc-honcho ask`/`record` (`--peer` default) | `${HONCHO_USER_PEER_ID:-user}` |
+| Tenant console (experimental) | seed-memory `observed` | env, fallback `user` |
+
+Rules that keep it canonical:
+
+- **Writers send `observed` explicitly.** `pc-memory record` names the peer in
+  the request body rather than leaning on the server-side default; an omitted
+  field is one config drift away from a fragmenting write.
+- **Change it in one place or zero places.** If a deployment's memory history
+  already lives under a different peer (discover with `pc-honcho list-peers`),
+  set the input once — tfvars or the stack `.env` — never on an individual
+  component.
+- **Agent self-lessons are exempt.** The watchdog's failure/delegation lessons
+  set `observed` to the *agent's* slug deliberately (§10); the canonical peer
+  governs facts about the *human*. The rule is "no accidental peers," not "one
+  peer total."
+
+### Production backstop: identity map + re-consolidation sweep
+
+A canonical input keeps *configured* components aligned. It cannot stop a
+*new* writer — the next gateway, an imported history, a vendored tool with
+its own naming scheme — from minting peers before anyone thinks to thread the
+variable. The recommended production backstop, designed but not implemented
+here (§15), is:
+
+1. **Identity map at admission.** A small alias table (`peer_alias` →
+   canonical peer) consulted at the write choke point (`/admit`), so known
+   aliases — legacy names, per-channel session peers — are rewritten to the
+   canonical peer as they arrive instead of accumulating.
+2. **Periodic re-consolidation sweep.** A background job (the sweeper cadence
+   of §8 fits) that lists peers, diffs against the expected set (canonical
+   peer + agent slugs), flags unexpected peers for operator review, and — on
+   operator confirmation, never automatically (§16) — migrates their
+   documents to the canonical peer and records the alias in the map.
+
+Both belong to a separate enhancement. The deploy-time input is deliberately
+shippable without them: it fixes the drift that already happened once, and it
+makes the backstop's job boring.

--- a/experimental/multi-tenant/tenant-console/src/tenantconsole/steps.py
+++ b/experimental/multi-tenant/tenant-console/src/tenantconsole/steps.py
@@ -27,6 +27,7 @@ instantly and offline.
 
 from __future__ import annotations
 
+import os
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
@@ -432,7 +433,11 @@ class Provisioner:
                 "content": content,
                 "workspace_name": ws,
                 "observer": "operator",
-                "observed": "user",
+                # A5: seeds are ABOUT the tenant's principal user — resolve the
+                # canonical user peer (same deploy-time input as the governor
+                # default and the pc-* helpers) instead of a hardcoded literal,
+                # so seeded facts land on the peer readers actually query.
+                "observed": (os.environ.get("HONCHO_USER_PEER_ID") or "").strip() or "user",
                 "created_by_peer": "operator",
                 "memory_class": seed["memory_class"],
                 "scope_kind": "workspace",

--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -178,6 +178,11 @@ module "container_apps" {
   # tfvars so dev/prod never silently share a governed-memory workspace.
   honcho_workspace_name = var.honcho_workspace_name
 
+  # A5: canonical user peer — one deploy-time input for the human principal's
+  # memory peer, threaded into hermes + paperclip + memory-governor so writers
+  # and readers always name the same peer. Default "user".
+  honcho_user_peer_id = var.honcho_user_peer_id
+
   # OTel tracing from the model-router sidecar → App Insights (B3 observability).
   # Off by default; flip observability_enabled=true in dev.auto.tfvars to activate.
   observability_enabled = var.observability_enabled

--- a/infrastructure/environments/dev/variables.tf
+++ b/infrastructure/environments/dev/variables.tf
@@ -313,6 +313,12 @@ variable "honcho_workspace_name" {
   type        = string
 }
 
+variable "honcho_user_peer_id" {
+  description = "A5: canonical user peer — the ONE peer id representing the human principal, threaded into hermes, paperclip, and the memory-governor alike. Default \"user\" matches every component's code-level fallback; override in tfvars only if this environment's memory history lives under a different peer (discover with `pc-honcho list-peers`)."
+  type        = string
+  default     = "user"
+}
+
 variable "observability_enabled" {
   description = "Emit GenAI-semconv spans from the model-router to App Insights. Off by default; flip to true in dev.auto.tfvars to activate."
   type        = bool

--- a/infrastructure/modules/container-apps/hermes.tf
+++ b/infrastructure/modules/container-apps/hermes.tf
@@ -230,6 +230,16 @@ resource "azurerm_container_app" "hermes" {
         name  = "HONCHO_APP_ID"
         value = "hermes-${var.environment}"
       }
+      # A5: canonical user peer. The gateway is where user identity ENTERS the
+      # platform — left unpinned, gateways tend to auto-derive peer names from
+      # channel session ids (one peer per chat surface), which fragments a
+      # single human across peers no reader queries. Thread the same
+      # var.honcho_user_peer_id every other component gets so writes from this
+      # container land on the canonical peer. docs/design/memory-system.md §18.
+      env {
+        name  = "HONCHO_USER_PEER_ID"
+        value = var.honcho_user_peer_id
+      }
       env {
         name  = "AZURE_CLIENT_ID"
         value = azurerm_user_assigned_identity.hermes.client_id

--- a/infrastructure/modules/container-apps/memory_governor.tf
+++ b/infrastructure/modules/container-apps/memory_governor.tf
@@ -157,6 +157,14 @@ resource "azurerm_container_app" "memory_governor" {
         value = "http://ca-honcho-${var.environment}"
       }
       env {
+        # A5: canonical user peer — /admit defaults `observed` to this when a
+        # writer omits it. Threads the SAME var.honcho_user_peer_id the gateway
+        # and paperclip receive, so the governor never invents a peer no
+        # reader queries. docs/design/memory-system.md §18.
+        name  = "HONCHO_USER_PEER_ID"
+        value = var.honcho_user_peer_id
+      }
+      env {
         # Planner canary allowlist. Empty = planner answers enabled=false for
         # every agent even with MEMORY_PLANNER_ENABLED on. Add slugs one at a time.
         name  = "PLANNER_AGENT_ALLOWLIST"

--- a/infrastructure/modules/container-apps/paperclip.tf
+++ b/infrastructure/modules/container-apps/paperclip.tf
@@ -347,10 +347,12 @@ resource "azurerm_container_app" "paperclip" {
         # a per-env split is needed in the future.
         value = var.honcho_workspace_name
       }
-      # Peer ID Orchestrator queries when answering "what do you know about Operator" —
-      # must match the peer the Telegram bot writes to. Discover the right value
-      # by running `pc-honcho list-peers` in the container, then re-applying with
-      # -var="honcho_user_peer_id=<id>".
+      # A5: canonical user peer — the pc-memory/pc-honcho helpers in this
+      # container write and query it, and it must match the peer the gateway
+      # writes to and the governor defaults `observed` to (all three thread the
+      # same var). If an existing deployment used a different id, discover it
+      # with `pc-honcho list-peers` in the container, then set
+      # honcho_user_peer_id in tfvars — one input, every component.
       env {
         name  = "HONCHO_USER_PEER_ID"
         value = var.honcho_user_peer_id

--- a/infrastructure/modules/container-apps/variables.tf
+++ b/infrastructure/modules/container-apps/variables.tf
@@ -350,10 +350,25 @@ variable "honcho_workspace_name" {
   }
 }
 
+# A5: canonical user peer. The ONE deploy-time id for the human principal's
+# memory peer, threaded into every container that writes or queries user-scoped
+# memory (hermes gateway, paperclip helpers, memory-governor /admit default).
+# The default MUST equal the code-level fallback everywhere ("user" — governor
+# config.user_peer_id(), pc-memory/pc-honcho, compose) — the previous default
+# here was "operator", a divergent placeholder, which is exactly the
+# fragmentation trap: components defaulting to DIFFERENT peers means writes
+# land where no reader looks. If an existing deployment's memory was built
+# under another peer id, set it per environment in tfvars after discovering it
+# with `pc-honcho list-peers` in the running paperclip container.
+# See docs/design/memory-system.md §18.
 variable "honcho_user_peer_id" {
-  description = "Peer ID in Honcho for the principal user. Must match what the Telegram bot writes to. Discover by running `pc-honcho list-peers` in the running paperclip container. Default 'operator' is a placeholder — almost certainly wrong until verified."
+  description = "Canonical Honcho peer ID for the principal user — every component that writes or queries user-scoped memory resolves this single input. Keep aligned with HONCHO_USER_PEER_ID in the compose stacks; empty/placeholder values are rejected."
   type        = string
-  default     = "operator"
+  default     = "user"
+  validation {
+    condition     = length(trimspace(var.honcho_user_peer_id)) > 0 && !contains(["CHANGEME", "TODO"], var.honcho_user_peer_id)
+    error_message = "honcho_user_peer_id must be a real peer id (default \"user\"); empty or placeholder values fragment user identity across peers."
+  }
 }
 
 variable "honcho_deriver_job_timeout_seconds" {

--- a/infrastructure/terraform.tfvars.example
+++ b/infrastructure/terraform.tfvars.example
@@ -11,6 +11,15 @@ discord_enabled  = false
 # Set a DISTINCT value per environment so dev/prod never share governed memory.
 honcho_workspace_name = "hermes"
 
+# A5: canonical user peer — ONE deploy-time id for the human principal's memory
+# peer, threaded into hermes, paperclip, and the memory-governor alike (env
+# HONCHO_USER_PEER_ID). Defaults to "user" everywhere; only set this if the
+# environment's memory history was built under a different peer id (discover
+# with `pc-honcho list-peers` in the paperclip container). NEVER point
+# individual components at different peers — that fragments one human across
+# peers and recall silently misses. docs/design/memory-system.md §18.
+# honcho_user_peer_id = "user"
+
 # aaf-0013: Key Vault firewall defaults to Deny (secure-by-default). With public
 # access on and no private endpoint, add your Terraform-runner egress IP so
 # apply/secret-pull is not locked out (example uses an RFC-5737 documentation IP):

--- a/services/memory-governor/src/governor/config.py
+++ b/services/memory-governor/src/governor/config.py
@@ -44,6 +44,22 @@ EMBEDDING_TIMEOUT_S = float(os.environ.get("EMBEDDING_TIMEOUT_S", "10"))
 # docker-compose service name.
 HONCHO_BASE_URL = os.environ.get("HONCHO_BASE_URL", "http://honcho:8000")
 
+# Canonical user peer (A5). ONE deploy-time input names the peer that
+# represents the human principal; every component that writes or queries a
+# user-scoped memory resolves this SAME input (compose env, Terraform
+# var.honcho_user_peer_id, the pc-memory/pc-honcho helpers, and this service's
+# /admit default). Divergent per-component defaults are how one human fragments
+# across several peers and recall goes quiet — see
+# docs/design/memory-system.md §18 ("Identity: the canonical user peer").
+# Exposed as a function (read at call time, not import time) so the default in
+# AdmitBody tracks the environment without a module reload.
+DEFAULT_USER_PEER_ID = "user"
+
+
+def user_peer_id() -> str:
+    val = (os.environ.get("HONCHO_USER_PEER_ID") or "").strip()
+    return val or DEFAULT_USER_PEER_ID
+
 # Optional shared-secret for mutating endpoints (auth-proxy injects it).
 GOVERNOR_API_KEY = _secret("GOVERNOR_API_KEY", "memory-governor-api-key")
 

--- a/services/memory-governor/src/governor/main.py
+++ b/services/memory-governor/src/governor/main.py
@@ -137,7 +137,14 @@ class AdmitBody(BaseModel):
     content: str = Field(min_length=1, max_length=65000)
     workspace_name: str
     observer: str
-    observed: str = "user"
+    # A5: when the caller omits `observed`, default to the CANONICAL user peer
+    # (HONCHO_USER_PEER_ID, fallback "user") — the same deploy-time input every
+    # other component resolves. A hardcoded literal here is exactly how identity
+    # fragments: a writer that omits the field lands on one peer while a
+    # differently-defaulted reader queries another, and recall silently misses.
+    # default_factory (not a literal) so the env var is read per request, not
+    # frozen at import. See docs/design/memory-system.md §18.
+    observed: str = Field(default_factory=config.user_peer_id)
     created_by_peer: str
     session_id: str | None = None
     issue_id: str | None = None

--- a/services/memory-governor/src/governor/memory/admission.py
+++ b/services/memory-governor/src/governor/memory/admission.py
@@ -45,7 +45,10 @@ class AdmitRequest:
     content: str
     workspace_name: str
     observer: str  # peer that holds the memory (usually the agent slug)
-    observed: str  # peer the memory is about (usually 'user' or the agent)
+    # Peer the memory is about. For user-scoped facts this MUST be the canonical
+    # user peer (config.user_peer_id(), i.e. HONCHO_USER_PEER_ID) — main.py's
+    # AdmitBody defaults it there. Agent self-lessons use the agent slug instead.
+    observed: str
     created_by_peer: str
     session_id: str | None = None
     issue_id: str | None = None

--- a/tests/memory-governor/test_identity.py
+++ b/tests/memory-governor/test_identity.py
@@ -1,0 +1,79 @@
+"""A5 — canonical user peer. One deploy-time input (HONCHO_USER_PEER_ID) names
+the peer that represents the human principal; the governor's /admit must
+default `observed` to it when a writer omits the field, and the fallback when
+the input is unset must be "user" — the SAME fallback every other component
+(compose, Terraform, pc-memory/pc-honcho) uses. Divergent per-component
+defaults are the identity-fragmentation failure mode documented in
+docs/design/memory-system.md §18. Offline: no DB, no HTTP."""
+
+from governor import config
+from governor import main as governor_main
+
+
+# ── config.user_peer_id(): the single resolution point ──────────────────────
+
+def test_default_is_user_when_env_unset(monkeypatch):
+    monkeypatch.delenv("HONCHO_USER_PEER_ID", raising=False)
+    assert config.user_peer_id() == "user"
+    assert config.DEFAULT_USER_PEER_ID == "user"
+
+
+def test_env_value_wins(monkeypatch):
+    monkeypatch.setenv("HONCHO_USER_PEER_ID", "principal-42")
+    assert config.user_peer_id() == "principal-42"
+
+
+def test_blank_env_falls_back_to_default(monkeypatch):
+    # An empty/whitespace value must NOT become a real (empty) peer id — that
+    # would be a third accidental identity. Fall through to the canonical default.
+    monkeypatch.setenv("HONCHO_USER_PEER_ID", "   ")
+    assert config.user_peer_id() == "user"
+
+
+def test_read_at_call_time_not_import_time(monkeypatch):
+    # Long-lived processes and tests must see env changes without a module
+    # reload — the default is a function, not a frozen module constant.
+    monkeypatch.setenv("HONCHO_USER_PEER_ID", "first")
+    assert config.user_peer_id() == "first"
+    monkeypatch.setenv("HONCHO_USER_PEER_ID", "second")
+    assert config.user_peer_id() == "second"
+
+
+# ── AdmitBody: a writer that omits `observed` lands on the canonical peer ───
+
+def _admit_body(**overrides):
+    fields = {
+        "content": "the user's dog is named Biscuit",
+        "workspace_name": "ws",
+        "observer": "researcher",
+        "created_by_peer": "researcher",
+    }
+    fields.update(overrides)
+    return governor_main.AdmitBody(**fields)
+
+
+def test_admit_observed_defaults_to_canonical_peer(monkeypatch):
+    monkeypatch.setenv("HONCHO_USER_PEER_ID", "principal-42")
+    assert _admit_body().observed == "principal-42"
+
+
+def test_admit_observed_defaults_to_user_when_unset(monkeypatch):
+    monkeypatch.delenv("HONCHO_USER_PEER_ID", raising=False)
+    assert _admit_body().observed == "user"
+
+
+def test_admit_default_tracks_env_per_request(monkeypatch):
+    # default_factory, not a literal frozen at import: two requests under
+    # different env values resolve independently.
+    monkeypatch.setenv("HONCHO_USER_PEER_ID", "alpha")
+    first = _admit_body()
+    monkeypatch.setenv("HONCHO_USER_PEER_ID", "beta")
+    second = _admit_body()
+    assert (first.observed, second.observed) == ("alpha", "beta")
+
+
+def test_admit_explicit_observed_still_wins(monkeypatch):
+    # Agent self-lessons (watchdog) deliberately set observed to the agent slug;
+    # the canonical default must never override an explicit value.
+    monkeypatch.setenv("HONCHO_USER_PEER_ID", "principal-42")
+    assert _admit_body(observed="researcher").observed == "researcher"

--- a/tests/skills/test_user_peer_threading.py
+++ b/tests/skills/test_user_peer_threading.py
@@ -1,0 +1,120 @@
+"""A5 — canonical user peer threading through the skill helper scripts.
+
+pc-memory.sh must send `observed` EXPLICITLY on record (an omitted field is
+one config drift away from a fragmenting write), and pc-honcho.sh must default
+--peer to the same input — both resolving HONCHO_USER_PEER_ID with the same
+"user" fallback the governor and compose stacks use. Offline: curl is stubbed
+onto PATH and logs its argv; nothing is contacted.
+See docs/design/memory-system.md §18."""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO / "apps" / "hermes" / "overrides" / "skills" / "playbooks" / "honcho-memory" / "scripts"
+
+CURL_STUB = """#!/bin/sh
+{
+for a in "$@"; do printf 'ARG:%s\\n' "$a"; done
+printf 'CALL-END\\n'
+} >> "$CURL_LOG"
+"""
+
+
+def _run(tmp_path, script, args, extra_env=None, unset=()):
+    """Run a helper script with a stubbed curl; return the list of curl calls,
+    each call a list of argv strings."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    stub = bin_dir / "curl"
+    stub.write_text(CURL_STUB)
+    stub.chmod(0o755)
+    log = tmp_path / "curl.log"
+    log.write_text("")
+
+    env = dict(os.environ)
+    for name in ("HONCHO_USER_PEER_ID", *unset):
+        env.pop(name, None)
+    env.update(extra_env or {})
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["CURL_LOG"] = str(log)
+
+    proc = subprocess.run(
+        ["sh", str(SCRIPTS / script), *args],
+        env=env, capture_output=True, text=True, timeout=30,
+    )
+    assert proc.returncode == 0, f"{script} failed: {proc.stderr}"
+
+    calls, current = [], []
+    for line in log.read_text().splitlines():
+        if line == "CALL-END":
+            calls.append(current)
+            current = []
+        elif line.startswith("ARG:"):
+            current.append(line[4:])
+    return calls
+
+
+def _payload(call):
+    """The JSON body following -d in a stubbed curl argv."""
+    return json.loads(call[call.index("-d") + 1])
+
+
+# ── pc-memory.sh: record sends observed explicitly ───────────────────────────
+
+def test_pc_memory_record_defaults_observed_to_user(tmp_path):
+    calls = _run(tmp_path, "pc-memory.sh", ["record", "--content", "fact"])
+    body = _payload(calls[0])
+    assert body["observed"] == "user"
+    # and the field is IN the request — never left to the server-side default
+    assert "observed" in body
+
+
+def test_pc_memory_record_threads_env_peer(tmp_path):
+    calls = _run(
+        tmp_path, "pc-memory.sh", ["record", "--content", "fact"],
+        extra_env={"HONCHO_USER_PEER_ID": "principal-42"},
+    )
+    body = _payload(calls[0])
+    assert body["observed"] == "principal-42"
+    # writer identity stays the agent — only the SUBJECT is the canonical peer
+    assert body["observer"] == body["created_by_peer"] != "principal-42"
+
+
+# ── pc-honcho.sh: --peer defaults to the canonical peer ──────────────────────
+
+def test_pc_honcho_ask_defaults_peer_to_user(tmp_path):
+    calls = _run(tmp_path, "pc-honcho.sh", ["ask", "--query", "what do you know"])
+    url = next(a for a in calls[0] if "/peers/" in a)
+    assert "/peers/user/chat" in url
+
+
+def test_pc_honcho_ask_threads_env_peer(tmp_path):
+    calls = _run(
+        tmp_path, "pc-honcho.sh", ["ask", "--query", "what do you know"],
+        extra_env={"HONCHO_USER_PEER_ID": "principal-42"},
+    )
+    url = next(a for a in calls[0] if "/peers/" in a)
+    assert "/peers/principal-42/chat" in url
+
+
+def test_pc_honcho_ask_explicit_peer_wins(tmp_path):
+    calls = _run(
+        tmp_path, "pc-honcho.sh",
+        ["ask", "--peer", "researcher", "--query", "self check"],
+        extra_env={"HONCHO_USER_PEER_ID": "principal-42"},
+    )
+    url = next(a for a in calls[0] if "/peers/" in a)
+    assert "/peers/researcher/chat" in url
+
+
+def test_pc_honcho_record_defaults_peer(tmp_path):
+    calls = _run(
+        tmp_path, "pc-honcho.sh", ["record", "--content", "note"],
+        extra_env={"HONCHO_USER_PEER_ID": "principal-42"},
+    )
+    # two calls: idempotent session ensure, then the message post
+    msg_body = _payload(calls[-1])
+    assert msg_body["messages"][0]["peer_id"] == "principal-42"


### PR DESCRIPTION
## What

One deploy-time input — **`HONCHO_USER_PEER_ID`** — now names the memory peer that represents the human principal, resolved by every component that writes or queries user-scoped memory, with the **same `"user"` fallback everywhere**.

The name follows the repo's own conventions: the Terraform module and the `docs/skills/` playbooks already referenced `HONCHO_USER_PEER_ID`; this PR makes it real end-to-end instead of a paperclip-only env var with a divergent `"operator"` default.

## Why (the failure mode)

Peer-scoped memory fails silently when writers disagree on what the user is called: a gateway auto-derives a peer per chat surface from session ids, a helper script omits `observed` and inherits the server default, a service default points at a legacy alias. Every write succeeds; the reader queries one peer; recall answers "I don't know" moments after being told the fact. This repo had the seeds of exactly that: Terraform defaulted the peer to `operator` ("almost certainly wrong" per its own comment), the governor hardcoded `observed = "user"`, and `pc-memory record` sent no `observed` at all. Full narrative: [docs/design/memory-system.md §18](docs/design/memory-system.md#18-identity-the-canonical-user-peer).

## Surface map (every threaded component)

| Layer | File | Change |
|---|---|---|
| Governor config | `services/memory-governor/src/governor/config.py` | `user_peer_id()` — env, fallback `user`, read at call time |
| Governor /admit | `services/memory-governor/src/governor/main.py` | `AdmitBody.observed` default via `default_factory=config.user_peer_id` (was literal `"user"`) |
| Governor admission | `services/memory-governor/src/governor/memory/admission.py` | doc comment: user-scoped `observed` must be the canonical peer |
| Helper (write) | `apps/hermes/overrides/skills/playbooks/honcho-memory/scripts/pc-memory.sh` | `record` now sends `observed` **explicitly** (`${HONCHO_USER_PEER_ID:-user}`) |
| Helper (read/write) | `apps/hermes/overrides/skills/playbooks/honcho-memory/scripts/pc-honcho.sh` | `ask`/`record` `--peer` now defaults to the canonical peer |
| Compose (local) | `docker-compose.yml` | `HONCHO_USER_PEER_ID: ${HONCHO_USER_PEER_ID:-user}` on `paperclip` + `memory-governor` |
| Compose (site) | `deploy/mac-site/docker-compose.yml` | same two services, same input |
| Env templates | `.env.example`, `deploy/mac-site/.env.example` | documented input, one place to override |
| Terraform module | `infrastructure/modules/container-apps/variables.tf` | default `operator` → `user` + placeholder validation |
| Terraform apps | `hermes.tf` (new), `memory_governor.tf` (new), `paperclip.tf` (comment) | all three containers now receive the same var |
| Terraform env | `infrastructure/environments/dev/{variables,main}.tf`, `terraform.tfvars.example` | pass-through + documented override |
| Tenant console (experimental) | `experimental/multi-tenant/tenant-console/src/tenantconsole/steps.py` | seed memories resolve env instead of literal `"user"` |

**Deliberately not threaded:** `services/watchdog/memory.py` — agent self-lessons set `observed` to the *agent's* slug by design (the rule is "no accidental peers", not "one peer total"); Plane D `session-memory` `peer_id` stays optional (session-scoped, 24 h TTL).

## Tests

- `tests/memory-governor/test_identity.py` — config resolution (default / env / blank / call-time) + `AdmitBody` default threading (env wins, explicit `observed` wins, per-request not import-frozen)
- `tests/skills/test_user_peer_threading.py` — runs the actual shell helpers against a stubbed `curl`, asserts the JSON bodies / URLs carry the canonical peer (default and env-override)
- New CI step `skill helpers (canonical user-peer threading, A5)` runs the skills suite

Local results: `pytest -q tests/memory-governor tests/skills` → **219 passed**; watchdog suite → **75 passed**; tenant-console suite → 9 passed, 1 skipped; `terraform fmt -check` clean; compose files YAML-parse; `scan-internal-refs.sh` → OK; shellcheck clean on both helpers.

## Docs

- `docs/design/memory-system.md` **§18 “Identity: the canonical user peer”** — fragmentation failure mode (generic), the one-input rule, the threading table, and the recommended production backstop (identity map at admission + periodic re-consolidation sweep — referenced only; separate enhancement, recorded in §15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)