### PR TITLE
feat(smoke): e2e agent-loop canary roundtrip (A2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,15 @@ EMBEDDING_PRICE_PER_MTOK=
 BUDGET_ENFORCE_MODE=
 BUDGET_FALLBACK_TIER=
 
+# ── Agent-loop canary (e2e smoke; docker-compose.canary.yml overlay) ─────────
+# All optional — working defaults are baked into the overlay + script.
+# CANARY_MODEL is both the router tier name and the canary agent's model;
+# CANARY_TIMEOUT_SECONDS bounds the roundtrip poll in scripts/smoke-canary.sh.
+CANARY_MODEL=
+CANARY_STUB_PORT=
+CANARY_STUB_API_KEY=
+CANARY_TIMEOUT_SECONDS=
+
 # ── Azure AI Foundry — grok-4-fast-reasoning (primary default model) ─────────
 # Key Vault secrets: platform-azure-ai-foundry-grok4-uri-target
 #                    platform-azure-ai-foundry-grok4-api-key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
       - uses: actions/checkout@v7
       - name: docker compose config
         run: docker compose config -q
+      - name: docker compose config (canary overlay)
+        run: docker compose -f docker-compose.yml -f docker-compose.canary.yml config -q
 
   scripts:
     runs-on: ubuntu-latest
@@ -80,6 +82,8 @@ jobs:
         run: |
           sudo apt-get update -qq && sudo apt-get install -y shellcheck
           shellcheck --severity=error scripts/*.sh
+      - name: agent-loop canary self-check (offline)
+        run: bash scripts/smoke-canary.sh --self-check
 
   node-tests:
     runs-on: ubuntu-latest
@@ -127,8 +131,10 @@ jobs:
         run: pytest -q services/watchdog/tests
       - name: skill helpers (canonical user-peer threading, A5)
         run: pytest -q tests/skills
+      - name: canary stub self-test
+        run: python scripts/canary/anthropic_stub.py --self-test
       - name: compileall
-        run: python -m compileall services installer
+        run: python -m compileall services installer scripts/canary
 
   # A3 — vendored-config schema guard. Every config key AAF ships to a
   # vendored app (compose/Terraform env blocks, the generated Hermes

--- a/.github/workflows/local-stack-smoke.yml
+++ b/.github/workflows/local-stack-smoke.yml
@@ -64,10 +64,13 @@ jobs:
       # Fail fast with the REAL error if the bundled agent runtime can't even
       # boot inside the paperclip container (import errors here previously
       # surfaced only as an opaque one-line `adapter_failed` recovery comment).
+      # --user node is load-bearing: agents spawn as node, and a root-run
+      # probe would create root-owned files under ~/.hermes that then break
+      # the node-user spawns it is trying to validate.
       - name: Probe agent runtime inside the paperclip container
         run: |
           docker compose -f docker-compose.yml -f docker-compose.canary.yml --profile full \
-            exec -T paperclip sh -c 'python3 --version && hermes --version && echo "runtime probe OK"'
+            exec -T --user node paperclip sh -c 'python3 --version && hermes --version && echo "runtime probe OK"'
       - name: Canary roundtrip (file issue → agent wakes → disposition → done)
         run: CANARY_TIMEOUT_SECONDS=420 bash scripts/smoke-canary.sh
       - name: Logs on failure

--- a/.github/workflows/local-stack-smoke.yml
+++ b/.github/workflows/local-stack-smoke.yml
@@ -5,20 +5,26 @@ on:
   push:
     paths:
       - 'docker-compose.yml'
+      - 'docker-compose.canary.yml'
       - 'services/**'
       - 'apps/**'
       - 'infrastructure/migrations/**'
       - 'scripts/smoke-local.sh'
+      - 'scripts/smoke-canary.sh'
+      - 'scripts/canary/**'
       - 'scripts/local-stack.sh'
       - '.env.example'
       - '.github/workflows/local-stack-smoke.yml'
   pull_request:
     paths:
       - 'docker-compose.yml'
+      - 'docker-compose.canary.yml'
       - 'services/**'
       - 'apps/**'
       - 'infrastructure/migrations/**'
       - 'scripts/smoke-local.sh'
+      - 'scripts/smoke-canary.sh'
+      - 'scripts/canary/**'
       - 'scripts/local-stack.sh'
       - '.env.example'
       - '.github/workflows/local-stack-smoke.yml'
@@ -43,13 +49,25 @@ jobs:
             fi
             sleep 10
           done
-      - name: Smoke
+      - name: Smoke (health gate — no model creds)
         run: bash scripts/smoke-local.sh
+      # ── Agent-loop canary ─────────────────────────────────────────────────
+      # The health gate above proves containers are up; it does NOT prove an
+      # agent can complete work. The canary overlay adds a scripted stub model
+      # backend (only the LLM inference is stubbed) and the roundtrip files a
+      # real issue, waits for the agent to wake, drive the model-router, post
+      # a disposition comment, and close it. See scripts/smoke-canary.sh.
+      - name: Apply canary overlay (stub model tier)
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.canary.yml \
+            --profile full up -d --wait canary-stub model-router
+      - name: Canary roundtrip (file issue → agent wakes → disposition → done)
+        run: CANARY_TIMEOUT_SECONDS=420 bash scripts/smoke-canary.sh
       - name: Logs on failure
         if: failure()
         run: |
-          docker compose --profile full ps -a
-          docker compose --profile full logs --no-color
+          docker compose -f docker-compose.yml -f docker-compose.canary.yml --profile full ps -a
+          docker compose -f docker-compose.yml -f docker-compose.canary.yml --profile full logs --no-color
       - name: Teardown
         if: always()
-        run: docker compose --profile full down -v
+        run: docker compose -f docker-compose.yml -f docker-compose.canary.yml --profile full down -v

--- a/.github/workflows/local-stack-smoke.yml
+++ b/.github/workflows/local-stack-smoke.yml
@@ -61,6 +61,13 @@ jobs:
         run: |
           docker compose -f docker-compose.yml -f docker-compose.canary.yml \
             --profile full up -d --wait canary-stub model-router
+      # Fail fast with the REAL error if the bundled agent runtime can't even
+      # boot inside the paperclip container (import errors here previously
+      # surfaced only as an opaque one-line `adapter_failed` recovery comment).
+      - name: Probe agent runtime inside the paperclip container
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.canary.yml --profile full \
+            exec -T paperclip sh -c 'python3 --version && hermes --version && echo "runtime probe OK"'
       - name: Canary roundtrip (file issue → agent wakes → disposition → done)
         run: CANARY_TIMEOUT_SECONDS=420 bash scripts/smoke-canary.sh
       - name: Logs on failure

--- a/apps/paperclip/docker-entrypoint.sh
+++ b/apps/paperclip/docker-entrypoint.sh
@@ -193,6 +193,17 @@ echo "[entrypoint] Skills manifests available at ${MANIFESTS_DIR}"
 # exits non-zero — a container that would spawn dead agents must not serve.
 /usr/local/bin/write-hermes-config.sh
 
+# The Hermes home tree is created/written by ROOT during this entrypoint
+# (write-hermes-config.sh mkdir + config.yaml, plus the skills/manifests sync
+# above), but the hermes CLI runs as `node` at agent spawn and must stat/read
+# AND WRITE inside it (its .env probe, sessions, logs). On Azure Files (SMB)
+# permissions surface as 0777 so this was invisible; on a real POSIX volume a
+# root-owned ~/.hermes killed EVERY agent spawn with
+#   PermissionError: [Errno 13] Permission denied: '/paperclip/.hermes/.env'
+# (surfacing only as an opaque `adapter_failed` recovery comment). Caught by
+# the agent-loop canary (scripts/smoke-canary.sh).
+chown -R node:node "${HERMES_HOME:-/paperclip/.hermes}" 2>/dev/null || true
+
 # ── JWT Auth Proxy for automation API access ─────────────────────────────────
 # When PAPERCLIP_AUTOMATION_JWT_SECRET is set, the auth proxy sits on port 3100
 # (the public port) and forwards to Paperclip on port 3099 (internal).

--- a/docker-compose.canary.yml
+++ b/docker-compose.canary.yml
@@ -1,0 +1,44 @@
+# Agent-loop canary overlay — apply ON TOP of docker-compose.yml:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.canary.yml \
+#     --profile full up -d --build
+#   bash scripts/smoke-canary.sh
+#
+# Adds a scripted Anthropic-Messages stub model backend (no model credentials
+# needed) and registers it as the router's CLAUDE tier, so the e2e canary
+# (file issue → agent wakes → Hermes calls the router → agent posts a
+# disposition and closes) can run in CI. ONLY the LLM inference is stubbed —
+# see scripts/canary/anthropic_stub.py for the exact real-vs-stubbed line.
+#
+# This file is NOT part of the default stack; the base compose remains a
+# no-credentials health-gated slice. See docs/local-development.md.
+
+services:
+  canary-stub:
+    image: python:3.12-alpine
+    volumes: ["./scripts/canary:/canary:ro"]
+    command: ["python", "/canary/anthropic_stub.py"]
+    environment:
+      CANARY_STUB_PORT: "9785"
+      CANARY_STUB_API_KEY: ${CANARY_STUB_API_KEY:-canary-stub-key}
+    # Published so scripts/smoke-canary.sh can arm the stub with the filed
+    # issue's identifier and read its request counters. Loopback only.
+    ports: ["127.0.0.1:${CANARY_STUB_PORT:-9785}:9785"]
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:9785/health').status==200 else 1)\""]
+      interval: 3s
+      timeout: 5s
+      retries: 10
+
+  model-router:
+    environment:
+      # Register the stub as the CLAUDE tier (Anthropic Messages dispatch).
+      # Hermes's anthropic_messages transport → router /v1/messages →
+      # AsyncAnthropic against the stub. The tier name (CLAUDE_MODEL) must
+      # match the canary agent's adapterConfig.model in smoke-canary.sh.
+      CLAUDE_BASE_URL: http://canary-stub:9785
+      CLAUDE_API_KEY: ${CANARY_STUB_API_KEY:-canary-stub-key}
+      CLAUDE_MODEL: ${CANARY_MODEL:-claude-canary}
+    depends_on:
+      canary-stub:
+        condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,6 +205,15 @@ services:
       HONCHO_USER_PEER_ID: ${HONCHO_USER_PEER_ID:-user}
       PAPERCLIP_AUTOMATION_JWT_SECRET: ${PAPERCLIP_AUTOMATION_JWT_SECRET:-localdev-automation-secret-change-me}
       PAPERCLIP_AGENT_JWT_SECRET: ${PAPERCLIP_AGENT_JWT_SECRET:-localdev-agent-secret-change-me}
+      # Agents run INSIDE this container and authenticate with a local agent
+      # JWT (iss "paperclip", agent secret) that ONLY the backend on :3099
+      # validates — the auth-proxy on :3100 accepts automation JWTs only. The
+      # hermes adapter's paperclipApiUrl default is http://127.0.0.1:3100/api
+      # (the proxy), so without this every agent-side API call (posting the
+      # result comment, marking the issue done) 401s with "Invalid token" while
+      # all health checks stay green. The agent-loop canary smoke
+      # (scripts/smoke-canary.sh) exists to catch exactly this class of gap.
+      PAPERCLIP_API_URL: http://127.0.0.1:3099/api
       PAPERCLIP_ADMIN_EMAIL: ${PAPERCLIP_ADMIN_EMAIL:-admin@localhost}
       PAPERCLIP_ADMIN_PASSWORD: ${PAPERCLIP_ADMIN_PASSWORD:-localdev-admin-change-me}
     ports: ["${PAPERCLIP_PORT:-3100}:3100"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,7 +214,12 @@ services:
       # all health checks stay green. The agent-loop canary smoke
       # (scripts/smoke-canary.sh) exists to catch exactly this class of gap.
       PAPERCLIP_API_URL: http://127.0.0.1:3099/api
-      PAPERCLIP_ADMIN_EMAIL: ${PAPERCLIP_ADMIN_EMAIL:-admin@localhost}
+      # Must be a VALID email shape: better-auth's sign-up validator rejects
+      # TLD-less addresses (admin@localhost → 400 "[body.email] Invalid email
+      # address"), so the previous admin@localhost default could never be
+      # registered and the auth-proxy's admin-session bootstrap was
+      # broken-by-default on a fresh stack — caught by scripts/smoke-canary.sh.
+      PAPERCLIP_ADMIN_EMAIL: ${PAPERCLIP_ADMIN_EMAIL:-admin@example.com}
       PAPERCLIP_ADMIN_PASSWORD: ${PAPERCLIP_ADMIN_PASSWORD:-localdev-admin-change-me}
     ports: ["${PAPERCLIP_PORT:-3100}:3100"]
     volumes: ["paperclip-data:/paperclip"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,6 +220,13 @@ services:
       # registered and the auth-proxy's admin-session bootstrap was
       # broken-by-default on a fresh stack — caught by scripts/smoke-canary.sh.
       PAPERCLIP_ADMIN_EMAIL: ${PAPERCLIP_ADMIN_EMAIL:-admin@example.com}
+      # better-auth derives its trusted origins from PAPERCLIP_ALLOWED_HOSTNAMES
+      # plus the backend's LISTEN port (3099 behind the auth-proxy) — so the
+      # proxy's public origin http://localhost:3100 was NOT trusted and every
+      # sign-up/sign-in through the proxy 403'd "Invalid origin". Setting the
+      # public URL switches better-auth to explicit base-URL mode and trusts
+      # this origin. Caught by scripts/smoke-canary.sh.
+      PAPERCLIP_PUBLIC_URL: ${PAPERCLIP_PUBLIC_URL:-http://localhost:${PAPERCLIP_PORT:-3100}}
       PAPERCLIP_ADMIN_PASSWORD: ${PAPERCLIP_ADMIN_PASSWORD:-localdev-admin-change-me}
     ports: ["${PAPERCLIP_PORT:-3100}:3100"]
     volumes: ["paperclip-data:/paperclip"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,12 +221,19 @@ services:
       # broken-by-default on a fresh stack — caught by scripts/smoke-canary.sh.
       PAPERCLIP_ADMIN_EMAIL: ${PAPERCLIP_ADMIN_EMAIL:-admin@example.com}
       # better-auth derives its trusted origins from PAPERCLIP_ALLOWED_HOSTNAMES
-      # plus the backend's LISTEN port (3099 behind the auth-proxy) — so the
+      # plus the backend's LISTEN port (3099 behind the auth-proxy), so the
       # proxy's public origin http://localhost:3100 was NOT trusted and every
-      # sign-up/sign-in through the proxy 403'd "Invalid origin". Setting the
-      # public URL switches better-auth to explicit base-URL mode and trusts
-      # this origin. Caught by scripts/smoke-canary.sh.
+      # sign-up/sign-in through the proxy 403'd "Invalid origin". Two settings
+      # are needed (both caught live by scripts/smoke-canary.sh):
+      #   - PAPERCLIP_PUBLIC_URL: what the auth-proxy rewrites Origin to (and
+      #     the entrypoint's config.json publicUrl). NOTE: PaperClip's server
+      #     rewrites a localhost base URL's port to its own LISTEN port
+      #     (rewriteLocalUrlPort), so this alone cannot whitelist the proxy
+      #     origin for better-auth.
+      #   - BETTER_AUTH_TRUSTED_ORIGINS: upstream's explicit escape hatch —
+      #     a comma list unioned verbatim into better-auth's trusted origins.
       PAPERCLIP_PUBLIC_URL: ${PAPERCLIP_PUBLIC_URL:-http://localhost:${PAPERCLIP_PORT:-3100}}
+      BETTER_AUTH_TRUSTED_ORIGINS: ${BETTER_AUTH_TRUSTED_ORIGINS:-http://localhost:${PAPERCLIP_PORT:-3100}}
       PAPERCLIP_ADMIN_PASSWORD: ${PAPERCLIP_ADMIN_PASSWORD:-localdev-admin-change-me}
     ports: ["${PAPERCLIP_PORT:-3100}:3100"]
     volumes: ["paperclip-data:/paperclip"]

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -95,6 +95,49 @@ Other wrapper commands: `scripts/local-stack.sh smoke` (re-run the health gate),
 
 ---
 
+## Agent-loop canary (the smoke that proves agents can work)
+
+The health gate above proves containers are **up**. It does not prove an agent
+can **complete work** — a stack can pass every health check while the
+wake → adapter → router → model → disposition path is dead (broken auth
+headers, dropped env wiring, a dead tier). The canary closes that gap:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.canary.yml \
+  --profile full up -d --build
+bash scripts/smoke-canary.sh
+```
+
+What the roundtrip actually exercises (all real production code paths):
+
+1. Files a canary issue via the auth-proxy (automation JWT → session
+   injection), assigned to a `hermes_local` agent it creates on first run.
+2. PaperClip's assignment wake fires; the hermes adapter spawns the real
+   Hermes runtime inside the paperclip container.
+3. Hermes calls the model-router's `/v1/messages` (real router auth + tier
+   dispatch) which forwards to the model backend.
+4. The model replies with a `terminal` tool call; the **real** Hermes runtime
+   executes it — authenticated `curl`s against the PaperClip API that post a
+   disposition comment and PATCH the issue to `done`.
+5. The script polls the issue and **fails loudly** when: the agent never
+   completes (timeout), the issue lands terminal-but-not-done, the issue is
+   done without a disposition comment, or the issue closed without the model
+   hop ever traversing the router.
+
+**What is stubbed:** only the LLM inference. `docker-compose.canary.yml`
+registers `scripts/canary/anthropic_stub.py` — a scripted
+Anthropic-Messages-compatible server — as the router's CLAUDE tier, so the
+canary needs **no model credentials** and runs in CI
+(`.github/workflows/local-stack-smoke.yml`). The stub always answers with the
+same two turns (tool call, then done); nothing about the agent loop itself is
+faked. To run the same roundtrip against a real Claude tier, skip the overlay
+and set `CLAUDE_BASE_URL` / `CLAUDE_API_KEY` / `CLAUDE_MODEL` plus
+`CANARY_MODEL=<your CLAUDE_MODEL>` instead.
+
+Offline checks without a stack: `bash scripts/smoke-canary.sh --self-check`.
+
+---
+
 ## Iterating on a service
 
 To rebuild a single service after editing its code:

--- a/scripts/canary/anthropic_stub.py
+++ b/scripts/canary/anthropic_stub.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""Scripted Anthropic-Messages-API stub for the agent-loop canary smoke.
+
+WHAT THIS IS
+    A stdlib-only HTTP server that impersonates an Anthropic /v1/messages
+    model backend so the e2e agent-loop canary (scripts/smoke-canary.sh) can
+    run in CI with NO model credentials. It is registered as the router's
+    CLAUDE tier by docker-compose.canary.yml; the model-router forwards
+    Hermes's anthropic_messages traffic here via the real Anthropic SDK.
+
+WHAT IS REAL vs STUBBED in the canary roundtrip
+    REAL:     issue filing → assignment wake → hermes_local adapter spawn →
+              Hermes runtime boot → router auth + tier dispatch → terminal
+              tool execution inside the paperclip container → authenticated
+              PaperClip API calls (disposition comment + status=done).
+    STUBBED:  only the LLM inference. Instead of a model deciding what to do,
+              this server replies with a fixed script:
+                turn 1 → a `terminal` tool_use that posts the disposition
+                          comment and PATCHes the canary issue to done
+                turn 2+ → plain text + end_turn.
+              The tool call is EXECUTED BY THE REAL Hermes runtime — nothing
+              about the loop mechanics is faked.
+
+CONTROL SURFACE (used by scripts/smoke-canary.sh)
+    GET  /health         → 200 liveness
+    POST /canary-config  → {"issueIdentifier": "ABC-1", "apiBase": ".../api"}
+                           arms the stub for one roundtrip (resets counters)
+    GET  /canary-state   → counters {model_requests, tool_turns, ...} so the
+                           smoke can assert the model hop actually traversed
+                           the router (an issue closed out-of-band would
+                           otherwise pass silently)
+    POST /v1/messages    → the scripted Anthropic Messages endpoint
+                           (supports stream:true SSE and non-streaming JSON)
+
+Auth: requires x-api-key == CANARY_STUB_API_KEY (default canary-stub-key) on
+/v1/messages — asserts the router actually forwarded its tier credential.
+
+Run self-checks (no network):  python3 scripts/canary/anthropic_stub.py --self-test
+"""
+
+import json
+import os
+import re
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PORT = int(os.environ.get("CANARY_STUB_PORT", "9785"))
+API_KEY = os.environ.get("CANARY_STUB_API_KEY", "canary-stub-key")
+# How long a /v1/messages request will wait for /canary-config to arrive when
+# it looks like our canary task but the smoke script hasn't armed us yet
+# (assignment wake can beat the config call in a race).
+CONFIG_WAIT_SECONDS = float(os.environ.get("CANARY_CONFIG_WAIT_SECONDS", "20"))
+MARKER = "AAF-CANARY-ROUNDTRIP"
+DISPOSITION_TAG = "[aaf-canary] disposition:"
+
+_state_lock = threading.Lock()
+_state = {
+    "issue_identifier": None,
+    "api_base": None,
+    "model_requests": 0,       # total /v1/messages calls seen
+    "tool_turns": 0,           # times we replied with the terminal tool_use
+    "final_turns": 0,          # times we replied end_turn after the tool ran
+    "unmatched_requests": 0,   # auxiliary calls (no terminal tool / no marker)
+}
+
+
+def _log(msg):
+    print(f"[canary-stub] {msg}", flush=True)
+
+
+# ── Turn scripting (pure — exercised by --self-test) ─────────────────────────
+
+def build_disposition_command(issue_identifier, api_base):
+    """The shell command the 'model' asks the real Hermes terminal tool to run.
+
+    Prefers $PAPERCLIP_API_URL (injected by the hermes adapter / compose) so a
+    stack whose agent-side API wiring is broken fails LOUDLY instead of being
+    papered over; falls back to the api_base the smoke script supplied.
+    """
+    comment_body = (
+        f"{DISPOSITION_TAG} completed - canary roundtrip verified. "
+        "Wake -> adapter -> Hermes runtime -> router -> model(stub) -> "
+        "terminal tool -> PaperClip API all traversed. "
+        "(Model inference is stubbed by scripts/canary/anthropic_stub.py; "
+        "everything else in this loop is real.)"
+    )
+    comment_json = json.dumps({"body": comment_body})
+    done_json = json.dumps({"status": "done"})
+    return (
+        f'api="${{PAPERCLIP_API_URL:-{api_base}}}"; api="${{api%/}}"; '
+        'case "$api" in */api) ;; *) api="$api/api" ;; esac; '
+        f'curl -sS -f -X POST "$api/issues/{issue_identifier}/comments" '
+        '-H "Authorization: Bearer $PAPERCLIP_API_KEY" '
+        '-H "Origin: http://localhost:3100" '
+        '-H "Content-Type: application/json" '
+        f"-d {shell_quote(comment_json)} "
+        f'&& curl -sS -f -X PATCH "$api/issues/{issue_identifier}" '
+        '-H "Authorization: Bearer $PAPERCLIP_API_KEY" '
+        '-H "Origin: http://localhost:3100" '
+        '-H "Content-Type: application/json" '
+        f"-d {shell_quote(done_json)}"
+    )
+
+
+def shell_quote(s):
+    return "'" + s.replace("'", "'\\''") + "'"
+
+
+def _iter_text(value):
+    """Yield every text fragment in an Anthropic message content value."""
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, list):
+        for block in value:
+            if isinstance(block, dict):
+                if isinstance(block.get("text"), str):
+                    yield block["text"]
+                # tool_result content can nest blocks
+                if isinstance(block.get("content"), (str, list)):
+                    yield from _iter_text(block["content"])
+
+
+def request_text(body):
+    parts = []
+    parts.extend(_iter_text(body.get("system", "")))
+    for msg in body.get("messages", []):
+        parts.extend(_iter_text(msg.get("content", "")))
+    return "\n".join(parts)
+
+
+def has_terminal_tool(body):
+    for tool in body.get("tools") or []:
+        if isinstance(tool, dict) and tool.get("name") == "terminal":
+            return True
+    return False
+
+
+def already_ran_tool(body):
+    """True if a prior assistant turn in this transcript already carried our
+    canary terminal tool_use (i.e. the tool result is coming back)."""
+    for msg in body.get("messages", []):
+        if msg.get("role") != "assistant":
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "tool_use"
+                and block.get("name") == "terminal"
+                and DISPOSITION_TAG in json.dumps(block.get("input", {}))
+            ):
+                return True
+    return False
+
+
+def decide_turn(body, issue_identifier, api_base):
+    """Return ('tool', command) | ('final', text) | ('aux', text)."""
+    text = request_text(body)
+    if MARKER not in text:
+        return ("aux", "ok")
+    if already_ran_tool(body):
+        return ("final", "Canary disposition posted and issue closed. Done.")
+    if has_terminal_tool(body) and issue_identifier:
+        return ("tool", build_disposition_command(issue_identifier, api_base))
+    # Canary task but no terminal tool exposed — make the failure diagnosable.
+    return (
+        "aux",
+        "canary-stub: task recognised but no `terminal` tool was offered; "
+        "cannot post the disposition. Check the agent's enabled toolsets.",
+    )
+
+
+# ── Anthropic response rendering ─────────────────────────────────────────────
+
+_msg_counter = [0]
+
+
+def _next_msg_id():
+    _msg_counter[0] += 1
+    return f"msg_canary_{_msg_counter[0]:06d}"
+
+
+def render_content_blocks(kind, payload):
+    if kind == "tool":
+        return [
+            {"type": "text", "text": "Executing the canary disposition via the terminal tool."},
+            {
+                "type": "tool_use",
+                "id": f"toolu_canary_{_msg_counter[0]:06d}",
+                "name": "terminal",
+                "input": {"command": payload, "timeout": 120},
+            },
+        ]
+    return [{"type": "text", "text": payload}]
+
+
+def non_stream_response(model, kind, payload):
+    stop_reason = "tool_use" if kind == "tool" else "end_turn"
+    return {
+        "id": _next_msg_id(),
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": render_content_blocks(kind, payload),
+        "stop_reason": stop_reason,
+        "stop_sequence": None,
+        "usage": {"input_tokens": 64, "output_tokens": 64},
+    }
+
+
+def sse_events(model, kind, payload):
+    """Yield (event_name, data_dict) tuples in Anthropic SSE wire order."""
+    stop_reason = "tool_use" if kind == "tool" else "end_turn"
+    msg_id = _next_msg_id()
+    yield (
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": msg_id,
+                "type": "message",
+                "role": "assistant",
+                "model": model,
+                "content": [],
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 64, "output_tokens": 1},
+            },
+        },
+    )
+    blocks = render_content_blocks(kind, payload)
+    for idx, block in enumerate(blocks):
+        if block["type"] == "text":
+            yield (
+                "content_block_start",
+                {"type": "content_block_start", "index": idx,
+                 "content_block": {"type": "text", "text": ""}},
+            )
+            yield (
+                "content_block_delta",
+                {"type": "content_block_delta", "index": idx,
+                 "delta": {"type": "text_delta", "text": block["text"]}},
+            )
+        else:  # tool_use
+            yield (
+                "content_block_start",
+                {"type": "content_block_start", "index": idx,
+                 "content_block": {"type": "tool_use", "id": block["id"],
+                                    "name": block["name"], "input": {}}},
+            )
+            yield (
+                "content_block_delta",
+                {"type": "content_block_delta", "index": idx,
+                 "delta": {"type": "input_json_delta",
+                           "partial_json": json.dumps(block["input"])}},
+            )
+        yield ("content_block_stop", {"type": "content_block_stop", "index": idx})
+    yield (
+        "message_delta",
+        {"type": "message_delta",
+         "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+         "usage": {"output_tokens": 64}},
+    )
+    yield ("message_stop", {"type": "message_stop"})
+
+
+# ── HTTP server ──────────────────────────────────────────────────────────────
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):  # route BaseHTTPRequestHandler noise through our logger
+        _log(fmt % args)
+
+    def _json(self, code, obj):
+        data = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _read_body(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(length) if length else b"{}"
+        return json.loads(raw or b"{}")
+
+    def do_GET(self):
+        path = self.path.split("?")[0]
+        if path == "/health":
+            self._json(200, {"status": "ok", "service": "canary-stub"})
+        elif path == "/canary-state":
+            with _state_lock:
+                self._json(200, dict(_state))
+        else:
+            self._json(404, {"error": "not found"})
+
+    def do_POST(self):
+        path = self.path.split("?")[0]
+        if path == "/canary-config":
+            try:
+                body = self._read_body()
+            except Exception as e:
+                self._json(400, {"error": f"bad json: {e}"})
+                return
+            ident = body.get("issueIdentifier")
+            api_base = body.get("apiBase")
+            if not ident:
+                self._json(400, {"error": "issueIdentifier required"})
+                return
+            with _state_lock:
+                _state["issue_identifier"] = ident
+                _state["api_base"] = api_base or "http://127.0.0.1:3099/api"
+                _state["model_requests"] = 0
+                _state["tool_turns"] = 0
+                _state["final_turns"] = 0
+                _state["unmatched_requests"] = 0
+            _log(f"armed for issue {ident} (api_base={api_base})")
+            self._json(200, {"status": "armed", "issueIdentifier": ident})
+        elif path in ("/v1/messages", "/anthropic/v1/messages"):
+            self._handle_messages()
+        else:
+            self._json(404, {"error": "not found"})
+
+    def _handle_messages(self):
+        provided = (self.headers.get("x-api-key") or "").strip()
+        if provided != API_KEY:
+            _log(f"REJECTED /v1/messages: bad x-api-key ({provided[:8]!r}...)")
+            self._json(401, {"type": "error",
+                             "error": {"type": "authentication_error",
+                                       "message": "invalid x-api-key"}})
+            return
+        try:
+            body = self._read_body()
+        except Exception as e:
+            self._json(400, {"type": "error",
+                             "error": {"type": "invalid_request_error",
+                                       "message": f"bad json: {e}"}})
+            return
+
+        model = body.get("model", "claude-canary")
+        with _state_lock:
+            _state["model_requests"] += 1
+            ident = _state["issue_identifier"]
+            api_base = _state["api_base"]
+
+        # The assignment wake can reach us before smoke-canary.sh arms the
+        # stub; if this request carries the canary marker, wait briefly.
+        if ident is None and MARKER in request_text(body):
+            deadline = time.monotonic() + CONFIG_WAIT_SECONDS
+            while time.monotonic() < deadline:
+                time.sleep(0.5)
+                with _state_lock:
+                    ident = _state["issue_identifier"]
+                    api_base = _state["api_base"]
+                if ident:
+                    break
+
+        kind, payload = decide_turn(body, ident, api_base)
+        with _state_lock:
+            if kind == "tool":
+                _state["tool_turns"] += 1
+            elif kind == "final":
+                _state["final_turns"] += 1
+            else:
+                _state["unmatched_requests"] += 1
+        _log(
+            f"/v1/messages turn={kind} stream={bool(body.get('stream'))} "
+            f"model={model} msgs={len(body.get('messages', []))} "
+            f"tools={len(body.get('tools') or [])}"
+        )
+
+        if body.get("stream"):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            # SSE has no fixed length; close delimits the response.
+            self.send_header("Connection", "close")
+            self.end_headers()
+            for event, data in sse_events(model, kind, payload):
+                chunk = f"event: {event}\ndata: {json.dumps(data)}\n\n".encode()
+                self.wfile.write(chunk)
+                self.wfile.flush()
+            self.close_connection = True
+        else:
+            self._json(200, non_stream_response(model, kind, payload))
+
+
+# ── Self-test (no network) ───────────────────────────────────────────────────
+
+def self_test():
+    failures = []
+
+    def check(name, cond):
+        print(("  PASS " if cond else "  FAIL ") + name)
+        if not cond:
+            failures.append(name)
+
+    task_prompt = (
+        f"You are Canary. ## Assigned Task\nIssue: AAF-1\nTitle: [{MARKER}] roundtrip\n"
+        f"{MARKER}: post the disposition comment and mark this issue done."
+    )
+    tools = [{"name": "terminal", "description": "run shell",
+              "input_schema": {"type": "object",
+                               "properties": {"command": {"type": "string"}}}}]
+
+    # 1. first canary turn → terminal tool_use with disposition + done curls
+    body1 = {"model": "claude-canary", "max_tokens": 512, "stream": False,
+             "system": "sys", "tools": tools,
+             "messages": [{"role": "user", "content": task_prompt}]}
+    kind, payload = decide_turn(body1, "AAF-1", "http://127.0.0.1:3099/api")
+    check("turn1 is tool", kind == "tool")
+    check("turn1 posts disposition comment", DISPOSITION_TAG in payload)
+    check("turn1 targets the issue", "/issues/AAF-1" in payload)
+    check("turn1 marks done", '\\"status\\": \\"done\\"' in json.dumps(payload))
+    resp = non_stream_response("claude-canary", kind, payload)
+    check("non-stream stop_reason tool_use", resp["stop_reason"] == "tool_use")
+    check("non-stream has tool_use block",
+          any(b["type"] == "tool_use" and b["name"] == "terminal"
+              for b in resp["content"]))
+
+    # 2. second turn (tool result back) → end_turn
+    body2 = {
+        "model": "claude-canary", "max_tokens": 512, "tools": tools,
+        "messages": [
+            {"role": "user", "content": task_prompt},
+            {"role": "assistant", "content": resp["content"]},
+            {"role": "user", "content": [
+                {"type": "tool_result",
+                 "tool_use_id": resp["content"][1]["id"],
+                 "content": [{"type": "text", "text": '{"exit_code": 0}'}]}]},
+        ],
+    }
+    kind2, payload2 = decide_turn(body2, "AAF-1", "http://127.0.0.1:3099/api")
+    check("turn2 is final", kind2 == "final")
+
+    # 3. auxiliary request (no marker) never gets the tool script
+    body3 = {"model": "claude-canary", "max_tokens": 64,
+             "messages": [{"role": "user", "content": "summarize this session"}]}
+    kind3, _ = decide_turn(body3, "AAF-1", "http://127.0.0.1:3099/api")
+    check("aux request is aux", kind3 == "aux")
+
+    # 4. canary task but stub not armed → no tool turn (aux, diagnosable)
+    kind4, payload4 = decide_turn(body1, None, None)
+    check("unarmed stub does not emit tool turn", kind4 != "tool")
+
+    # 5. SSE event ordering is valid Anthropic wire shape
+    events = list(sse_events("claude-canary", "tool", payload))
+    names = [e[0] for e in events]
+    check("sse starts with message_start", names[0] == "message_start")
+    check("sse ends with message_stop", names[-1] == "message_stop")
+    check("sse has input_json_delta",
+          any(d.get("delta", {}).get("type") == "input_json_delta"
+              for _, d in events))
+    check(
+        "sse tool json reassembles",
+        json.loads(
+            next(d["delta"]["partial_json"] for _, d in events
+                 if d.get("delta", {}).get("type") == "input_json_delta")
+        )["command"] == payload,
+    )
+
+    # 6. the disposition command survives shell quoting (no unescaped quotes)
+    check("command shell-quotes JSON payloads", payload.count("-d '") == 2)
+
+    print(f"[canary-stub] self-test: {len(failures)} failure(s)")
+    return 1 if failures else 0
+
+
+def main():
+    if "--self-test" in sys.argv:
+        sys.exit(self_test())
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
+    _log(f"listening on :{PORT} (POST /canary-config to arm; GET /canary-state)")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke-canary.sh
+++ b/scripts/smoke-canary.sh
@@ -43,7 +43,10 @@ PAPERCLIP_AUTOMATION_JWT_SECRET="${PAPERCLIP_AUTOMATION_JWT_SECRET:-localdev-aut
 # Must match the auth-proxy's verifyJwt defaults (apps/paperclip/auth-proxy.mjs).
 PAPERCLIP_AUTOMATION_JWT_ISSUER="${PAPERCLIP_AUTOMATION_JWT_ISSUER:-azureagentforge-automation}"
 PAPERCLIP_AUTOMATION_JWT_AUDIENCE="${PAPERCLIP_AUTOMATION_JWT_AUDIENCE:-paperclip-api}"
-PAPERCLIP_ADMIN_EMAIL="${PAPERCLIP_ADMIN_EMAIL:-admin@localhost}"
+# better-auth rejects TLD-less emails (admin@localhost), so the default must
+# be a real email shape and must match the paperclip container's
+# PAPERCLIP_ADMIN_EMAIL (the auth-proxy signs in with that account).
+PAPERCLIP_ADMIN_EMAIL="${PAPERCLIP_ADMIN_EMAIL:-admin@example.com}"
 PAPERCLIP_ADMIN_PASSWORD="${PAPERCLIP_ADMIN_PASSWORD:-localdev-admin-change-me}"
 # In-container URL agents use for their own API calls (backend, NOT the proxy).
 PAPERCLIP_INTERNAL_API_URL="${PAPERCLIP_INTERNAL_API_URL:-http://127.0.0.1:3099/api}"

--- a/scripts/smoke-canary.sh
+++ b/scripts/smoke-canary.sh
@@ -176,6 +176,28 @@ wait_http() { # url label deadline_s
   done
 }
 
+# On failure, pull everything the stack knows about the canary issue so the
+# CI log is self-diagnosing: the issue JSON (blocker attention / recovery
+# action), its comments (PaperClip's run-recovery comments carry the adapter
+# failure summary), the company's recent runs (error + errorCode), and the
+# stub counters.
+dump_diagnostics() {
+  echo "  ── canary diagnostics ──────────────────────────────────────────"
+  if [ -n "${ISSUE_IDENT:-}" ]; then
+    api GET "/api/issues/${ISSUE_IDENT}"
+    echo "  issue: $(printf '%s' "$API_BODY" | head -c 1500)"
+    api GET "/api/issues/${ISSUE_IDENT}/comments"
+    echo "  comments: $(printf '%s' "$API_BODY" | head -c 2500)"
+  fi
+  if [ -n "${COMPANY_ID:-}" ]; then
+    api GET "/api/companies/${COMPANY_ID}/runs?sinceMinutes=60&limit=10"
+    echo "  runs: $(printf '%s' "$API_BODY" | head -c 3000)"
+  fi
+  STUB_STATE="$(curl -s "${STUB}/canary-state" 2>/dev/null || echo '{}')"
+  echo "  stub: ${STUB_STATE}"
+  echo "  ────────────────────────────────────────────────────────────────"
+}
+
 # ── 0. Preconditions ─────────────────────────────────────────────────────────
 wait_http "${BASE}/api/auth/proxy-health" "paperclip auth-proxy" 120 || summary_and_exit
 wait_http "${STUB}/health" "canary stub" 60 || summary_and_exit
@@ -316,9 +338,12 @@ while :; do
   fi
   case "$STATUS" in
     done|cancelled) break ;;
