### PR TITLE
feat(router): hard cost-envelope enforcement — warn/downgrade/block (A6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,24 @@ OPENAI_COMPAT_API_KEY=
 EMBEDDING_API_KEY=
 EMBEDDING_BASE_URL=
 EMBEDDING_MODEL=text-embedding-3-small
+# Daily cap for the embeddings ledger bucket (default 1.00; 0 disables the cap,
+# spend is still tracked). EMBEDDING_PRICE_PER_MTOK is the list-price fallback
+# used when LiteLLM reports no response_cost (default 0.02 matches
+# text-embedding-3-small; adjust it alongside EMBEDDING_MODEL).
+EMBEDDING_DAILY_BUDGET_USD=
+EMBEDDING_PRICE_PER_MTOK=
+
+# ── Model Router — acting budget enforcement (A6) ─────────────────────────────
+# What happens when a tier exhausts its *_DAILY_BUDGET_USD:
+#   warn (default) — serve anyway + WARN log (pre-A6 behavior, ship-dark safe)
+#   downgrade      — serve BUDGET_FALLBACK_TIER instead; response carries the
+#                    X-Router-Budget-Downgrade header
+#   block          — refuse with 429 + machine-readable budget_exceeded body
+# Invalid values fail open to warn. The fallback tier itself is exempt (it is
+# the designated floor). See services/model-router/README.md § Budget
+# enforcement for per-path semantics (/v1/messages, /v1/embeddings).
+BUDGET_ENFORCE_MODE=
+BUDGET_FALLBACK_TIER=
 
 # ── Azure AI Foundry — grok-4-fast-reasoning (primary default model) ─────────
 # Key Vault secrets: platform-azure-ai-foundry-grok4-uri-target

--- a/deploy/mac-site/docker-compose.yml
+++ b/deploy/mac-site/docker-compose.yml
@@ -37,6 +37,12 @@ x-router-models: &router-models
   PHI_MODEL: ${PHI_MODEL:-Phi-4}
   PHI_MAX_TOKENS: ${PHI_MAX_TOKENS:-2048}
   PHI_DAILY_BUDGET_USD: ${PHI_DAILY_BUDGET_USD:-0.50}
+  # A6 acting budget enforcement: warn (default; observe-only) | downgrade
+  # (serve BUDGET_FALLBACK_TIER + X-Router-Budget-Downgrade header) | block
+  # (429 budget_exceeded). Invalid values fail open to warn.
+  BUDGET_ENFORCE_MODE: ${BUDGET_ENFORCE_MODE:-warn}
+  BUDGET_FALLBACK_TIER: ${BUDGET_FALLBACK_TIER:-gpt4o-mini}
+  EMBEDDING_DAILY_BUDGET_USD: ${EMBEDDING_DAILY_BUDGET_USD:-1.00}
 
 services:
   # ── Single-writer lease guard — every service waits on this ────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,12 @@ services:
       EMBEDDING_API_KEY: ${EMBEDDING_API_KEY:-}
       EMBEDDING_BASE_URL: ${EMBEDDING_BASE_URL:-}
       EMBEDDING_MODEL: ${EMBEDDING_MODEL:-text-embedding-3-small}
+      EMBEDDING_DAILY_BUDGET_USD: ${EMBEDDING_DAILY_BUDGET_USD:-1.00}
+      # A6 acting budget enforcement: warn (default; pre-A6 behavior) |
+      # downgrade (serve BUDGET_FALLBACK_TIER + X-Router-Budget-Downgrade
+      # header) | block (429 budget_exceeded). Invalid values fail open to warn.
+      BUDGET_ENFORCE_MODE: ${BUDGET_ENFORCE_MODE:-warn}
+      BUDGET_FALLBACK_TIER: ${BUDGET_FALLBACK_TIER:-gpt4o-mini}
     ports: ["${ROUTER_PORT:-8080}:8080"]
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8080/health').status==200 else 1)\""]

--- a/infrastructure/modules/container-apps/hermes.tf
+++ b/infrastructure/modules/container-apps/hermes.tf
@@ -461,6 +461,18 @@ resource "azurerm_container_app" "hermes" {
         value = "4096"
       }
 
+      # ── A6 acting budget enforcement ──
+      # warn (default; observe-only) | downgrade (serve the fallback tier +
+      # X-Router-Budget-Downgrade header) | block (429 budget_exceeded).
+      env {
+        name  = "BUDGET_ENFORCE_MODE"
+        value = var.budget_enforce_mode
+      }
+      env {
+        name  = "BUDGET_FALLBACK_TIER"
+        value = var.budget_fallback_tier
+      }
+
       env {
         name  = "LOG_LEVEL"
         value = "info" # was "debug" — excessive log volume in deployed environments

--- a/infrastructure/modules/container-apps/memory_governor.tf
+++ b/infrastructure/modules/container-apps/memory_governor.tf
@@ -230,6 +230,22 @@ resource "azurerm_container_app" "memory_governor" {
         name  = "GPT4O_DAILY_BUDGET_USD"
         value = var.memory_classifier_daily_budget_usd
       }
+      # ── A6 acting budget enforcement (same contract as the hermes-pod
+      # router). The embeddings cap protects the governor's vector-retrieval
+      # spend; there is no downgrade target for embeddings (vector-space pin),
+      # so downgrade degrades to warn on that path and block 429s.
+      env {
+        name  = "BUDGET_ENFORCE_MODE"
+        value = var.budget_enforce_mode
+      }
+      env {
+        name  = "BUDGET_FALLBACK_TIER"
+        value = var.budget_fallback_tier
+      }
+      env {
+        name  = "EMBEDDING_DAILY_BUDGET_USD"
+        value = var.embedding_daily_budget_usd
+      }
     }
   }
 

--- a/infrastructure/modules/container-apps/variables.tf
+++ b/infrastructure/modules/container-apps/variables.tf
@@ -503,6 +503,29 @@ variable "memory_classifier_daily_budget_usd" {
   default     = "1.00"
 }
 