+    blocked)
+      dump_diagnostics
+      die "issue moved to BLOCKED — PaperClip's run dispatch/recovery gave up on the assignee (see diagnostics above for the recovery comment + run error)" ;;
   esac
   if [ "$(date +%s)" -ge "$deadline" ]; then
-    STUB_STATE="$(curl -s "${STUB}/canary-state" 2>/dev/null || echo '{}')"
+    dump_diagnostics
     die "TIMEOUT after ${CANARY_TIMEOUT_SECONDS}s — agent never completed the canary issue (last status: ${STATUS:-unknown}). The wake→adapter→router→model→disposition path is broken."
   fi
   sleep "$CANARY_POLL_SECONDS"
@@ -330,6 +355,7 @@ STUB_STATE="$(curl -s "${STUB}/canary-state" 2>/dev/null || echo '{}')"
 if [ "$STATUS" = "done" ]; then
   pass "issue reached status=done"
 else
+  dump_diagnostics
   die "issue terminal but NOT done (status=${STATUS}) — the agent gave up or the issue was cancelled"
 fi
 

--- a/scripts/smoke-canary.sh
+++ b/scripts/smoke-canary.sh
@@ -189,9 +189,24 @@ dump_diagnostics() {
     api GET "/api/issues/${ISSUE_IDENT}/comments"
     echo "  comments: $(printf '%s' "$API_BODY" | head -c 2500)"
   fi
-  if [ -n "${COMPANY_ID:-}" ]; then
-    api GET "/api/companies/${COMPANY_ID}/runs?sinceMinutes=60&limit=10"
-    echo "  runs: $(printf '%s' "$API_BODY" | head -c 3000)"
+  if [ -n "${ISSUE_IDENT:-}" ]; then
+    api GET "/api/issues/${ISSUE_IDENT}/runs"
+    echo "  runs: $(printf '%s' "$API_BODY" | head -c 2000)"
+    # Pull the newest run's log — it carries the adapter's full stderr (e.g.
+    # the hermes traceback that the recovery comment truncates to one line).
+    local_run_id="$(jget "$API_BODY" "next((r.get('id') for r in (d if isinstance(d, list) else (d or {}).get('runs', [])) if isinstance(r, dict) and r.get('id')), '')")"
+    if [ -n "$local_run_id" ]; then
+      api GET "/api/heartbeat-runs/${local_run_id}/log?limitBytes=6000"
+      echo "  run ${local_run_id} log (tail):"
+      printf '%s' "$API_BODY" | python3 -c '
+import json,sys
+try:
+    d = json.loads(sys.stdin.read() or "{}")
+    log = d.get("log") or d.get("content") or d.get("data") or json.dumps(d)
+except Exception:
+    log = "<unparseable>"
+print("\n".join("    | " + l for l in str(log).splitlines()[-60:]))'
+    fi
   fi
   STUB_STATE="$(curl -s "${STUB}/canary-state" 2>/dev/null || echo '{}')"
   echo "  stub: ${STUB_STATE}"

--- a/scripts/smoke-canary.sh
+++ b/scripts/smoke-canary.sh
@@ -132,8 +132,13 @@ print(f"{h}.{p}.{sig}")
 PY
 }
 
-# api METHOD PATH [JSON_BODY] → body on stdout; HTTP code in API_CODE
+# api METHOD PATH [JSON_BODY] → sets API_CODE (HTTP status) and API_BODY.
+# MUST be invoked directly — NEVER via command substitution: `$(api ...)`
+# runs it in a subshell, so neither variable would reach the caller (that
+# exact bug shipped in the first version of this script and made every
+# status-code check compare against an empty string).
 API_CODE=""
+API_BODY=""
 api() {
   local method="$1" path="$2" body="${3:-}"
   local args=(-sS -X "$method" "${BASE}${path}"
@@ -143,7 +148,7 @@ api() {
     -o /tmp/aaf_canary_resp -w '%{http_code}')
   [ -n "$body" ] && args+=(-d "$body")
   API_CODE="$(curl "${args[@]}" 2>/dev/null || echo 000)"
-  cat /tmp/aaf_canary_resp 2>/dev/null
+  API_BODY="$(cat /tmp/aaf_canary_resp 2>/dev/null || printf '')"
 }
 
 # jget JSON PYEXPR → evaluates PYEXPR with `d` bound to parsed JSON
@@ -199,11 +204,11 @@ esac
 
 # ── 2. Automation JWT works end-to-end through the proxy ────────────────────
 JWT="$(mint_jwt)"
-whoami_resp="$(api GET /api/auth/whoami)"
-if [ "$API_CODE" = "200" ] && printf '%s' "$whoami_resp" | grep -q '"jwt"'; then
+api GET /api/auth/whoami
+if [ "$API_CODE" = "200" ] && printf '%s' "$API_BODY" | grep -q '"jwt"'; then
   pass "automation JWT accepted by auth-proxy"
 else
-  die "automation JWT rejected (${API_CODE}): $(printf '%s' "$whoami_resp" | head -c 300)"
+  die "automation JWT rejected (${API_CODE}): $(printf '%s' "$API_BODY" | head -c 300)"
 fi
 
 # ── 2b. Claim first instance admin (idempotent) ──────────────────────────────
@@ -211,30 +216,30 @@ fi
 # claims it via POST /api/bootstrap/claim (authenticated+private mode). The
 # JWT proxy path rides the bootstrapped admin session, so the claim lands on
 # our admin user. 409 = already claimed (fine on re-runs).
-claim="$(api POST /api/bootstrap/claim '{}')"
+api POST /api/bootstrap/claim '{}'
 case "$API_CODE" in
   200) pass "instance admin claimed" ;;
   409) pass "instance admin already claimed" ;;