+variable "budget_enforce_mode" {
+  type        = string
+  description = "Router acting budget enforcement (A6): warn (default; observe-only, pre-A6 behavior) | downgrade (serve budget_fallback_tier + X-Router-Budget-Downgrade header) | block (429 budget_exceeded). The router fails open to warn on any other value."
+  default     = "warn"
+
+  validation {
+    condition     = contains(["warn", "downgrade", "block"], var.budget_enforce_mode)
+    error_message = "budget_enforce_mode must be one of: warn, downgrade, block."
+  }
+}
+
+variable "budget_fallback_tier" {
+  type        = string
+  description = "Tier the router serves instead when budget_enforce_mode=downgrade trips (the designated floor; exempt from enforcement)."
+  default     = "gpt4o-mini"
+}
+
+variable "embedding_daily_budget_usd" {
+  type        = string
+  description = "Daily budget cap (USD) for the router's /v1/embeddings ledger bucket (A6). \"0\" disables the cap; spend is still tracked."
+  default     = "1.00"
+}
+
 variable "memory_sweeper_cron" {
   type        = string
   description = "Cron expression for the nightly TTL sweeper job."

--- a/services/model-router/Dockerfile
+++ b/services/model-router/Dockerfile
@@ -22,7 +22,7 @@ RUN groupadd --gid 1001 appgroup && \
     useradd --uid 1001 --gid appgroup --shell /bin/bash --create-home appuser
 
 COPY --from=builder /install /usr/local
-COPY --chown=appuser:appgroup main.py .
+COPY --chown=appuser:appgroup main.py budget_enforcement.py ./
 
 USER appuser
 

--- a/services/model-router/README.md
+++ b/services/model-router/README.md
@@ -61,6 +61,8 @@ Set `OLLAMA_BASE_URL` and `OLLAMA_MODELS` (comma-separated model tags) to regist
 | `EMBEDDING_MODEL` | Model / deployment name (default: `text-embedding-3-small` — matches Honcho's 1536-dim document-embedding space) |
 | `EMBEDDING_TIMEOUT_SECONDS` | Upstream timeout (default: `20`) |
 | `EMBEDDING_MAX_INPUTS` | Max inputs per request (default: `256`) |
+| `EMBEDDING_DAILY_BUDGET_USD` | Daily cap for the `embeddings` ledger bucket (default: `1.00`; `0` disables the cap — spend is still tracked) |
+| `EMBEDDING_PRICE_PER_MTOK` | List-price fallback for cost estimation when LiteLLM reports no `response_cost` (default: `0.02`, matching `text-embedding-3-small`; adjust alongside `EMBEDDING_MODEL`) |
 
 **Provider-detection pin**: the router prepends `openai/` to a bare `EMBEDDING_MODEL` before handing it to LiteLLM. This is load-bearing for the Foundry path — with an `azure.com` `EMBEDDING_BASE_URL` and no provider prefix, LiteLLM flips to its AZURE provider (`api-key` header auth) and Foundry's OpenAI-compatible endpoint rejects the call with `400 unknown_model`. The `openai/` prefix keeps auth on `Authorization: Bearer`. An explicit `provider/` prefix in `EMBEDDING_MODEL` is honored unchanged.
 
@@ -97,6 +99,29 @@ The tier value must be a key present in `MODELS` at request time (i.e. a registe
 - Ephemeral passthrough tiers → `gpt4o-mini`
 
 Tiers that cannot fit the request (input + max_tokens > context_limit) are pruned from the chain.
+
+## Budget enforcement (`BUDGET_ENFORCE_MODE`)
+
+Per-tier daily budgets are tracked on every path; **by default they only warn** (the pre-existing behavior, ship-dark safe). `BUDGET_ENFORCE_MODE` upgrades the budgets from observability to an acting control:
+
+| Mode | Over-budget behavior |
+|---|---|
+| `warn` *(default)* | Serve the requested tier and emit a `budget_enforce` WARN log — behavior identical to before this feature existed |
+| `downgrade` | Serve `BUDGET_FALLBACK_TIER` (default: `gpt4o-mini`) instead; the response carries the `X-Router-Budget-Downgrade: <from>-><to>` header and `_router.budget_downgraded_from` metadata |
+| `block` | Refuse with HTTP 429 and a machine-readable `budget_exceeded` body (`error`, `tier`, `spent_usd`, `limit_usd`, `mode`) |
+
+Semantics:
+
+- **All paths are covered.** Enforcement wraps `select_tier` (so `/v1/chat/completions` — including Claude tiers dispatched through the direct Anthropic SDK — and ephemeral passthrough tiers are checked), plus explicit checks on the two paths that bypass tier selection: the native `/v1/messages` endpoint and `/v1/embeddings`.
+- **The fallback tier is exempt** — it is the designated floor; blocking it would turn "over budget" into an outage. A misconfigured fallback (unregistered, or the same tier that is over budget) degrades to `warn` rather than stranding requests. An invalid `BUDGET_ENFORCE_MODE` value fails open to `warn`.
+- **Native `/v1/messages`**: responses must stay Anthropic-shaped, so `downgrade` only takes effect there when `BUDGET_FALLBACK_TIER` is itself an Anthropic-backed tier; otherwise the request degrades to `warn`. `block` returns an Anthropic-shaped 429 (`{"type": "error", "error": {"type": "rate_limit_error", ...}}`) so `anthropic_messages` transports parse it like any upstream error. This path also now records its spend to the daily ledger (streaming and non-streaming) — previously it recorded nothing, which is exactly the gap class this feature closes.
+- **`/v1/embeddings`**: spend accrues to a dedicated `embeddings` ledger bucket capped by `EMBEDDING_DAILY_BUDGET_USD`. There is no same-vector-space downgrade target (the model is pinned so query embeddings match the stored document space), so `downgrade` degrades to `warn` on this path; `block` 429s.
+
+| Env var | Purpose |
+|---|---|
+| `BUDGET_ENFORCE_MODE` | `warn` (default) \| `downgrade` \| `block` |
+| `BUDGET_FALLBACK_TIER` | Tier served in `downgrade` mode (default: `gpt4o-mini`) |
+| `EMBEDDING_DAILY_BUDGET_USD` | Daily cap for the embeddings bucket (default: `1.00`; `0` disables) |
 
 ## Security
 

--- a/services/model-router/budget_enforcement.py
+++ b/services/model-router/budget_enforcement.py
@@ -1,0 +1,149 @@
+"""Acting budget enforcement for per-tier daily budgets (AAF A6).
+
+PORTABILITY CONTRACT: this module is deliberately self-contained — stdlib
+only, no FastAPI, no LiteLLM, no host-specific imports. It is vendored
+verbatim from the upstream private deployment's budget-enforcement module
+(their M5 hardening enhancement; this port is AAF enhancement A6). The host
+router owns tier config, spend ledgers, and HTTP; this module owns the
+DECISION of what happens when a request lands on a tier that has exhausted
+its daily budget.
+
+Why it exists: per-tier daily budgets historically only ever WARNED —
+observed evidence upstream is a Claude tier running ~25x its daily budget
+with nothing but `budget_exceeded` WARN log lines (real money). This module
+upgrades that from observability to an acting control, behind an env var
+so the default remains exactly the old behavior.
+
+Modes (env var BUDGET_ENFORCE_MODE, normalized by resolve_mode()):
+
+  warn (default) — serve the requested tier anyway and emit a warning.
+                   This is the pre-existing behavior (ship-dark safe):
+                   budgets observed, never acted on.
+  downgrade      — serve the configured fallback tier instead and mark the
+                   response (DOWNGRADE_HEADER + host log line). If the
+                   fallback tier is unavailable (not registered, or the
+                   same tier that's over budget), degrade to warn — a
+                   misconfigured fallback must never strand a request.
+  block          — refuse the request; the host returns HTTP 429 with the
+                   machine-readable body from block_detail().
+
+The fallback tier is deliberately EXEMPT from enforcement: it is the
+designated floor, and blocking it would turn "over budget" into a full
+outage. (In this router the floor is gpt4o-mini, matching the pre-existing
+gpt4o-mini→phi4 over-budget redirect's spirit of degrade-don't-die.)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Container
+
+# ── Modes ─────────────────────────────────────────────────────────────────────
+MODE_WARN = "warn"
+MODE_DOWNGRADE = "downgrade"
+MODE_BLOCK = "block"
+VALID_MODES = (MODE_WARN, MODE_DOWNGRADE, MODE_BLOCK)
+
+# ── Decision actions ──────────────────────────────────────────────────────────
+ACTION_ALLOW = "allow"          # under budget — serve as requested
+ACTION_WARN = "warn"            # over budget — serve as requested, warn loudly
+ACTION_DOWNGRADE = "downgrade"  # over budget — serve the fallback tier instead
+ACTION_BLOCK = "block"          # over budget — refuse with 429
+
+# Response header the host sets when a request was budget-downgraded, value
+# "<requested-tier>-><served-tier>" (see downgrade_header()).
+DOWNGRADE_HEADER = "X-Router-Budget-Downgrade"
+
+
+def resolve_mode(raw: str | None) -> str:
+    """Normalize a BUDGET_ENFORCE_MODE env value; unknown values -> warn.
+
+    Fail-open on config typos: an invalid mode must not brick the router,
+    and warn is the pre-existing (ship-dark) behavior.
+    """
+    mode = (raw or MODE_WARN).strip().lower()
+    return mode if mode in VALID_MODES else MODE_WARN
+
+
+@dataclass(frozen=True)
+class BudgetDecision:
+    """What the host router should do with one request. Pure data."""
+
+    action: str              # one of the ACTION_* constants
+    requested_tier: str      # the tier the request resolved to
+    serve_tier: str | None   # tier to actually serve (None only for block)
+    reason: str              # human-readable, log/error-body ready
+    spent_usd: float = 0.0
+    limit_usd: float = 0.0
+
+
+def decide(
+    *,
+    tier: str,
+    over_budget: bool,
+    mode: str,
+    fallback_tier: str | None,
+    registered_tiers: Container[str],
+    spent_usd: float = 0.0,
+    limit_usd: float = 0.0,
+) -> BudgetDecision:
+    """The enforcement decision for serving `tier` right now.
+
+    Pure function: the host supplies the over-budget verdict (its ledger),
+    the mode, the configured fallback tier, and the set of registered tiers;
+    this returns what to do. Never raises.
+    """
+    if not over_budget:
+        return BudgetDecision(ACTION_ALLOW, tier, tier, "under budget",
+                              spent_usd, limit_usd)
+
+    over = (
+        f"tier '{tier}' daily budget exhausted "
+        f"(spent ${spent_usd:.4f} of ${limit_usd:.2f})"
+    )
+
+    if mode == MODE_BLOCK:
+        return BudgetDecision(
+            ACTION_BLOCK, tier, None,
+            over + "; BUDGET_ENFORCE_MODE=block refused the request",
+            spent_usd, limit_usd,
+        )
+
+    if mode == MODE_DOWNGRADE:
+        if fallback_tier and fallback_tier != tier and fallback_tier in registered_tiers:
+            return BudgetDecision(
+                ACTION_DOWNGRADE, tier, fallback_tier,
+                over + f"; downgrading to '{fallback_tier}'",
+                spent_usd, limit_usd,
+            )
+        # Misconfigured / self-referential fallback: never strand the request.
+        return BudgetDecision(
+            ACTION_WARN, tier, tier,
+            over + f"; downgrade fallback {fallback_tier!r} unavailable — "
+                   "serving requested tier",
+            spent_usd, limit_usd,
+        )
+
+    # MODE_WARN (and anything resolve_mode would have normalized to it).
+    return BudgetDecision(
+        ACTION_WARN, tier, tier,
+        over + "; BUDGET_ENFORCE_MODE=warn serves it anyway",
+        spent_usd, limit_usd,
+    )
+
+
+def downgrade_header(decision: BudgetDecision) -> tuple[str, str]:
+    """(header-name, header-value) marking a budget downgrade on the response."""
+    return DOWNGRADE_HEADER, f"{decision.requested_tier}->{decision.serve_tier}"
+
+
+def block_detail(decision: BudgetDecision) -> dict:
+    """Machine-readable 429 error body for a block decision."""
+    return {
+        "error": "budget_exceeded",
+        "message": decision.reason,
+        "tier": decision.requested_tier,
+        "spent_usd": round(decision.spent_usd, 6),
+        "limit_usd": round(decision.limit_usd, 6),
+        "mode": MODE_BLOCK,
+    }

--- a/services/model-router/main.py
+++ b/services/model-router/main.py
@@ -29,6 +29,10 @@ from anthropic import AsyncAnthropic
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
+# Local module (same directory): pure decision logic for acting budget
+# enforcement (A6) — see the "Acting budget enforcement" section below.
+import budget_enforcement
+
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s %(message)s")
 log = logging.getLogger("router")
 
@@ -442,6 +446,94 @@ def daily_cost_rollup() -> dict[str, object]:
     }
 
 
+# ─── Acting budget enforcement (A6) ──────────────────────────────────────────
+# Per-tier DAILY budgets historically only WARNED (upstream evidence: a Claude
+# tier ran ~25× its daily budget with nothing but budget_exceeded WARN lines —
+# real money). BUDGET_ENFORCE_MODE upgrades that to an acting control:
+#   warn (default)  — pre-A6 behavior exactly (ship-dark safe): serve + WARN.
+#   downgrade       — serve BUDGET_FALLBACK_TIER instead; mark the response
+#                     with the X-Router-Budget-Downgrade header + a log line.
+#   block           — 429 with a machine-readable budget_exceeded body.
+# The decision logic lives in budget_enforcement.py — stdlib-only and
+# host-agnostic, vendored verbatim from the upstream private deployment.
+# Enforcement wraps select_tier() as its FINAL stage, so every path that
+# selects a tier there (the OpenAI-compat /v1/chat/completions path, including
+# the Anthropic direct-SDK dispatch inside _call_model, and ephemeral
+# passthrough tiers) is covered. Two paths bypass select_tier and get explicit
+# checks of their own: the native /v1/messages endpoint (the exact gap class
+# that let the upstream Claude tier overrun silently) and /v1/embeddings
+# (which has no tier at all — see the embeddings section for its dedicated
+# ledger bucket). This router has no selftest/probe traffic, so nothing needs
+# a spend exemption.
+_BUDGET_ENFORCE_MODE = budget_enforcement.resolve_mode(os.environ.get("BUDGET_ENFORCE_MODE"))
+_BUDGET_FALLBACK_TIER = os.environ.get("BUDGET_FALLBACK_TIER", "gpt4o-mini")
+log.info(
+    "budget_enforce mode=%s fallback_tier=%s",
+    _BUDGET_ENFORCE_MODE, _BUDGET_FALLBACK_TIER,
+)
+
+
+def _budget_decision(tier: str) -> budget_enforcement.BudgetDecision:
+    """The enforcement decision for serving `tier` right now (pure lookup)."""
+    return budget_enforcement.decide(
+        tier=tier,
+        over_budget=is_over_budget(tier),
+        mode=_BUDGET_ENFORCE_MODE,
+        fallback_tier=_BUDGET_FALLBACK_TIER,
+        registered_tiers=MODELS,
+        spent_usd=_spend.get(tier, 0.0),
+        limit_usd=MODELS[tier]["daily_budget"],
+    )
+
+
+def _apply_budget_enforcement(tier: str, body: dict) -> str:
+    """Acting per-tier daily-budget enforcement (A6) — final select_tier stage.
+
+    warn → serve the requested tier (+ WARN log, exactly the old behavior);
+    downgrade → serve the fallback tier and stash a marker in a private body
+    slot (same pattern as __router_extra_headers__) so the endpoint can add
+    the X-Router-Budget-Downgrade response header; block → raise 429 with the
+    machine-readable budget_exceeded detail.
+    """
+    decision = _budget_decision(tier)
+    if decision.action == budget_enforcement.ACTION_ALLOW:
+        return tier
+    if decision.action == budget_enforcement.ACTION_WARN:
+        log.warning("budget_enforce mode=%s tier=%s %s",
+                    _BUDGET_ENFORCE_MODE, tier, decision.reason)
+        return tier
+    if decision.action == budget_enforcement.ACTION_DOWNGRADE:
+        log.warning("budget_enforce_downgrade tier=%s→%s %s",
+                    tier, decision.serve_tier, decision.reason)
+        body["__budget_downgrade__"] = {"from": tier, "to": decision.serve_tier}
+        return decision.serve_tier
+    # ACTION_BLOCK — FastAPI wraps the dict detail as {"detail": {...}}.
+    log.warning("budget_enforce_block tier=%s %s", tier, decision.reason)
+    raise HTTPException(status_code=429, detail=budget_enforcement.block_detail(decision))
+
+
+def _budget_downgrade_headers(body: dict) -> dict[str, str]:
+    """Response headers marking a budget downgrade, if one happened for `body`."""
+    marker = body.get("__budget_downgrade__")
+    if not isinstance(marker, dict):
+        return {}
+    name, value = budget_enforcement.downgrade_header(
+        budget_enforcement.BudgetDecision(
+            budget_enforcement.ACTION_DOWNGRADE,
+            marker.get("from", ""), marker.get("to", ""), "",
+        )
+    )
+    return {name: value}
+
+
+def _budget_downgrade_meta(body: dict) -> dict:
+    """_router metadata marking a budget downgrade, if one happened for `body`."""
+    marker = body.get("__budget_downgrade__")
+    if not isinstance(marker, dict) or not marker.get("from"):
+        return {}
+    return {"budget_downgraded_from": marker["from"]}
+
+
 # ─── Observability (GenAI semconv) ────────────────────────────────────────────
 # One OTel span per model call with GenAI semantic-convention attributes, behind
 # OBSERVABILITY_ENABLED (default off), content-redacted (no prompt/response text).
@@ -694,6 +786,26 @@ def _usage_from_result(result: dict, *, fallback_tier: str) -> tuple[str, int, i
     return model, int(usage.get("prompt_tokens", 0) or 0), int(usage.get("completion_tokens", 0) or 0)
 
 
+def _record_anthropic_usage(tier: str, deployment: str, usage, caller: str | None = None) -> None:
+    """Record estimated cost from an Anthropic SDK usage object (best-effort).
+
+    A6: the native /v1/messages path calls the Anthropic SDK directly (it never
+    goes through _call_model), so before this its spend was invisible to the
+    daily ledger — budget enforcement on that path would have been inert.
+    Accepts anything with input_tokens/output_tokens attributes (the SDK usage
+    object, or a dict-backed shim from the SSE accumulator). Never raises."""
+    try:
+        input_tokens = getattr(usage, "input_tokens", 0) or 0
+        output_tokens = getattr(usage, "output_tokens", 0) or 0
+        record_cost(
+            tier, _estimate_anthropic_cost(deployment, input_tokens, output_tokens),
+            model=deployment, input_tokens=input_tokens, output_tokens=output_tokens,
+            caller=caller,
+        )
+    except Exception as e:  # never let cost accounting break a response
+        log.debug("anthropic_cost_estimate_failed tier=%s error=%s", tier, e)
+
+
 # ─── Routing ──────────────────────────────────────────────────────────────────
 # Map agent/persona names to model tiers. Populate via PERSONA_TIERS_JSON env
 # var at runtime (JSON object: {"my-agent": "gpt4o-mini", ...}), or extend
@@ -734,6 +846,14 @@ def _get_passthrough_config(model_name: str) -> dict[str, Any]:
 
 
 def select_tier(body: dict) -> str:
+    # A6 acting budget enforcement runs LAST so the finally-selected tier is
+    # always checked against its own daily budget (a pure pass-through in the
+    # default warn mode). The pre-existing gpt4o-mini→phi4 over-budget redirect
+    # inside _select_tier_base is unchanged — enforcement wraps it.
+    return _apply_budget_enforcement(_select_tier_base(body), body)
+
+
+def _select_tier_base(body: dict) -> str:
     tier = (body.get("tier") or body.get("metadata", {}).get("tier", "")).lower()
 
     if not tier or tier == "auto":
@@ -854,7 +974,10 @@ def _build_completion_kwargs(tier: str, body: dict, *, stream: bool) -> dict[str
 #   - computer-use, MCP tools, citations                                 ✗
 
 def _is_anthropic_tier(tier: str) -> bool:
-    return MODELS[tier]["litellm_model"].startswith("anthropic/")
+    # .get chain: callers pass ledger-bucket names too (e.g. the A6
+    # "embeddings" bucket via record_cost → _genai_system), which have no
+    # MODELS entry — treat unknown names as non-Anthropic, never KeyError.
+    return MODELS.get(tier, {}).get("litellm_model", "").startswith("anthropic/")
 
 
 # ─── Tool format translation ──────────────────────────────────────────────────
@@ -1223,7 +1346,8 @@ def _build_messages_passthrough_kwargs(cfg: dict, body: dict, request: Request) 
 
 
 async def _stream_anthropic_messages_sse(
-    client, kwargs: dict[str, Any], tier: str, t_start: float
+    client, kwargs: dict[str, Any], tier: str, t_start: float,
+    caller: str | None = None,
 ):
     """Yield raw Anthropic SSE events as the upstream stream produces them.
 
@@ -1236,6 +1360,9 @@ async def _stream_anthropic_messages_sse(
     # it as a separate parameter).
     kwargs = dict(kwargs)
     kwargs.pop("stream", None)
+    # A6 usage capture for cost recording: message_start carries the input
+    # token count, message_delta carries the (cumulative) output count.
+    usage_acc = {"input_tokens": 0, "output_tokens": 0}
     try:
         async for event in await client.messages.create(stream=True, **kwargs):
             event_type = getattr(event, "type", "message")
@@ -1244,7 +1371,22 @@ async def _stream_anthropic_messages_sse(
             except Exception:
                 # Older SDK style fallback
                 payload = getattr(event, "to_dict", lambda: {})() or {}
+            if event_type == "message_start":
+                u = (payload.get("message") or {}).get("usage") or {}
+                for k in usage_acc:
+                    usage_acc[k] = u.get(k) or usage_acc[k]
+            elif event_type == "message_delta":
+                u = payload.get("usage") or {}
+                usage_acc["output_tokens"] = u.get("output_tokens") or usage_acc["output_tokens"]
             yield f"event: {event_type}\ndata: {json.dumps(payload)}\n\n"
+        # A6: streamed native Claude calls accrue to the daily ledger too —
+        # this is the main production mode (Hermes anthropic_messages), so
+        # leaving it untracked would leave enforcement blind on the exact
+        # path it was built for.
+        _record_anthropic_usage(
+            tier, MODELS[tier]["litellm_model"].split("/", 1)[1],
+            type("U", (), usage_acc)(), caller=caller,
+        )
         log.info("messages_stream_ok tier=%s latency=%.2fs", tier, time.monotonic() - t_start)
     except Exception as e:
         log.warning("messages_stream_failed tier=%s error=%s", tier, e)
@@ -1496,6 +1638,11 @@ async def chat_completions(request: Request):
         body["__router_caller__"] = caller
 
     tier = select_tier(body)
+    # A6: select_tier stashes a __budget_downgrade__ marker in the body when
+    # enforcement swapped the tier; surface it as a response header + _router
+    # metadata so callers can see the downgrade (empty dicts otherwise).
+    bd_headers = _budget_downgrade_headers(body)
+    bd_meta = _budget_downgrade_meta(body)
     stream = bool(body.get("stream", False))
 
     # Capture prompt-cache (and other Anthropic-beta) markers BEFORE handing the
@@ -1553,6 +1700,7 @@ async def chat_completions(request: Request):
                     headers={
                         "Cache-Control": "no-cache",
                         "Connection": "keep-alive",
+                        **bd_headers,
                     },
                 )
             except Exception as e:
@@ -1574,9 +1722,9 @@ async def chat_completions(request: Request):
     # Non-streaming path
     try:
         result = await _call_model(tier, body)
-        result["_router"] = {"tier": tier, "estimated_input_tokens": estimated}
+        result["_router"] = {"tier": tier, "estimated_input_tokens": estimated, **bd_meta}
         log.info("success tier=%s latency=%.2fs", tier, time.monotonic() - t_start)
-        return JSONResponse(content=result)
+        return JSONResponse(content=result, headers=bd_headers)
     except Exception as e:
         log.warning("primary_failed tier=%s error=%s", tier, e)
         log.debug("primary_failed_traceback tier=%s\n%s", tier, traceback.format_exc())
@@ -1588,9 +1736,10 @@ async def chat_completions(request: Request):
                 "tier": fb,
                 "fallback_from": tier,
                 "estimated_input_tokens": estimated,
+                **bd_meta,
             }
             log.info("fallback_success tier=%s latency=%.2fs", fb, time.monotonic() - t_start)
-            return JSONResponse(content=result)
+            return JSONResponse(content=result, headers=bd_headers)
         except Exception as e:
             log.warning("fallback_failed tier=%s error=%s", fb, e)
             log.debug("fallback_failed_traceback tier=%s\n%s", fb, traceback.format_exc())
@@ -1633,6 +1782,56 @@ async def messages(request: Request):
             detail=f"Tier {tier!r} is not an Anthropic-backed tier",
         )
 
+    # Acting budget enforcement (A6): the native Messages path bypasses
+    # select_tier (tier comes from _select_anthropic_tier_for_model above) —
+    # the exact gap class that let the upstream deployment's Claude tier
+    # overrun its daily budget with only WARN lines — so it gets an explicit
+    # check here. The response must stay Anthropic-shaped end to end, so a
+    # downgrade can only serve another Anthropic-backed tier: the configured
+    # fallback participates only when it is Anthropic-backed; otherwise
+    # decide() sees no usable fallback and degrades to warn (a non-servable
+    # fallback must never strand a request). block returns an Anthropic-shaped
+    # 429 so anthropic_messages transports parse it like any upstream error.
+    _msg_fallback = (
+        _BUDGET_FALLBACK_TIER
+        if _BUDGET_FALLBACK_TIER in MODELS and _is_anthropic_tier(_BUDGET_FALLBACK_TIER)
+        else None
+    )
+    decision = budget_enforcement.decide(
+        tier=tier,
+        over_budget=is_over_budget(tier),
+        mode=_BUDGET_ENFORCE_MODE,
+        fallback_tier=_msg_fallback,
+        registered_tiers=MODELS,
+        spent_usd=_spend.get(tier, 0.0),
+        limit_usd=MODELS[tier]["daily_budget"],
+    )
+    bd_headers: dict[str, str] = {}
+    bd_meta: dict[str, str] = {}
+    if decision.action == budget_enforcement.ACTION_BLOCK:
+        log.warning("budget_enforce_block tier=%s %s (messages)", tier, decision.reason)
+        return JSONResponse(
+            status_code=429,
+            content={
+                "type": "error",
+                "error": {
+                    "type": "rate_limit_error",
+                    "message": decision.reason,
+                    "detail": budget_enforcement.block_detail(decision),
+                },
+            },
+        )
+    if decision.action == budget_enforcement.ACTION_DOWNGRADE:
+        log.warning("budget_enforce_downgrade tier=%s→%s %s (messages)",
+                    tier, decision.serve_tier, decision.reason)
+        name, value = budget_enforcement.downgrade_header(decision)
+        bd_headers[name] = value
+        bd_meta["budget_downgraded_from"] = tier
+        tier = decision.serve_tier
+    elif decision.action == budget_enforcement.ACTION_WARN:
+        log.warning("budget_enforce mode=%s tier=%s %s (messages)",
+                    _BUDGET_ENFORCE_MODE, tier, decision.reason)
+
     cfg = MODELS[tier]
     stream = bool(body.get("stream", False))
 
@@ -1648,14 +1847,16 @@ async def messages(request: Request):
 
     client = _make_anthropic_client(cfg)
     kwargs = _build_messages_passthrough_kwargs(cfg, body, request)
+    caller = resolve_caller_id(request.headers)
 
     if stream:
         return StreamingResponse(
-            _stream_anthropic_messages_sse(client, kwargs, tier, t_start),
+            _stream_anthropic_messages_sse(client, kwargs, tier, t_start, caller=caller),
             media_type="text/event-stream",
             headers={
                 "Cache-Control": "no-cache",
                 "Connection": "keep-alive",
+                **bd_headers,
             },
         )
 
@@ -1680,13 +1881,21 @@ async def messages(request: Request):
         }
         return JSONResponse(status_code=status, content=err_body)
 
+    # A6: accrue this call's spend to the daily ledger — the native path never
+    # goes through _call_model, so without this the enforcement above would
+    # never see the spend it is supposed to act on.
+    _record_anthropic_usage(
+        tier, cfg["litellm_model"].split("/", 1)[1], getattr(resp, "usage", None),
+        caller=caller,
+    )
+
     try:
         result = resp.model_dump(exclude_unset=False, mode="json")
     except Exception:
         result = getattr(resp, "to_dict", lambda: {})() or {}
-    result["_router"] = {"tier": tier, "estimated_input_tokens": estimated}
+    result["_router"] = {"tier": tier, "estimated_input_tokens": estimated, **bd_meta}
     log.info("messages success tier=%s latency=%.2fs", tier, time.monotonic() - t_start)
-    return JSONResponse(content=result)
+    return JSONResponse(content=result, headers=bd_headers)
 
 
 # ─── Embeddings ──────────────────────────────────────────────────────────────
@@ -1704,6 +1913,56 @@ _EMBED_API_KEY = _tier_env("EMBEDDING_API_KEY") or _tier_env("OPENAI_API_KEY")
 _EMBED_API_BASE = os.environ.get("EMBEDDING_BASE_URL") or None
 _EMBED_TIMEOUT_S = int(os.environ.get("EMBEDDING_TIMEOUT_SECONDS", "20"))
 _EMBED_MAX_INPUTS = int(os.environ.get("EMBEDDING_MAX_INPUTS", "256"))
+
+# ── Embeddings daily budget (A6 acting enforcement) ──────────────────────────
+# /v1/embeddings bypasses tier selection entirely (no MODELS entry), so its
+# spend was previously invisible to cost governance — the same "spend with no
+# acting control" gap class A6 closes for the chat tiers. Embeddings spend now
+# accrues to a dedicated "embeddings" ledger bucket (it shows up in
+# daily_cost_rollup like any tier), capped by EMBEDDING_DAILY_BUDGET_USD; a
+# cap of 0 disables the ceiling (spend is still tracked), mirroring
+# PER_CALLER_DAILY_USD's convention. There is no meaningful downgrade target —
+# a different embedding model would land queries in a different vector space
+# than the stored document embeddings (the whole point of the model pin) — so
+# in downgrade mode this path degrades to warn (decide() gets
+# fallback_tier=None); block mode 429s with the same machine-readable body as
+# the chat paths. Cost comes from LiteLLM's response_cost when available, else
+# a list-price token estimate at EMBEDDING_PRICE_PER_MTOK (default matches
+# text-embedding-3-small; adjust it alongside EMBEDDING_MODEL).
+_EMBED_LEDGER_BUCKET = "embeddings"
+_EMBED_DAILY_BUDGET_USD = float(os.environ.get("EMBEDDING_DAILY_BUDGET_USD", "1.00") or 0)
+_EMBED_PRICE_PER_MTOK = float(os.environ.get("EMBEDDING_PRICE_PER_MTOK", "0.02") or 0)
+log.info(
+    "budget_enforce embeddings_daily_budget_usd=%.2f (0 disables the cap)",
+    _EMBED_DAILY_BUDGET_USD,
+)
+
+
+def is_embeddings_over_budget() -> bool:
+    """True when the embeddings bucket has reached its daily cap. A cap of 0
+    (or negative) disables the ceiling — mirrors PER_CALLER_DAILY_USD."""
+    if _EMBED_DAILY_BUDGET_USD <= 0:
+        return False
+    _reset_if_new_day()
+    return _spend.get(_EMBED_LEDGER_BUCKET, 0.0) >= _EMBED_DAILY_BUDGET_USD
+
+
+def _embedding_cost(resp, payload: dict) -> tuple[float, int]:
+    """(cost_usd, input_tokens) for one embeddings call. Prefers LiteLLM's
+    response_cost; falls back to a list-price token estimate. Defaults
+    gracefully — it runs on the hot path after a successful upstream call."""
+    usage = payload.get("usage") or {}
+    try:
+        tokens = int(usage.get("prompt_tokens") or usage.get("total_tokens") or 0)
+    except (TypeError, ValueError):
+        tokens = 0
+    try:
+        cost = float((getattr(resp, "_hidden_params", None) or {}).get("response_cost") or 0.0)
+    except (TypeError, ValueError):
+        cost = 0.0
+    if cost <= 0:
+        cost = tokens / 1_000_000 * _EMBED_PRICE_PER_MTOK
+    return cost, tokens
 
 
 def _pin_embedding_provider(model: str) -> str:
@@ -1752,6 +2011,34 @@ async def embeddings(request: Request):
         raise HTTPException(status_code=400, detail="'input' is required")
     if isinstance(inp, list) and len(inp) > _EMBED_MAX_INPUTS:
         raise HTTPException(status_code=400, detail=f"too many inputs (max {_EMBED_MAX_INPUTS})")
+
+    # aaf-0005: same per-caller budget gate as the chat endpoints — a caller
+    # over its daily cap must not keep spending through the embeddings path.
+    caller = resolve_caller_id(request.headers)
+    if is_over_caller_budget(caller):
+        raise HTTPException(status_code=429, detail="Per-caller daily budget exceeded")
+
+    # Acting budget enforcement (A6). fallback_tier=None: there is no
+    # same-vector-space downgrade target (see the bucket's comment block), so
+    # downgrade mode degrades to warn here; block refuses with the same
+    # machine-readable 429 body as the chat paths.
+    decision = budget_enforcement.decide(
+        tier=_EMBED_LEDGER_BUCKET,
+        over_budget=is_embeddings_over_budget(),
+        mode=_BUDGET_ENFORCE_MODE,
+        fallback_tier=None,
+        registered_tiers=MODELS,
+        spent_usd=_spend.get(_EMBED_LEDGER_BUCKET, 0.0),
+        limit_usd=_EMBED_DAILY_BUDGET_USD,
+    )
+    if decision.action == budget_enforcement.ACTION_BLOCK:
+        log.warning("budget_enforce_block tier=%s %s (embeddings)",
+                    _EMBED_LEDGER_BUCKET, decision.reason)
+        raise HTTPException(status_code=429, detail=budget_enforcement.block_detail(decision))
+    if decision.action != budget_enforcement.ACTION_ALLOW:
+        log.warning("budget_enforce mode=%s tier=%s %s (embeddings)",
+                    _BUDGET_ENFORCE_MODE, _EMBED_LEDGER_BUCKET, decision.reason)
+
     try:
         # _EMBED_LITELLM_MODEL (not _EMBED_MODEL): the openai/ prefix pin is
         # load-bearing against azure.com api_bases — see _pin_embedding_provider.
@@ -1771,6 +2058,15 @@ async def embeddings(request: Request):
         payload = resp.model_dump()
     except AttributeError:
         payload = resp if isinstance(resp, dict) else dict(resp)
+
+    # A6: embeddings spend accrues to the ledger (dedicated bucket + the
+    # per-caller ledger when the request is attributed).
+    cost, tokens = _embedding_cost(resp, payload)
+    record_cost(
+        _EMBED_LEDGER_BUCKET, cost, model=_EMBED_MODEL, input_tokens=tokens,
+        caller=caller, correlation_id=resolve_correlation_id(request.headers),
+    )
+
     data = payload.get("data") or []
     return {
         "object": "list",

--- a/services/model-router/tests/test_budget_enforcement.py
+++ b/services/model-router/tests/test_budget_enforcement.py
@@ -1,0 +1,504 @@
+"""Acting budget enforcement (A6): BUDGET_ENFORCE_MODE warn|downgrade|block.
+
+Per-tier daily budgets historically only WARNED. A6 adds an acting control
+behind BUDGET_ENFORCE_MODE:
+
+  warn (default) — pre-A6 behavior exactly (ship-dark safe): serve + WARN log.
+  downgrade      — serve BUDGET_FALLBACK_TIER; mark the response with the
+                   X-Router-Budget-Downgrade header (+ _router metadata).
+  block          — 429 with a machine-readable budget_exceeded body.
+
+Decision logic lives in budget_enforcement.py (stdlib-only, vendored from the
+upstream private deployment). Wiring covers select_tier — the OpenAI-compat
+/v1/chat/completions path (which dispatches Anthropic tiers to the direct-SDK
+bypass via _call_model) — PLUS explicit checks on the two paths that bypass
+select_tier: the native /v1/messages Anthropic path (which must stay
+Anthropic-shaped, so a downgrade only serves an Anthropic-backed fallback and
+otherwise degrades to warn) and /v1/embeddings (dedicated "embeddings" ledger
+bucket; no same-vector-space downgrade target, so downgrade degrades to warn
+there too).
+
+The mode is read from env at import time (unset in the canonical test env →
+warn); mode-specific tests monkeypatch main._BUDGET_ENFORCE_MODE, following
+the suite's existing monkeypatch-the-module-global pattern.
+"""
+
+from datetime import date
+
+import pytest
+
+import budget_enforcement as be
+
+
+def _pin_today(router):
+    """Pin the budget day to today so the lazy rollover doesn't clear
+    directly-injected spend mid-test."""
+    router._budget_date = str(date.today())
+
+
+def _make_over_budget(router, tier):
+    """Blow `tier`'s daily budget in the ledger."""
+    _pin_today(router)
+    router._spend[tier] = router.MODELS[tier]["daily_budget"] + 1.0
+
+
+def _chat_body(model="claude"):
+    return {"model": model, "messages": [{"role": "user", "content": "hi"}]}
+
+
+def _messages_body(model="claude"):
+    return {"model": model, "max_tokens": 5,
+            "messages": [{"role": "user", "content": "hi"}]}
+
+
+# ── Pure module: resolve_mode ────────────────────────────────────────────────
+
+class TestResolveMode:
+    def test_none_defaults_to_warn(self):
+        assert be.resolve_mode(None) == be.MODE_WARN
+
+    def test_empty_defaults_to_warn(self):
+        assert be.resolve_mode("") == be.MODE_WARN
+
+    def test_normalizes_case_and_whitespace(self):
+        assert be.resolve_mode("  DOWNGRADE ") == be.MODE_DOWNGRADE
+        assert be.resolve_mode("Block") == be.MODE_BLOCK
+
+    def test_invalid_value_fails_open_to_warn(self):
+        # A config typo must not brick the router into an unknown mode.
+        assert be.resolve_mode("explode") == be.MODE_WARN
+
+
+# ── Pure module: decide ──────────────────────────────────────────────────────
+
+class TestDecide:
+    TIERS = {"gpt4o-mini": {}, "phi4": {}, "claude": {}}
+
+    def _decide(self, **over):
+        kwargs = dict(
+            tier="claude", over_budget=True, mode=be.MODE_WARN,
+            fallback_tier="gpt4o-mini", registered_tiers=self.TIERS,
+            spent_usd=6.25, limit_usd=0.25,
+        )
+        kwargs.update(over)
+        return be.decide(**kwargs)
+
+    def test_under_budget_allows_any_mode(self):
+        for mode in be.VALID_MODES:
+            d = self._decide(over_budget=False, mode=mode)
+            assert d.action == be.ACTION_ALLOW
+            assert d.serve_tier == "claude"
+
+    def test_warn_mode_serves_requested_tier(self):
+        d = self._decide(mode=be.MODE_WARN)
+        assert d.action == be.ACTION_WARN
+        assert d.serve_tier == "claude"
+        assert "warn" in d.reason
+
+    def test_downgrade_mode_serves_fallback(self):
+        d = self._decide(mode=be.MODE_DOWNGRADE)
+        assert d.action == be.ACTION_DOWNGRADE
+        assert d.serve_tier == "gpt4o-mini"
+        assert d.requested_tier == "claude"
+
+    def test_downgrade_unregistered_fallback_degrades_to_warn(self):
+        # Misconfigured fallback must never strand the request.
+        d = self._decide(mode=be.MODE_DOWNGRADE, fallback_tier="no-such-tier")
+        assert d.action == be.ACTION_WARN
+        assert d.serve_tier == "claude"
+        assert "unavailable" in d.reason
+
+    def test_downgrade_self_referential_fallback_degrades_to_warn(self):
+        # The fallback tier itself is exempt: it's the designated floor.
+        d = self._decide(tier="gpt4o-mini", mode=be.MODE_DOWNGRADE,
+                         fallback_tier="gpt4o-mini")
+        assert d.action == be.ACTION_WARN
+        assert d.serve_tier == "gpt4o-mini"
+
+    def test_block_mode_blocks(self):
+        d = self._decide(mode=be.MODE_BLOCK)
+        assert d.action == be.ACTION_BLOCK
+        assert d.serve_tier is None
+
+    def test_block_detail_shape(self):
+        d = self._decide(mode=be.MODE_BLOCK)
+        detail = be.block_detail(d)
+        assert detail["error"] == "budget_exceeded"
+        assert detail["tier"] == "claude"
+        assert detail["spent_usd"] == pytest.approx(6.25)
+        assert detail["limit_usd"] == pytest.approx(0.25)
+        assert detail["mode"] == "block"
+        assert "budget exhausted" in detail["message"]
+
+    def test_downgrade_header_value(self):
+        d = self._decide(mode=be.MODE_DOWNGRADE)
+        name, value = be.downgrade_header(d)
+        assert name == "X-Router-Budget-Downgrade"
+        assert value == "claude->gpt4o-mini"
+
+
+# ── warn (default): ship-dark — behavior unchanged ───────────────────────────
+
+class TestWarnModeIsShipDark:
+    def test_import_default_is_warn(self, router):
+        # BUDGET_ENFORCE_MODE is unset in the canonical test env → warn.
+        assert router._BUDGET_ENFORCE_MODE == "warn"
+
+    def test_over_budget_tier_still_selected(self, router):
+        _make_over_budget(router, "claude")
+        body = _chat_body()
+        assert router.select_tier(body) == "claude"
+        # No downgrade marker → no response header.
+        assert "__budget_downgrade__" not in body
+
+    def test_endpoint_serves_over_budget_tier_without_marker(
+        self, client, router, monkeypatch
+    ):
+        _make_over_budget(router, "claude")
+        called = []
+
+        async def fake_call(tier, body):
+            called.append(tier)
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+        monkeypatch.setattr(router, "_call_model", fake_call)
+        r = client.post("/v1/chat/completions", json=_chat_body())
+        assert r.status_code == 200
+        assert called == ["claude"]
+        assert "X-Router-Budget-Downgrade" not in r.headers
+        assert "budget_downgraded_from" not in r.json()["_router"]
+
+    def test_existing_gpt4o_to_phi4_redirect_untouched(self, router):
+        # The pre-existing base-selector redirect keeps working in warn mode.
+        _make_over_budget(router, "gpt4o-mini")
+        assert router.select_tier(_chat_body(model="gpt-4o-mini")) == "phi4"
+
+
+# ── downgrade mode ───────────────────────────────────────────────────────────
+
+class TestDowngradeMode:
+    @pytest.fixture()
+    def downgrade_router(self, router, monkeypatch):
+        monkeypatch.setattr(router, "_BUDGET_ENFORCE_MODE", "downgrade")
+        return router
+
+    def test_select_tier_downgrades_and_marks_body(self, downgrade_router):
+        _make_over_budget(downgrade_router, "claude")
+        body = _chat_body()
+        assert downgrade_router.select_tier(body) == "gpt4o-mini"
+        assert body["__budget_downgrade__"] == {
+            "from": "claude", "to": "gpt4o-mini",
+        }
+
+    def test_under_budget_not_downgraded(self, downgrade_router):
+        body = _chat_body()
+        assert downgrade_router.select_tier(body) == "claude"
+        assert "__budget_downgrade__" not in body
+
+    def test_endpoint_serves_fallback_with_header(
+        self, client, downgrade_router, monkeypatch
+    ):
+        _make_over_budget(downgrade_router, "claude")
+        called = []
+
+        async def fake_call(tier, body):
+            called.append(tier)
+            return {"choices": [{"message": {"content": "cheap ok"}}]}
+
+        monkeypatch.setattr(downgrade_router, "_call_model", fake_call)
+        r = client.post("/v1/chat/completions", json=_chat_body())
+        assert r.status_code == 200
+        assert called == ["gpt4o-mini"]
+        assert r.headers["X-Router-Budget-Downgrade"] == "claude->gpt4o-mini"
+        meta = r.json()["_router"]
+        assert meta["tier"] == "gpt4o-mini"
+        assert meta["budget_downgraded_from"] == "claude"
+
+    def test_non_anthropic_tier_also_downgraded(self, downgrade_router):
+        # Enforcement is generic, not Claude-specific.
+        _make_over_budget(downgrade_router, "phi4")
+        body = _chat_body(model="phi4")
+        assert downgrade_router.select_tier(body) == "gpt4o-mini"
+
+    def test_unavailable_fallback_serves_requested_tier(
+        self, downgrade_router, monkeypatch
+    ):
+        monkeypatch.setattr(downgrade_router, "_BUDGET_FALLBACK_TIER", "no-such-tier")
+        _make_over_budget(downgrade_router, "claude")
+        body = _chat_body()
+        assert downgrade_router.select_tier(body) == "claude"
+        assert "__budget_downgrade__" not in body
+
+
+# ── block mode ───────────────────────────────────────────────────────────────
+
+class TestBlockMode:
+    @pytest.fixture()
+    def block_router(self, router, monkeypatch):
+        monkeypatch.setattr(router, "_BUDGET_ENFORCE_MODE", "block")
+        return router
+
+    def test_endpoint_429_with_budget_exceeded_body(
+        self, client, block_router, monkeypatch
+    ):
+        _make_over_budget(block_router, "claude")
+
+        async def must_not_be_called(tier, body):  # pragma: no cover
+            raise AssertionError("blocked request must not reach the model")
+
+        monkeypatch.setattr(block_router, "_call_model", must_not_be_called)
+        r = client.post("/v1/chat/completions", json=_chat_body())
+        assert r.status_code == 429
+        detail = r.json()["detail"]
+        assert detail["error"] == "budget_exceeded"
+        assert detail["tier"] == "claude"
+        assert detail["mode"] == "block"
+        assert detail["spent_usd"] > detail["limit_usd"]
+
+    def test_under_budget_still_served(self, client, block_router, monkeypatch):
+        async def fake_call(tier, body):
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+        monkeypatch.setattr(block_router, "_call_model", fake_call)
+        r = client.post("/v1/chat/completions", json=_chat_body())
+        assert r.status_code == 200
+
+    def test_fallback_floor_tier_is_exempt(self, client, block_router, monkeypatch):
+        # gpt4o-mini over budget redirects to phi4 in the base selector; blow
+        # phi4's budget too and point the enforcement fallback at phi4 itself —
+        # the floor is exempt (self-referential fallback degrades to warn), so
+        # the request is served, never stranded.
+        monkeypatch.setattr(block_router, "_BUDGET_ENFORCE_MODE", "downgrade")
+        monkeypatch.setattr(block_router, "_BUDGET_FALLBACK_TIER", "phi4")
+        _make_over_budget(block_router, "gpt4o-mini")
+        block_router._spend["phi4"] = block_router.MODELS["phi4"]["daily_budget"] + 1.0
+        body = _chat_body(model="gpt-4o-mini")
+        assert block_router.select_tier(body) == "phi4"
+        assert "__budget_downgrade__" not in body
+
+
+# ── Native /v1/messages path (bypasses select_tier) ──────────────────────────
+# The Anthropic-native endpoint picks its tier via
+# _select_anthropic_tier_for_model and calls the SDK directly — the exact gap
+# class that let the upstream Claude tier overrun with only WARN lines — so it
+# has its own explicit enforcement and its own coverage here.
+
+class _FakeUsage:
+    input_tokens = 3
+    output_tokens = 1
+    cache_creation_input_tokens = 0
+    cache_read_input_tokens = 0
+
+
+class _FakeAnthropicResp:
+    usage = _FakeUsage()
+
+    def model_dump(self, **_kw):
+        return {
+            "id": "msg_test", "type": "message", "role": "assistant",
+            "model": "claude",
+            "content": [{"type": "text", "text": "pong"}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 3, "output_tokens": 1},
+        }
+
+
+def _fake_anthropic_client(created):
+    class _Messages:
+        async def create(self, **kwargs):
+            created.append(kwargs)
+            return _FakeAnthropicResp()
+
+    class _Client:
+        messages = _Messages()
+
+    return _Client()
+
+
+class TestMessagesNativePathEnforcement:
+    def test_warn_mode_still_serves_claude_direct(self, client, router, monkeypatch):
+        # Current behavior preserved: over-budget Claude on the direct-SDK
+        # path is served (with a WARN), not downgraded or blocked.
+        _make_over_budget(router, "claude")
+        created = []
+        monkeypatch.setattr(router, "_make_anthropic_client",
+                            lambda cfg: _fake_anthropic_client(created))
+        r = client.post("/v1/messages", json=_messages_body())
+        assert r.status_code == 200
+        assert len(created) == 1  # the direct SDK client WAS called
+        assert r.json()["_router"]["tier"] == "claude"
+        assert "X-Router-Budget-Downgrade" not in r.headers
+
+    def test_native_path_records_spend(self, client, router, monkeypatch):
+        # A6 prerequisite: the direct-SDK path accrues to the daily ledger
+        # (before this it recorded nothing, so enforcement would be inert).
+        _pin_today(router)
+        router._spend.pop("claude", None)
+        created = []
+        monkeypatch.setattr(router, "_make_anthropic_client",
+                            lambda cfg: _fake_anthropic_client(created))
+        r = client.post("/v1/messages", json=_messages_body())
+        assert r.status_code == 200
+        assert router._spend["claude"] > 0.0
+
+    def test_block_mode_429_before_any_upstream_call(self, client, router, monkeypatch):
+        monkeypatch.setattr(router, "_BUDGET_ENFORCE_MODE", "block")
+        _make_over_budget(router, "claude")
+
+        def must_not_build_client(cfg):  # pragma: no cover
+            raise AssertionError("blocked request must not build an SDK client")
+
+        monkeypatch.setattr(router, "_make_anthropic_client", must_not_build_client)
+        r = client.post("/v1/messages", json=_messages_body())
+        assert r.status_code == 429
+        body = r.json()
+        # Anthropic-shaped error so anthropic_messages transports can parse it.
+        assert body["type"] == "error"
+        assert body["error"]["type"] == "rate_limit_error"
+        assert body["error"]["detail"]["error"] == "budget_exceeded"
+        assert body["error"]["detail"]["tier"] == "claude"
+
+    def test_downgrade_with_non_anthropic_fallback_degrades_to_warn(
+        self, client, router, monkeypatch
+    ):
+        # AAF divergence from the upstream deployment (documented in the PR):
+        # this router has no Anthropic→OpenAI response translation for the
+        # native path, so with the default gpt4o-mini fallback (not Anthropic-
+        # backed) a downgrade cannot keep the response Anthropic-shaped. The
+        # module's fallback-unavailable rule kicks in: degrade to warn, serve
+        # the requested tier — never strand the request.
+        monkeypatch.setattr(router, "_BUDGET_ENFORCE_MODE", "downgrade")
+        _make_over_budget(router, "claude")
+        created = []
+        monkeypatch.setattr(router, "_make_anthropic_client",
+                            lambda cfg: _fake_anthropic_client(created))
+        r = client.post("/v1/messages", json=_messages_body())
+        assert r.status_code == 200
+        assert len(created) == 1  # served by the requested tier's SDK client
+        assert r.json()["_router"]["tier"] == "claude"
+        assert "X-Router-Budget-Downgrade" not in r.headers
+
+    def test_downgrade_with_anthropic_fallback_serves_it_natively(
+        self, client, router, monkeypatch
+    ):
+        # An Anthropic-backed fallback CAN serve the native shape, so the
+        # downgrade happens in-path and is marked on the response.
+        router.MODELS["claude-mini"] = dict(
+            router.MODELS["claude"],
+            litellm_model="anthropic/claude-mini",
+            daily_budget=5.0,
+        )
+        monkeypatch.setattr(router, "_BUDGET_ENFORCE_MODE", "downgrade")
+        monkeypatch.setattr(router, "_BUDGET_FALLBACK_TIER", "claude-mini")
+        _make_over_budget(router, "claude")
+        created = []
+        monkeypatch.setattr(router, "_make_anthropic_client",
+                            lambda cfg: _fake_anthropic_client(created))
+        r = client.post("/v1/messages", json=_messages_body())
+        assert r.status_code == 200
+        assert len(created) == 1
+        assert created[0]["model"] == "claude-mini"  # fallback deployment used
+        assert r.headers["X-Router-Budget-Downgrade"] == "claude->claude-mini"
+        meta = r.json()["_router"]
+        assert meta["tier"] == "claude-mini"
+        assert meta["budget_downgraded_from"] == "claude"
+
+    def test_under_budget_native_path_untouched_in_downgrade_mode(
+        self, client, router, monkeypatch
+    ):
+        monkeypatch.setattr(router, "_BUDGET_ENFORCE_MODE", "downgrade")
+        _pin_today(router)
+        router._spend.pop("claude", None)
+        created = []
+        monkeypatch.setattr(router, "_make_anthropic_client",
+                            lambda cfg: _fake_anthropic_client(created))
+        r = client.post("/v1/messages", json=_messages_body())
+        assert r.status_code == 200
+        assert len(created) == 1
+        assert r.json()["_router"]["tier"] == "claude"
+
+
+# ── /v1/embeddings path (no tier at all) ─────────────────────────────────────
+# Embeddings bypass tier selection; A6 gives them a dedicated "embeddings"
+# ledger bucket + cap. No same-vector-space downgrade target exists, so
+# downgrade mode degrades to warn; block mode 429s.
+
+async def _fake_aembedding(**kwargs):
+    return {
+        "data": [{"index": 0, "embedding": [0.1, 0.2]}],
+        "model": "text-embedding-3-small",
+        "usage": {"prompt_tokens": 100, "total_tokens": 100},
+    }
+
+
+class TestEmbeddingsBudget:
+    @pytest.fixture()
+    def embed_router(self, router, monkeypatch):
+        monkeypatch.setattr(router, "_EMBED_API_KEY", "test-embed-key")
+        monkeypatch.setattr(router.litellm, "aembedding", _fake_aembedding)
+        return router
+
+    def _blow_bucket(self, router):
+        _pin_today(router)
+        router._spend[router._EMBED_LEDGER_BUCKET] = router._EMBED_DAILY_BUDGET_USD + 1.0
+
+    def test_spend_accrues_to_embeddings_bucket(self, client, embed_router):
+        _pin_today(embed_router)
+        embed_router._spend.pop("embeddings", None)
+        r = client.post("/v1/embeddings", json={"input": "hello"})
+        assert r.status_code == 200
+        # 100 tokens at the default $0.02/MTok list price.
+        assert embed_router._spend["embeddings"] == pytest.approx(0.000002)
+
+    def test_warn_mode_over_budget_still_served(self, client, embed_router):
+        self._blow_bucket(embed_router)
+        r = client.post("/v1/embeddings", json={"input": "hello"})
+        assert r.status_code == 200
+
+    def test_block_mode_over_budget_429(self, client, embed_router, monkeypatch):
+        monkeypatch.setattr(embed_router, "_BUDGET_ENFORCE_MODE", "block")
+        self._blow_bucket(embed_router)
+
+        async def must_not_be_called(**kwargs):  # pragma: no cover
+            raise AssertionError("blocked embeddings call must not reach upstream")
+
+        monkeypatch.setattr(embed_router.litellm, "aembedding", must_not_be_called)
+        r = client.post("/v1/embeddings", json={"input": "hello"})
+        assert r.status_code == 429
+        detail = r.json()["detail"]
+        assert detail["error"] == "budget_exceeded"
+        assert detail["tier"] == "embeddings"
+
+    def test_block_mode_under_budget_served(self, client, embed_router, monkeypatch):
+        monkeypatch.setattr(embed_router, "_BUDGET_ENFORCE_MODE", "block")
+        _pin_today(embed_router)
+        embed_router._spend.pop("embeddings", None)
+        r = client.post("/v1/embeddings", json={"input": "hello"})
+        assert r.status_code == 200
+
+    def test_downgrade_mode_degrades_to_warn(self, client, embed_router, monkeypatch):
+        # No same-vector-space fallback exists → downgrade serves anyway.
+        monkeypatch.setattr(embed_router, "_BUDGET_ENFORCE_MODE", "downgrade")
+        self._blow_bucket(embed_router)
+        r = client.post("/v1/embeddings", json={"input": "hello"})
+        assert r.status_code == 200
+        assert "X-Router-Budget-Downgrade" not in r.headers
+
+    def test_zero_cap_disables_ceiling(self, client, embed_router, monkeypatch):
+        monkeypatch.setattr(embed_router, "_BUDGET_ENFORCE_MODE", "block")
+        monkeypatch.setattr(embed_router, "_EMBED_DAILY_BUDGET_USD", 0.0)
+        _pin_today(embed_router)
+        embed_router._spend["embeddings"] = 999.0
+        r = client.post("/v1/embeddings", json={"input": "hello"})
+        assert r.status_code == 200
+
+    def test_per_caller_cap_applies_to_embeddings(self, client, embed_router, monkeypatch):
+        # aaf-0005 parity: an attributed caller over its daily cap is refused
+        # on the embeddings path just like on the chat paths.
+        monkeypatch.setattr(embed_router, "PER_CALLER_DAILY_USD", 1.0)
+        _pin_today(embed_router)
+        embed_router._spend_by_caller["agent-a"] = 2.0
+        r = client.post("/v1/embeddings", json={"input": "hello"},
+                        headers={"x-agent-id": "agent-a"})
+        assert r.status_code == 429
+        assert "Per-caller" in r.json()["detail"]


### PR DESCRIPTION
## What

Extends the v1.5 cost-governance layer from **observe-only** to **enforce-with-downgrade/block** for every router path, behind a single env knob. Default is `warn` — behavior identical to today (ship-dark safe).

**Provenance:** port of the upstream private deployment's just-merged M5 "acting budget enforcement". The decision module (`services/model-router/budget_enforcement.py`) was designed there as a portability contract — stdlib-only, framework-free, zero host imports — and is vendored verbatim (docstring host references sanitized). The host wiring is thin and adapted to this router's shape.

## Semantics

| Mode (`BUDGET_ENFORCE_MODE`) | Over-budget behavior |
|---|---|
| `warn` *(default)* | Serve the requested tier + `budget_enforce` WARN log — exactly the pre-A6 behavior |
| `downgrade` | Serve `BUDGET_FALLBACK_TIER` (default `gpt4o-mini`); response carries `X-Router-Budget-Downgrade: <from>-><to>` + `_router.budget_downgraded_from` |
| `block` | HTTP 429 with machine-readable `budget_exceeded` body (`error`, `tier`, `spent_usd`, `limit_usd`, `mode`) |

Guarantees:
- **Invalid mode fails open to `warn`** (a config typo must not brick the router).
- **The fallback tier is exempt** — it is the designated floor; an unregistered or self-referential fallback degrades to `warn` rather than stranding requests.
- **No selftest/probe exemption needed** — this router has no selftest traffic (unlike upstream).

## Path coverage (where this router differs from upstream)

| Path | Coverage |
|---|---|
| `/v1/chat/completions` | Enforcement wraps `select_tier` as its final stage — covers explicit tiers, persona routing, ephemeral passthrough tiers, and the Anthropic direct-SDK dispatch inside `_call_model`. The pre-existing `gpt4o-mini`→`phi4` over-budget redirect is untouched. |
| `/v1/messages` (native Anthropic, **bypasses `select_tier`**) | Explicit check. `block` returns an Anthropic-shaped 429 (`rate_limit_error`) so `anthropic_messages` transports parse it like any upstream error. **Divergence from upstream:** this router has no Anthropic→OpenAI response translation, so `downgrade` only takes effect when `BUDGET_FALLBACK_TIER` is itself Anthropic-backed; otherwise it degrades to `warn` (module's fallback-unavailable rule). **This path also now records its spend** (streaming + non-streaming, via list-price estimate) — previously it recorded nothing, which would have left enforcement blind on the exact path the feature was built for. |
| `/v1/embeddings` (#112, **no tier at all**) | **Decision: embeddings spend IS budgeted.** It now accrues to a dedicated `embeddings` ledger bucket (visible in `daily_cost_rollup`) capped by `EMBEDDING_DAILY_BUDGET_USD` (default `1.00`; `0` disables, mirroring `PER_CALLER_DAILY_USD`). No same-vector-space downgrade target exists (the model pin is the point), so `downgrade` degrades to `warn` here; `block` 429s. Also gains the aaf-0005 per-caller budget gate for parity with the chat endpoints. |

## Config

- `BUDGET_ENFORCE_MODE` — `warn` (default) | `downgrade` | `block`
- `BUDGET_FALLBACK_TIER` — default `gpt4o-mini`
- `EMBEDDING_DAILY_BUDGET_USD` — default `1.00`; `0` disables
- `EMBEDDING_PRICE_PER_MTOK` — list-price estimator fallback (default `0.02`, matches `text-embedding-3-small`)

Plumbed through `.env.example`, root + mac-site compose, and both Terraform router sidecars (hermes pod + memory-governor pod) via new validated module variables (`budget_enforce_mode`, `budget_fallback_tier`, `embedding_daily_budget_usd`). Dockerfile now ships `budget_enforcement.py` alongside `main.py`.

## Test evidence

```
before: 200 passed
after:  237 passed  (+37 in services/model-router/tests/test_budget_enforcement.py)
```

New coverage: pure module (resolve_mode normalization + invalid-mode fail-open, decide matrix, block_detail/downgrade_header shapes), warn-is-ship-dark (select_tier + endpoint unchanged, no header/meta), downgrade (+header, +`_router` meta, generic across tiers, unavailable-fallback degradation), block (429 before any upstream call), native `/v1/messages` (warn serves direct, block 429 Anthropic-shaped, non-Anthropic fallback degrades to warn, Anthropic fallback served natively with header, spend now recorded), embeddings (bucket accrual, warn/block/downgrade, zero-cap disable, per-caller gate), and floor-tier exemption.

`scripts/scan-internal-refs.sh`: clean. `docker compose config`: valid. `terraform fmt -check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