-  *) die "instance-admin claim failed (${API_CODE}): $(printf '%s' "$claim" | head -c 300)" ;;
+  *) die "instance-admin claim failed (${API_CODE}): $(printf '%s' "$API_BODY" | head -c 300)" ;;
 esac
 
 # ── 3. Find-or-create canary company ─────────────────────────────────────────
-companies="$(api GET /api/companies)"
-[ "$API_CODE" = "200" ] || die "list companies failed (${API_CODE}): $(printf '%s' "$companies" | head -c 300)"
-COMPANY_ID="$(jget "$companies" "next((c['id'] for c in (d if isinstance(d, list) else (d or {}).get('companies', d if isinstance(d, list) else [])) if isinstance(c, dict) and c.get('name') == '${COMPANY_NAME}'), '')")"
+api GET /api/companies
+[ "$API_CODE" = "200" ] || die "list companies failed (${API_CODE}): $(printf '%s' "$API_BODY" | head -c 300)"
+COMPANY_ID="$(jget "$API_BODY" "next((c['id'] for c in (d if isinstance(d, list) else (d or {}).get('companies', d if isinstance(d, list) else [])) if isinstance(c, dict) and c.get('name') == '${COMPANY_NAME}'), '')")"
 if [ -n "$COMPANY_ID" ]; then
   pass "company '${COMPANY_NAME}' exists (${COMPANY_ID})"
 else
-  created="$(api POST /api/companies "{\"name\":\"${COMPANY_NAME}\",\"description\":\"Canary company for the e2e agent-loop smoke\"}")"
-  COMPANY_ID="$(jget "$created" "(d or {}).get('id') or ((d or {}).get('company') or {}).get('id')")"
-  [ -n "$COMPANY_ID" ] || die "create company failed (${API_CODE}): $(printf '%s' "$created" | head -c 300)"
+  api POST /api/companies "{\"name\":\"${COMPANY_NAME}\",\"description\":\"Canary company for the e2e agent-loop smoke\"}"
+  COMPANY_ID="$(jget "$API_BODY" "(d or {}).get('id') or ((d or {}).get('company') or {}).get('id')")"
+  [ -n "$COMPANY_ID" ] || die "create company failed (${API_CODE}): $(printf '%s' "$API_BODY" | head -c 300)"
   pass "company created (${COMPANY_ID})"
 fi
 
 # ── 4. Find-or-create canary agent (hermes_local on the stub model tier) ────
-agents="$(api GET "/api/companies/${COMPANY_ID}/agents")"
-[ "$API_CODE" = "200" ] || die "list agents failed (${API_CODE}): $(printf '%s' "$agents" | head -c 300)"
-AGENT_ID="$(jget "$agents" "next((a['id'] for a in (d if isinstance(d, list) else (d or {}).get('agents', [])) if isinstance(a, dict) and a.get('name') == '${AGENT_NAME}'), '')")"
+api GET "/api/companies/${COMPANY_ID}/agents"
+[ "$API_CODE" = "200" ] || die "list agents failed (${API_CODE}): $(printf '%s' "$API_BODY" | head -c 300)"
+AGENT_ID="$(jget "$API_BODY" "next((a['id'] for a in (d if isinstance(d, list) else (d or {}).get('agents', [])) if isinstance(a, dict) and a.get('name') == '${AGENT_NAME}'), '')")"
 if [ -n "$AGENT_ID" ]; then
   pass "agent '${AGENT_NAME}' exists (${AGENT_ID})"
 else
@@ -260,9 +265,9 @@ print(json.dumps({
     },
     "budgetMonthlyCents": 100,
 }))' "$AGENT_NAME" "$CANARY_MODEL")"
-  created="$(api POST "/api/companies/${COMPANY_ID}/agents" "$agent_payload")"
-  AGENT_ID="$(jget "$created" "(d or {}).get('id') or ((d or {}).get('agent') or {}).get('id')")"
-  [ -n "$AGENT_ID" ] || die "create agent failed (${API_CODE}): $(printf '%s' "$created" | head -c 300)"
+  api POST "/api/companies/${COMPANY_ID}/agents" "$agent_payload"
+  AGENT_ID="$(jget "$API_BODY" "(d or {}).get('id') or ((d or {}).get('agent') or {}).get('id')")"
+  [ -n "$AGENT_ID" ] || die "create agent failed (${API_CODE}): $(printf '%s' "$API_BODY" | head -c 300)"
   pass "agent created (${AGENT_ID})"
 fi
 
@@ -282,10 +287,10 @@ print(json.dumps({
     "priority": "high",
     "assigneeAgentId": sys.argv[3],
 }))' "$MARKER" "$ts" "$AGENT_ID")"
-created="$(api POST "/api/companies/${COMPANY_ID}/issues" "$issue_payload")"
-ISSUE_ID="$(jget "$created" "(d or {}).get('id') or ((d or {}).get('issue') or {}).get('id')")"
-ISSUE_IDENT="$(jget "$created" "(d or {}).get('identifier') or ((d or {}).get('issue') or {}).get('identifier')")"
-[ -n "$ISSUE_ID" ] || die "create issue failed (${API_CODE}): $(printf '%s' "$created" | head -c 300)"
+api POST "/api/companies/${COMPANY_ID}/issues" "$issue_payload"
+ISSUE_ID="$(jget "$API_BODY" "(d or {}).get('id') or ((d or {}).get('issue') or {}).get('id')")"
+ISSUE_IDENT="$(jget "$API_BODY" "(d or {}).get('identifier') or ((d or {}).get('issue') or {}).get('identifier')")"
+[ -n "$ISSUE_ID" ] || die "create issue failed (${API_CODE}): $(printf '%s' "$API_BODY" | head -c 300)"
 [ -n "$ISSUE_IDENT" ] || ISSUE_IDENT="$ISSUE_ID"
 pass "canary issue filed (${ISSUE_IDENT}, backlog)"
 
@@ -294,8 +299,8 @@ arm="$(curl -sS -X POST "${STUB}/canary-config" -H "Content-Type: application/js
 printf '%s' "$arm" | grep -q '"armed"' || die "failed to arm canary stub: ${arm:-<no response>}"
 pass "stub armed for ${ISSUE_IDENT}"
 
-release="$(api PATCH "/api/issues/${ISSUE_IDENT}" '{"status":"todo"}')"
-[ "$API_CODE" = "200" ] || die "release to todo failed (${API_CODE}): $(printf '%s' "$release" | head -c 300)"
+api PATCH "/api/issues/${ISSUE_IDENT}" '{"status":"todo"}'
+[ "$API_CODE" = "200" ] || die "release to todo failed (${API_CODE}): $(printf '%s' "$API_BODY" | head -c 300)"
 pass "issue released to todo — assignment wake queued"
 
 # ── 6. Poll until terminal status or deadline ────────────────────────────────
@@ -303,8 +308,8 @@ deadline=$(( $(date +%s) + CANARY_TIMEOUT_SECONDS ))
 STATUS=""
 last_logged=""
 while :; do
-  issue="$(api GET "/api/issues/${ISSUE_IDENT}")"
-  STATUS="$(jget "$issue" "(d or {}).get('status') or ((d or {}).get('issue') or {}).get('status')")"
+  api GET "/api/issues/${ISSUE_IDENT}"
+  STATUS="$(jget "$API_BODY" "(d or {}).get('status') or ((d or {}).get('issue') or {}).get('status')")"
   if [ "$STATUS" != "$last_logged" ] && [ -n "$STATUS" ]; then
     echo "    status: ${STATUS} ($(( deadline - $(date +%s) ))s left)"
     last_logged="$STATUS"
@@ -328,9 +333,9 @@ else
   die "issue terminal but NOT done (status=${STATUS}) — the agent gave up or the issue was cancelled"
 fi
 
-comments="$(api GET "/api/issues/${ISSUE_IDENT}/comments")"
-[ "$API_CODE" = "200" ] || die "list comments failed (${API_CODE}): $(printf '%s' "$comments" | head -c 300)"
-disposition="$(jget "$comments" "next((c.get('body','') for c in (d if isinstance(d, list) else (d or {}).get('comments', [])) if isinstance(c, dict) and '${DISPOSITION_TAG}' in (c.get('body') or '')), '')")"
+api GET "/api/issues/${ISSUE_IDENT}/comments"
+[ "$API_CODE" = "200" ] || die "list comments failed (${API_CODE}): $(printf '%s' "$API_BODY" | head -c 300)"
+disposition="$(jget "$API_BODY" "next((c.get('body','') for c in (d if isinstance(d, list) else (d or {}).get('comments', [])) if isinstance(c, dict) and '${DISPOSITION_TAG}' in (c.get('body') or '')), '')")"
 if [ -n "$disposition" ]; then
   pass "disposition comment present"
   echo "    ${disposition}" | head -c 240; echo

--- a/scripts/smoke-canary.sh
+++ b/scripts/smoke-canary.sh
@@ -238,10 +238,10 @@ AGENT_ID="$(jget "$agents" "next((a['id'] for a in (d if isinstance(d, list) els
 if [ -n "$AGENT_ID" ]; then
   pass "agent '${AGENT_NAME}' exists (${AGENT_ID})"
 else
-  # provider "auto" is load-bearing: it stops the adapter inferring
-  # --provider anthropic from the claude-* model name, so the container's
-  # Hermes config.yaml (provider custom → router, api_mode
-  # anthropic_messages) controls routing.
+  # provider "auto" is defense-in-depth: the A1 build patch pins the
+  # adapter to --provider custom unconditionally (config.yaml → router),
+  # but on an unpatched image "auto" still prevents the adapter inferring
+  # --provider anthropic from the claude-* model name.
   agent_payload="$(python3 -c '
 import json, sys
 print(json.dumps({

--- a/scripts/smoke-canary.sh
+++ b/scripts/smoke-canary.sh
@@ -191,10 +191,10 @@ dump_diagnostics() {
   fi
   if [ -n "${ISSUE_IDENT:-}" ]; then
     api GET "/api/issues/${ISSUE_IDENT}/runs"
-    echo "  runs: $(printf '%s' "$API_BODY" | head -c 2000)"
+    echo "  runs: $(printf '%s' "$API_BODY" | head -c 4000)"
     # Pull the newest run's log — it carries the adapter's full stderr (e.g.
     # the hermes traceback that the recovery comment truncates to one line).
-    local_run_id="$(jget "$API_BODY" "next((r.get('id') for r in (d if isinstance(d, list) else (d or {}).get('runs', [])) if isinstance(r, dict) and r.get('id')), '')")"
+    local_run_id="$(jget "$API_BODY" "next((r.get('runId') or r.get('id') for r in (d if isinstance(d, list) else (d or {}).get('runs', [])) if isinstance(r, dict) and (r.get('runId') or r.get('id'))), '')")"
     if [ -n "$local_run_id" ]; then
       api GET "/api/heartbeat-runs/${local_run_id}/log?limitBytes=6000"
       echo "  run ${local_run_id} log (tail):"

--- a/scripts/smoke-canary.sh
+++ b/scripts/smoke-canary.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+# Agent-loop canary — the e2e smoke that proves the product actually works.
+#
+# The health gate (scripts/smoke-local.sh) proves containers are up; it does
+# NOT prove an agent can complete work. This script closes that gap with a
+# canary-issue roundtrip against the full local stack + the canary overlay
+# (docker-compose.canary.yml):
+#
+#   file issue → assignment wake → hermes_local adapter spawns the Hermes
+#   runtime → model call goes through the model-router (real auth + tier
+#   dispatch) → scripted stub "model" returns a terminal tool call → the REAL
+#   Hermes runtime executes it → agent posts a disposition comment and marks
+#   the issue done → this script asserts done + disposition + that the model
+#   hop actually traversed the router.
+#
+# ONLY the LLM inference is stubbed (scripts/canary/anthropic_stub.py); every
+# other hop is the real production code path.
+#
+# FAILS LOUDLY when:
+#   - the agent never completes the issue (wake/adapter/model path broken)
+#   - the issue lands terminal-but-not-done (e.g. cancelled)
+#   - the issue is done but carries no disposition comment
+#   - the issue is done but the model hop never traversed router → stub
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.canary.yml \
+#     --profile full up -d --build
+#   bash scripts/smoke-canary.sh
+#
+#   bash scripts/smoke-canary.sh --self-check   # offline: stub self-test +
+#                                               # JWT mint check, no stack
+set -uo pipefail
+
+PAPERCLIP_PORT="${PAPERCLIP_PORT:-3100}"
+ROUTER_PORT="${ROUTER_PORT:-8080}"
+CANARY_STUB_PORT="${CANARY_STUB_PORT:-9785}"
+CANARY_MODEL="${CANARY_MODEL:-claude-canary}"
+# Deadline for the full roundtrip (wake + Hermes boot + 2 model turns + curls).
+CANARY_TIMEOUT_SECONDS="${CANARY_TIMEOUT_SECONDS:-300}"
+CANARY_POLL_SECONDS="${CANARY_POLL_SECONDS:-5}"
+# Dev-default secrets — match docker-compose.yml / .env.example.
+PAPERCLIP_AUTOMATION_JWT_SECRET="${PAPERCLIP_AUTOMATION_JWT_SECRET:-localdev-automation-secret-change-me}"
+# Must match the auth-proxy's verifyJwt defaults (apps/paperclip/auth-proxy.mjs).
+PAPERCLIP_AUTOMATION_JWT_ISSUER="${PAPERCLIP_AUTOMATION_JWT_ISSUER:-azureagentforge-automation}"
+PAPERCLIP_AUTOMATION_JWT_AUDIENCE="${PAPERCLIP_AUTOMATION_JWT_AUDIENCE:-paperclip-api}"
+PAPERCLIP_ADMIN_EMAIL="${PAPERCLIP_ADMIN_EMAIL:-admin@localhost}"
+PAPERCLIP_ADMIN_PASSWORD="${PAPERCLIP_ADMIN_PASSWORD:-localdev-admin-change-me}"
+# In-container URL agents use for their own API calls (backend, NOT the proxy).
+PAPERCLIP_INTERNAL_API_URL="${PAPERCLIP_INTERNAL_API_URL:-http://127.0.0.1:3099/api}"
+
+BASE="http://localhost:${PAPERCLIP_PORT}"
+STUB="http://127.0.0.1:${CANARY_STUB_PORT}"
+ORIGIN="http://localhost:${PAPERCLIP_PORT}"
+COMPANY_NAME="${CANARY_COMPANY_NAME:-AAF Canary}"
+AGENT_NAME="${CANARY_AGENT_NAME:-Canary}"
+MARKER="AAF-CANARY-ROUNDTRIP"
+DISPOSITION_TAG="[aaf-canary] disposition:"
+
+fail=0
+pass() { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+bad()  { printf '  \033[31m✗\033[0m %s\n' "$1"; fail=1; }
+die()  { bad "$1"; summary_and_exit; }
+
+MODE="roundtrip"
+summary_and_exit() {
+  echo
+  if [ "$fail" -eq 0 ]; then
+    if [ "$MODE" = "self-check" ]; then
+      echo "smoke-canary: PASS (self-check only — no live roundtrip was run)"
+    else
+      echo "smoke-canary: PASS — agent-loop roundtrip verified (model hop stubbed, loop real)"
+    fi
+    exit 0
+  fi
+  echo "smoke-canary: FAIL"
+  echo "  Debug: docker compose -f docker-compose.yml -f docker-compose.canary.yml --profile full logs paperclip model-router canary-stub"
+  [ -n "${STUB_STATE:-}" ] && echo "  Stub counters at exit: ${STUB_STATE}"
+  exit 1
+}
+
+# ── Offline self-check mode ──────────────────────────────────────────────────
+if [ "${1:-}" = "--self-check" ]; then
+  MODE="self-check"
+  echo "smoke-canary: self-check (offline — no stack required)…"
+  if python3 "$(dirname "$0")/canary/anthropic_stub.py" --self-test; then
+    pass "stub model scripted-turn self-test"
+  else
+    bad "stub model scripted-turn self-test"
+  fi
+  if python3 - "$PAPERCLIP_AUTOMATION_JWT_SECRET" <<'PY'
+import base64, hashlib, hmac, json, sys, time
+secret = sys.argv[1]
+b64 = lambda b: base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+h = b64(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+now = int(time.time())
+p = b64(json.dumps({"sub": "aaf-canary", "role": "automation", "scope": ["*"],
+                    "iss": "automation-agent", "aud": "paperclip-api",
+                    "iat": now, "exp": now + 60}).encode())
+sig = b64(hmac.new(secret.encode(), f"{h}.{p}".encode(), hashlib.sha256).digest())
+token = f"{h}.{p}.{sig}"
+assert token.count(".") == 2 and len(token) > 60
+PY
+  then pass "automation JWT mint"; else bad "automation JWT mint"; fi
+  summary_and_exit
+fi
+
+command -v curl >/dev/null || { echo "curl required"; exit 1; }
+command -v python3 >/dev/null || { echo "python3 required"; exit 1; }
+
+echo "smoke-canary: e2e agent-loop roundtrip (stub model backend, real loop)…"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+mint_jwt() {
+  python3 - "$PAPERCLIP_AUTOMATION_JWT_SECRET" \
+    "$PAPERCLIP_AUTOMATION_JWT_ISSUER" "$PAPERCLIP_AUTOMATION_JWT_AUDIENCE" <<'PY'
+import base64, hashlib, hmac, json, sys, time
+secret, iss, aud = sys.argv[1], sys.argv[2], sys.argv[3]
+b64 = lambda b: base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+h = b64(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+now = int(time.time())
+# scope ["*"]: the canary exercises company/agent/issue/comment surfaces; "*"
+# satisfies both mapped scopes and the proxy's unmapped-path fallback.
+p = b64(json.dumps({"sub": "aaf-canary", "role": "automation", "scope": ["*"],
+                    "iss": iss, "aud": aud,
+                    "iat": now, "exp": now + 1800}).encode())
+sig = b64(hmac.new(secret.encode(), f"{h}.{p}".encode(), hashlib.sha256).digest())
+print(f"{h}.{p}.{sig}")
+PY
+}
+
+# api METHOD PATH [JSON_BODY] → body on stdout; HTTP code in API_CODE
+API_CODE=""
+api() {
+  local method="$1" path="$2" body="${3:-}"
+  local args=(-sS -X "$method" "${BASE}${path}"
+    -H "Authorization: Bearer ${JWT}"
+    -H "Origin: ${ORIGIN}"
+    -H "Content-Type: application/json"
+    -o /tmp/aaf_canary_resp -w '%{http_code}')
+  [ -n "$body" ] && args+=(-d "$body")
+  API_CODE="$(curl "${args[@]}" 2>/dev/null || echo 000)"
+  cat /tmp/aaf_canary_resp 2>/dev/null
+}
+
+# jget JSON PYEXPR → evaluates PYEXPR with `d` bound to parsed JSON
+jget() {
+  python3 -c '
+import json, sys
+try:
+    d = json.loads(sys.argv[1] or "null")
+except Exception:
+    d = None
+try:
+    v = eval(sys.argv[2])
+except Exception:
+    v = ""
+print(v if v is not None else "")' "$1" "$2" 2>/dev/null
+}
+
+wait_http() { # url label deadline_s
+  local url="$1" label="$2" deadline=$(( $(date +%s) + ${3:-90} )) code
+  while :; do
+    code="$(curl -s -o /dev/null -w '%{http_code}' "$url" 2>/dev/null || echo 000)"
+    [ "$code" = "200" ] && { pass "$label reachable"; return 0; }
+    [ "$(date +%s)" -ge "$deadline" ] && { bad "$label unreachable (last code $code)"; return 1; }
+    sleep 2
+  done
+}
+
+# ── 0. Preconditions ─────────────────────────────────────────────────────────
+wait_http "${BASE}/api/auth/proxy-health" "paperclip auth-proxy" 120 || summary_and_exit
+wait_http "${STUB}/health" "canary stub" 60 || summary_and_exit
+router_health="$(curl -s "http://localhost:${ROUTER_PORT}/health" 2>/dev/null || echo '')"
+if printf '%s' "$router_health" | grep -q "\"${CANARY_MODEL}\""; then
+  pass "router registered canary tier '${CANARY_MODEL}'"
+else
+  die "router /health does not list tier '${CANARY_MODEL}' — was docker-compose.canary.yml applied? (got: ${router_health:-<none>})"
+fi
+
+# ── 1. Admin sign-up (first user claims instance admin; idempotent) ─────────
+signup_code="$(curl -sS -X POST "${BASE}/api/auth/sign-up/email" \
+  -H "Content-Type: application/json" -H "Origin: ${ORIGIN}" \
+  -d "{\"name\":\"Admin\",\"email\":\"${PAPERCLIP_ADMIN_EMAIL}\",\"password\":\"${PAPERCLIP_ADMIN_PASSWORD}\"}" \
+  -o /tmp/aaf_canary_signup -w '%{http_code}' 2>/dev/null || echo 000)"
+case "$signup_code" in
+  2*) pass "admin user created (${PAPERCLIP_ADMIN_EMAIL})" ;;
+  4*)
+    if grep -qi "exist" /tmp/aaf_canary_signup 2>/dev/null; then
+      pass "admin user already exists"
+    else
+      die "admin sign-up failed (${signup_code}): $(head -c 300 /tmp/aaf_canary_signup)"
+    fi ;;
+  *) die "admin sign-up failed (${signup_code}): $(head -c 300 /tmp/aaf_canary_signup 2>/dev/null)" ;;
+esac
+
+# ── 2. Automation JWT works end-to-end through the proxy ────────────────────
+JWT="$(mint_jwt)"
+whoami_resp="$(api GET /api/auth/whoami)"
+if [ "$API_CODE" = "200" ] && printf '%s' "$whoami_resp" | grep -q '"jwt"'; then
+  pass "automation JWT accepted by auth-proxy"
+else
+  die "automation JWT rejected (${API_CODE}): $(printf '%s' "$whoami_resp" | head -c 300)"
+fi
+
+# ── 2b. Claim first instance admin (idempotent) ──────────────────────────────
+# Sign-up alone does NOT grant instance admin; the first browser-session user
+# claims it via POST /api/bootstrap/claim (authenticated+private mode). The
+# JWT proxy path rides the bootstrapped admin session, so the claim lands on
+# our admin user. 409 = already claimed (fine on re-runs).
+claim="$(api POST /api/bootstrap/claim '{}')"
+case "$API_CODE" in
+  200) pass "instance admin claimed" ;;
+  409) pass "instance admin already claimed" ;;
+  *) die "instance-admin claim failed (${API_CODE}): $(printf '%s' "$claim" | head -c 300)" ;;
+esac
+
+# ── 3. Find-or-create canary company ─────────────────────────────────────────
+companies="$(api GET /api/companies)"
+[ "$API_CODE" = "200" ] || die "list companies failed (${API_CODE}): $(printf '%s' "$companies" | head -c 300)"
+COMPANY_ID="$(jget "$companies" "next((c['id'] for c in (d if isinstance(d, list) else (d or {}).get('companies', d if isinstance(d, list) else [])) if isinstance(c, dict) and c.get('name') == '${COMPANY_NAME}'), '')")"
+if [ -n "$COMPANY_ID" ]; then
+  pass "company '${COMPANY_NAME}' exists (${COMPANY_ID})"
+else
+  created="$(api POST /api/companies "{\"name\":\"${COMPANY_NAME}\",\"description\":\"Canary company for the e2e agent-loop smoke\"}")"
+  COMPANY_ID="$(jget "$created" "(d or {}).get('id') or ((d or {}).get('company') or {}).get('id')")"
+  [ -n "$COMPANY_ID" ] || die "create company failed (${API_CODE}): $(printf '%s' "$created" | head -c 300)"
+  pass "company created (${COMPANY_ID})"
+fi
+
+# ── 4. Find-or-create canary agent (hermes_local on the stub model tier) ────
+agents="$(api GET "/api/companies/${COMPANY_ID}/agents")"
+[ "$API_CODE" = "200" ] || die "list agents failed (${API_CODE}): $(printf '%s' "$agents" | head -c 300)"
+AGENT_ID="$(jget "$agents" "next((a['id'] for a in (d if isinstance(d, list) else (d or {}).get('agents', [])) if isinstance(a, dict) and a.get('name') == '${AGENT_NAME}'), '')")"
+if [ -n "$AGENT_ID" ]; then
+  pass "agent '${AGENT_NAME}' exists (${AGENT_ID})"
+else
+  # provider "auto" is load-bearing: it stops the adapter inferring
+  # --provider anthropic from the claude-* model name, so the container's
+  # Hermes config.yaml (provider custom → router, api_mode
+  # anthropic_messages) controls routing.
+  agent_payload="$(python3 -c '
+import json, sys
+print(json.dumps({
+    "name": sys.argv[1],
+    "role": "general",
+    "title": "Canary roundtrip agent",
+    "adapterType": "hermes_local",
+    "adapterConfig": {
+        "model": sys.argv[2],
+        "provider": "auto",
+        "timeoutSec": 240,
+        "persistSession": False,
+        "quiet": True,
+        "maxTurnsPerRun": 6,
+        "enabledToolsets": ["terminal"],
+    },
+    "budgetMonthlyCents": 100,
+}))' "$AGENT_NAME" "$CANARY_MODEL")"
+  created="$(api POST "/api/companies/${COMPANY_ID}/agents" "$agent_payload")"
+  AGENT_ID="$(jget "$created" "(d or {}).get('id') or ((d or {}).get('agent') or {}).get('id')")"
+  [ -n "$AGENT_ID" ] || die "create agent failed (${API_CODE}): $(printf '%s' "$created" | head -c 300)"
+  pass "agent created (${AGENT_ID})"
+fi
+
+# ── 5. File the canary issue in backlog (no wake yet), arm stub, release ────
+ts="$(date -u +%Y%m%dT%H%M%SZ)"
+issue_payload="$(python3 -c '
+import json, sys
+print(json.dumps({
+    "title": f"[{sys.argv[1]}] agent-loop roundtrip {sys.argv[2]}",
+    "description": (
+        f"{sys.argv[1]}: This is the e2e agent-loop canary "
+        "(scripts/smoke-canary.sh). Post the disposition comment on this "
+        "issue and mark it done. A scripted stub model backend drives the "
+        "agent; the loop itself is real."
+    ),
+    "status": "backlog",
+    "priority": "high",
+    "assigneeAgentId": sys.argv[3],
+}))' "$MARKER" "$ts" "$AGENT_ID")"
+created="$(api POST "/api/companies/${COMPANY_ID}/issues" "$issue_payload")"
+ISSUE_ID="$(jget "$created" "(d or {}).get('id') or ((d or {}).get('issue') or {}).get('id')")"
+ISSUE_IDENT="$(jget "$created" "(d or {}).get('identifier') or ((d or {}).get('issue') or {}).get('identifier')")"
+[ -n "$ISSUE_ID" ] || die "create issue failed (${API_CODE}): $(printf '%s' "$created" | head -c 300)"
+[ -n "$ISSUE_IDENT" ] || ISSUE_IDENT="$ISSUE_ID"
+pass "canary issue filed (${ISSUE_IDENT}, backlog)"
+
+arm="$(curl -sS -X POST "${STUB}/canary-config" -H "Content-Type: application/json" \
+  -d "{\"issueIdentifier\":\"${ISSUE_IDENT}\",\"apiBase\":\"${PAPERCLIP_INTERNAL_API_URL}\"}" 2>/dev/null || echo '')"
+printf '%s' "$arm" | grep -q '"armed"' || die "failed to arm canary stub: ${arm:-<no response>}"
+pass "stub armed for ${ISSUE_IDENT}"
+
+release="$(api PATCH "/api/issues/${ISSUE_IDENT}" '{"status":"todo"}')"
+[ "$API_CODE" = "200" ] || die "release to todo failed (${API_CODE}): $(printf '%s' "$release" | head -c 300)"
+pass "issue released to todo — assignment wake queued"
+
+# ── 6. Poll until terminal status or deadline ────────────────────────────────
+deadline=$(( $(date +%s) + CANARY_TIMEOUT_SECONDS ))
+STATUS=""
+last_logged=""
+while :; do
+  issue="$(api GET "/api/issues/${ISSUE_IDENT}")"
+  STATUS="$(jget "$issue" "(d or {}).get('status') or ((d or {}).get('issue') or {}).get('status')")"
+  if [ "$STATUS" != "$last_logged" ] && [ -n "$STATUS" ]; then
+    echo "    status: ${STATUS} ($(( deadline - $(date +%s) ))s left)"
+    last_logged="$STATUS"
+  fi
+  case "$STATUS" in
+    done|cancelled) break ;;
+  esac
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    STUB_STATE="$(curl -s "${STUB}/canary-state" 2>/dev/null || echo '{}')"
+    die "TIMEOUT after ${CANARY_TIMEOUT_SECONDS}s — agent never completed the canary issue (last status: ${STATUS:-unknown}). The wake→adapter→router→model→disposition path is broken."
+  fi
+  sleep "$CANARY_POLL_SECONDS"
+done
+
+STUB_STATE="$(curl -s "${STUB}/canary-state" 2>/dev/null || echo '{}')"
+
+# ── 7. Assertions ────────────────────────────────────────────────────────────
+if [ "$STATUS" = "done" ]; then
+  pass "issue reached status=done"
+else
+  die "issue terminal but NOT done (status=${STATUS}) — the agent gave up or the issue was cancelled"
+fi
+
+comments="$(api GET "/api/issues/${ISSUE_IDENT}/comments")"
+[ "$API_CODE" = "200" ] || die "list comments failed (${API_CODE}): $(printf '%s' "$comments" | head -c 300)"
+disposition="$(jget "$comments" "next((c.get('body','') for c in (d if isinstance(d, list) else (d or {}).get('comments', [])) if isinstance(c, dict) and '${DISPOSITION_TAG}' in (c.get('body') or '')), '')")"
+if [ -n "$disposition" ]; then
+  pass "disposition comment present"
+  echo "    ${disposition}" | head -c 240; echo
+else
+  die "issue is done but carries NO disposition comment ('${DISPOSITION_TAG}') — done-without-work"
+fi
+
+model_requests="$(jget "$STUB_STATE" "(d or {}).get('model_requests', 0)")"
+tool_turns="$(jget "$STUB_STATE" "(d or {}).get('tool_turns', 0)")"
+if [ "${model_requests:-0}" -ge 1 ] 2>/dev/null && [ "${tool_turns:-0}" -ge 1 ] 2>/dev/null; then
+  pass "model hop traversed router → stub (requests=${model_requests}, tool turns=${tool_turns})"
+else
+  die "issue closed but the model hop never traversed the router → stub (state: ${STUB_STATE}) — something closed the issue out-of-band"
+fi
+
+summary_and_exit

--- a/scripts/vendored-config/manifest-paperclip.yaml
+++ b/scripts/vendored-config/manifest-paperclip.yaml
@@ -25,6 +25,8 @@ accepted_env:
     consumer: upstream server — better-auth signing secret
   - key: BETTER_AUTH_URL
     consumer: upstream server — better-auth base URL
+  - key: BETTER_AUTH_TRUSTED_ORIGINS
+    consumer: upstream server — comma list unioned into better-auth trusted origins (server/src/index.ts; needed because rewriteLocalUrlPort clobbers a localhost public URL's port, so the auth-proxy origin :3100 is otherwise untrusted)
   - key: PAPERCLIP_AGENT_JWT_SECRET
     consumer: upstream server — agent-JWT mint/validation secret
   - key: PAPERCLIP_API_URL

--- a/services/model-router/README.md
+++ b/services/model-router/README.md
@@ -125,7 +125,7 @@ Semantics:
 
 ## Security
 
-- **Bearer auth**: set `ROUTER_API_KEY` to require a matching `Authorization: Bearer <key>` header on all `/v1/*` requests.
+- **API-key auth**: set `ROUTER_API_KEY` to require a matching credential on all `/v1/*` requests — either `Authorization: Bearer <key>` (OpenAI-style clients) or `x-api-key: <key>` (Anthropic-native clients; the Anthropic SDK sends x-api-key for any custom base_url, which is how Hermes's `anthropic_messages` transport reaches `/v1/messages`). Fails closed (503) when unset.
 - **Rate limiting**: `RATE_LIMIT_RPM` (default: 60) enforces a per-IP sliding-window limit.
 - **Input validation**: message count capped at `MAX_MESSAGES` (default: 200); total tokens at `MAX_BODY_TOKENS` (default: 200 000).
 

--- a/services/model-router/main.py
+++ b/services/model-router/main.py
@@ -54,7 +54,20 @@ _ROUTER_API_KEY = os.environ.get("ROUTER_API_KEY", "")
 
 
 def _verify_auth(request: Request) -> None:
-    """Require a valid Bearer token. Fail closed when unconfigured (aaf-0005)."""
+    """Require a valid Bearer token OR x-api-key. Fail closed when unconfigured
+    (aaf-0005).
+
+    Two header schemes carry the same single ROUTER_API_KEY:
+      - `Authorization: Bearer <key>` — OpenAI-style clients (LiteLLM, the
+        OpenAI SDK, in-mesh services).
+      - `x-api-key: <key>` — Anthropic-native clients. The Anthropic SDK sends
+        x-api-key (not Authorization) for any non-anthropic.com base_url, so
+        Hermes's `api_mode: anthropic_messages` transport hits /v1/messages with
+        x-api-key only. Before this was accepted, every agent model call on the
+        cache-friendly Messages path died with 401 while /health stayed green —
+        exactly the silent stack-shape breakage the agent-loop canary smoke
+        (scripts/smoke-canary.sh) exists to catch.
+    """
     if not _ROUTER_API_KEY:
         # Fail CLOSED — an unset key must mean "down", never "open".
         raise HTTPException(
@@ -62,9 +75,15 @@ def _verify_auth(request: Request) -> None:
             detail="Router authentication not configured (ROUTER_API_KEY unset)",
         )
     auth = request.headers.get("authorization", "")
-    if not auth.lower().startswith("bearer "):
-        raise HTTPException(status_code=401, detail="Missing Authorization header")
-    token = auth[7:].strip()
+    if auth.lower().startswith("bearer "):
+        token = auth[7:].strip()
+    else:
+        token = (request.headers.get("x-api-key") or "").strip()
+        if not token:
+            raise HTTPException(
+                status_code=401,
+                detail="Missing Authorization header (Bearer) or x-api-key",
+            )
     # Constant-time comparison over fixed-length digests to prevent timing attacks.
     expected = hashlib.sha256(_ROUTER_API_KEY.encode()).digest()
     provided = hashlib.sha256(token.encode()).digest()

--- a/services/model-router/tests/test_auth.py
+++ b/services/model-router/tests/test_auth.py
@@ -46,6 +46,37 @@ class TestVerifyAuth:
         req = make_request(headers={"authorization": "bearer   s3cret  "})
         assert router._verify_auth(req) is None
 
+    def test_x_api_key_passes(self, router, monkeypatch, make_request):
+        """Anthropic-native clients (Hermes anthropic_messages transport) send
+        x-api-key instead of Authorization — same key, alternate header."""
+        monkeypatch.setattr(router, "_ROUTER_API_KEY", "s3cret")
+        req = make_request(headers={"x-api-key": "s3cret"})
+        assert router._verify_auth(req) is None
+
+    def test_x_api_key_wrong_403(self, router, monkeypatch, make_request):
+        monkeypatch.setattr(router, "_ROUTER_API_KEY", "s3cret")
+        with pytest.raises(HTTPException) as exc:
+            router._verify_auth(make_request(headers={"x-api-key": "wrong"}))
+        assert exc.value.status_code == 403
+
+    def test_bearer_wins_over_x_api_key(self, router, monkeypatch, make_request):
+        """When both headers are present the Bearer token is authoritative — a
+        wrong Bearer is rejected even if x-api-key is correct (no fallback that
+        would mask a misconfigured primary credential)."""
+        monkeypatch.setattr(router, "_ROUTER_API_KEY", "s3cret")
+        with pytest.raises(HTTPException) as exc:
+            router._verify_auth(
+                make_request(headers={"authorization": "Bearer wrong", "x-api-key": "s3cret"})
+            )
+        assert exc.value.status_code == 403
+
+    def test_x_api_key_fails_closed_when_unconfigured(self, router, monkeypatch, make_request):
+        # aaf-0005 also holds for the x-api-key scheme.
+        monkeypatch.setattr(router, "_ROUTER_API_KEY", "")
+        with pytest.raises(HTTPException) as exc:
+            router._verify_auth(make_request(headers={"x-api-key": "anything"}))
+        assert exc.value.status_code == 503
+
     def test_endpoint_rejects_unauthenticated(self, unauth_client, router, monkeypatch):
         """End-to-end: a protected endpoint 401s when the key is set and no
         header is sent (exercises the guard through the real ASGI Request)."""

--- a/services/paperclip/Dockerfile
+++ b/services/paperclip/Dockerfile
@@ -207,7 +207,15 @@ RUN mkdir -p /tmp/tsx-pkg && cd /tmp/tsx-pkg \
 # ── Stage 2c: Hermes CLI (Python) ─────────────────────────────────────────────
 # Build Hermes Agent from the local source (not PyPI).
 # Installs into /opt/hermes so it's independent of a specific Python venv path.
-FROM python:3.14-slim AS hermes-cli
+# MUST match the production stage's runtime python. The production base is
+# node:lts-trixie-slim (Debian trixie → python3 = 3.13) and PYTHONPATH below
+# hard-codes /opt/hermes/lib/python3.13/site-packages. Building this stage on
+# python:3.14 installed the Hermes deps under python3.14/ with cp314 binary
+# wheels — so the runtime python3.13 found an EMPTY site-packages and every
+# `hermes` spawn died instantly with ModuleNotFoundError (adapter_failed →
+# run recovery → issue blocked). The stack's health checks stayed green the
+# whole time; the agent-loop canary (scripts/smoke-canary.sh) caught it.
+FROM python:3.13-slim AS hermes-cli
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends gcc git \

--- a/services/paperclip/docker-entrypoint.sh
+++ b/services/paperclip/docker-entrypoint.sh
@@ -216,6 +216,16 @@ HERMES_EOF
 chown node:node "${HERMES_CONFIG}" 2>/dev/null || true
 echo "[entrypoint] Wrote Hermes config at ${HERMES_CONFIG} (provider=custom api_mode=chat_completions base_url=${HERMES_BASE_URL_DEFAULT})"
 
+# The Hermes home tree is created/written by ROOT during this entrypoint, but
+# the hermes CLI runs as `node` at agent spawn and must stat/read AND WRITE
+# inside it (its .env probe, sessions, logs). On Azure Files (SMB) permissions
+# surface as 0777 so this was invisible; on a real POSIX volume a root-owned
+# ~/.hermes killed EVERY agent spawn with
+#   PermissionError: [Errno 13] Permission denied: '/paperclip/.hermes/.env'
+# (surfacing only as an opaque `adapter_failed` recovery comment). Caught by
+# the agent-loop canary (scripts/smoke-canary.sh).
+chown -R node:node "${HERMES_CONFIG_DIR}" 2>/dev/null || true
+
 # ── JWT Auth Proxy for automation API access ─────────────────────────────────
 # When PAPERCLIP_AUTOMATION_JWT_SECRET is set, the auth proxy sits on port 3100
 # (the public port) and forwards to Paperclip on port 3099 (internal).


### PR DESCRIPTION
## What this proves

`local-stack-smoke` passed while the stack was incapable of doing work: it checked containers and health endpoints but never proved an agent could **complete a task**. This PR adds the only test that proves the product works — a canary-issue roundtrip run in CI on every stack-affecting change:

**file issue → assignment wake → `hermes_local` adapter spawns the real Hermes runtime → model call through the model-router (real auth + tier dispatch) → the agent executes a real terminal tool call → posts a disposition comment → marks the issue done.**

The smoke **fails loudly** (with self-diagnosing dumps: issue JSON, recovery comments, run errors, stub counters) when:
- the agent never completes the issue (bounded timeout; 420 s in CI),
- PaperClip moves the issue to `blocked` (dispatch/recovery gave up),
- the issue lands terminal-but-not-done,
- the issue is `done` without a disposition comment,
- the issue closed without the model hop ever traversing the router.

## What's real vs stubbed

**Only the LLM inference is stubbed.** `scripts/canary/anthropic_stub.py` is a scripted Anthropic-Messages-compatible backend (turn 1: `terminal` tool call that posts the disposition + PATCHes done; turn 2: end_turn), registered as the router's CLAUDE tier by the `docker-compose.canary.yml` overlay — so CI needs no model credentials. Everything else — wake, adapter spawn, the real vendored Hermes runtime, router auth/tier dispatch/OpenAI↔Anthropic conversion/SSE, terminal execution, authenticated PaperClip API writes — is the production code path. Nothing about the loop itself is faked.

## What the canary caught (all fixed here)

Each live CI iteration surfaced a real, previously invisible stack-shape defect — every one of them with all health checks green:

1. **`hermes` could never boot in the AAF paperclip image** (`fix(paperclip)`): the `hermes-cli` build stage used python:3.14 (deps under `python3.14/`, cp314 wheels) while the runtime image is Debian trixie python3.13 with `PYTHONPATH=/opt/hermes/lib/python3.13/site-packages` — a directory that never existed. Every agent spawn died in ModuleNotFoundError; run recovery moved assigned issues to `blocked` within seconds. Present since the file was first committed — no agent has ever been able to run in this image. Canary signature: `todo → blocked` in 5 s, `model_requests=0`.
2. **Router rejected Hermes's Anthropic-native model calls** (`fix(router)`): the Anthropic SDK sends `x-api-key` (not `Authorization: Bearer`) for custom base URLs, so `anthropic_messages` transport calls always 401'd. The router now accepts the same `ROUTER_API_KEY` via either header (fail-closed unchanged; Bearer authoritative when both present). This is also the router-side change that A1 (#115) documented as the precondition for re-enabling the cache-friendly `anthropic_messages` mode.
3. **Agent-side API calls hit the wrong port** (`fix(compose)`): agents authenticate with a local agent JWT that only the backend on `:3099` validates; the adapter's default targets the auth-proxy on `:3100`, so posting results / marking done 401'd. `PAPERCLIP_API_URL` now points at the internal backend (mirrors production wiring).
4. **The default admin credential could never be registered** (`fix(compose)`): better-auth rejects TLD-less emails, so `admin@localhost` could not sign up — which also bricked the auth-proxy's admin-session bootstrap on any fresh stack. Default is now `admin@example.com`.
5. **The auth-proxy's public origin was never trusted** (`fix(compose)`): better-auth derives trusted origins from `PAPERCLIP_ALLOWED_HOSTNAMES` + the backend's *listen* port (3099), and `rewriteLocalUrlPort` clobbers a localhost `PAPERCLIP_PUBLIC_URL`'s port — so sign-up/sign-in through the proxy 403'd `INVALID_ORIGIN`. Fixed via upstream's explicit `BETTER_AUTH_TRUSTED_ORIGINS` escape hatch (key added to the A3 vendored-config manifest with its verified consumer).

6. **The Hermes home was unusable by the agent user** (`fix(paperclip)`): the entrypoint (root) creates `/paperclip/.hermes` after the early recursive chown, so it stayed root-owned and every node-user `hermes` spawn died at import: `PermissionError: [Errno 13] Permission denied: '/paperclip/.hermes/.env'` — surfacing only as an opaque one-line `adapter_failed` recovery comment. Azure Files (SMB) masks this class entirely (everything appears 0777), which is why production never saw it; a real POSIX volume exposes it. Both entrypoint copies now chown the Hermes home to node, and the new CI runtime probe runs as `--user node` (a root probe would poison `~/.hermes` for the spawns it validates).

## Evidence of what was run locally

- **Vendored-Hermes e2e** (strongest local proof): installed the pinned Hermes v0.14 submodule into a venv and ran the adapter's exact spawn (`hermes chat -q … -Q -m claude-canary --provider custom -t terminal --max-turns … --source tool --yolo`) with the A1-generated `config.yaml` against the real model-router + stub: 2 streaming model calls through the router, 1 terminal tool turn executed by the real runtime, clean exit 0.
- **Both router wire shapes**: real Anthropic SDK (`x-api-key`, `/v1/messages`, stream + non-stream) and real OpenAI SDK (Bearer, `/v1/chat/completions` with OpenAI→Anthropic conversion, stream + non-stream) → router → stub, plus 401/403 auth negatives.
- **Script functional test**: full `smoke-canary.sh` run against a local mock of the auth-proxy API surface (sign-up → claim → company → agent → issue → wake → poll → done + disposition + counters): PASS. (This harness caught a real subshell bug in the script's status-code handling before it could mask later steps.)
- Router pytest suite: 241 passed (5 new auth tests). Stub `--self-test`: 14/14. `--self-check`: PASS. `docker compose config -q` (base + overlay), workflow YAML, `bash -n` + `shellcheck --severity=error`, `scan-internal-refs.sh`, and the A3 `validate_vendored_config.py` guard: all clean.
- **The full containerized roundtrip runs in this PR's `local-stack-smoke` workflow** (too heavy for the dev machine, which shares its Docker daemon with a production deployment).

## Green run evidence

[local-stack-smoke run 29189461169](https://github.com/mrobinson2/AzureAgentForge/actions/runs/29189461169) — health gate PASS, runtime probe PASS, canary roundtrip PASS: issue `todo → done` in ~5 s, disposition comment present, model hop verified through the router (stub counters: requests=2, tool turns=1). Every earlier iteration's failure was a real defect listed above, found and fixed by this same canary.

## CI wiring

- `local-stack-smoke.yml`: after the existing (unchanged) no-creds health gate, apply the canary overlay (`up -d --wait canary-stub model-router`) and run `scripts/smoke-canary.sh` (420 s roundtrip budget); failure logs + teardown include the overlay; path filters extended.
- `ci.yml`: overlay compose-config validation, stub self-test, script offline self-check, `compileall scripts/canary`.

## How to run locally

```bash
docker compose -f docker-compose.yml -f docker-compose.canary.yml --profile full up -d --build
bash scripts/smoke-canary.sh
```

Docs: new "Agent-loop canary" section in `docs/local-development.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
