### PR TITLE
feat(ci): vendored-config schema guard (A3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -153,7 +153,8 @@ HONCHO_APP_ID=
 # See docs/design/memory-system.md §18 ("Identity: the canonical user peer").
 HONCHO_USER_PEER_ID=user
 HERMES_HOME=
-HERMES_DB_PATH=
+# (HERMES_DB_PATH removed — the pinned Hermes has no state-db path override;
+# state.db always lives at HERMES_HOME/state.db. A3 schema-guard finding.)
 GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE=
 
 # ── Paperclip Orchestrator ────────────────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,3 +129,30 @@ jobs:
         run: pytest -q tests/skills
       - name: compileall
         run: python -m compileall services installer
+
+  # A3 — vendored-config schema guard. Every config key AAF ships to a
+  # vendored app (compose/Terraform env blocks, the generated Hermes
+  # config.yaml) must be read by the PINNED vendored source; keys the app
+  # silently drops (the Honcho 3.0.7 flat-key removal class) fail here
+  # instead of silently degrading a deployment.
+  # docs/design/vendored-config-schema-guard.md
+  validate-vendored-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The accepted-key universes are derived from the pinned vendored
+          # source (honcho pydantic settings, hermes config parser), so the
+          # submodules must be checked out — same as build-context.
+          submodules: recursive
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: install guard deps
+        run: pip install -r scripts/vendored-config/requirements.txt pytest
+      - name: self-test (prove the guard detects seeded drift before trusting a pass)
+        run: python scripts/validate_vendored_config.py --self-test
+      - name: schema guard (shipped config vs pinned vendored schemas)
+        run: python scripts/validate_vendored_config.py
+      - name: validator unit tests
+        run: pytest -q tests/vendored-config

--- a/deploy/mac-site/docker-compose.yml
+++ b/deploy/mac-site/docker-compose.yml
@@ -74,32 +74,38 @@ services:
       # Honcho builds an LLM client per specialist at import and raises on a
       # missing key; point summary/deriver at the OpenAI-compatible provider.
       LLM_OPENAI_API_KEY: "${EMBEDDING_API_KEY:?run secrets-pull.sh}"
-      SUMMARY_PROVIDER: "openai"
-      SUMMARY_MODEL: "gpt-4o-mini"
-      DERIVER_PROVIDER: "openai"
-      DERIVER_MODEL: "gpt-4o-mini"
-      # Honcho requires ALL FIVE dialectic reasoning levels; a missing level
-      # crash-loops the service on boot. Nested pydantic-settings path
-      # (env_prefix DIALECTIC_ + "__" delimiter); the flat form is ignored.
-      DIALECTIC_LEVELS__minimal__PROVIDER: "openai"
-      DIALECTIC_LEVELS__minimal__MODEL: "gpt-4o-mini"
-      DIALECTIC_LEVELS__minimal__THINKING_BUDGET_TOKENS: "0"
+      # Per-specialist model config — Honcho >= 3.0.7 nested MODEL_CONFIG shape.
+      # The pre-3.0.7 flat keys (SUMMARY_PROVIDER/SUMMARY_MODEL/...) are REMOVED
+      # upstream and silently ignored — shipping them makes every specialist
+      # fall back to direct-OpenAI gpt-5.4-mini (services/honcho/README.md).
+      # Drift here is caught by CI (scripts/validate_vendored_config.py).
+      SUMMARY_MODEL_CONFIG__TRANSPORT: "openai"
+      SUMMARY_MODEL_CONFIG__MODEL: "gpt-4o-mini"
+      DERIVER_MODEL_CONFIG__TRANSPORT: "openai"
+      DERIVER_MODEL_CONFIG__MODEL: "gpt-4o-mini"
+      # All five dialectic levels pinned to the same small model (3.0.11 fills
+      # omitted levels from built-in openai/gpt-5.4-mini defaults — pinning
+      # keeps the model choice ours). MAX_TOOL_ITERATIONS survived 3.0.7 and
+      # stays a per-level field, NOT under MODEL_CONFIG.
+      DIALECTIC_LEVELS__minimal__MODEL_CONFIG__TRANSPORT: "openai"
+      DIALECTIC_LEVELS__minimal__MODEL_CONFIG__MODEL: "gpt-4o-mini"
+      DIALECTIC_LEVELS__minimal__MODEL_CONFIG__THINKING_BUDGET_TOKENS: "0"
       DIALECTIC_LEVELS__minimal__MAX_TOOL_ITERATIONS: "1"
-      DIALECTIC_LEVELS__low__PROVIDER: "openai"
-      DIALECTIC_LEVELS__low__MODEL: "gpt-4o-mini"
-      DIALECTIC_LEVELS__low__THINKING_BUDGET_TOKENS: "0"
+      DIALECTIC_LEVELS__low__MODEL_CONFIG__TRANSPORT: "openai"
+      DIALECTIC_LEVELS__low__MODEL_CONFIG__MODEL: "gpt-4o-mini"
+      DIALECTIC_LEVELS__low__MODEL_CONFIG__THINKING_BUDGET_TOKENS: "0"
       DIALECTIC_LEVELS__low__MAX_TOOL_ITERATIONS: "2"
-      DIALECTIC_LEVELS__medium__PROVIDER: "openai"
-      DIALECTIC_LEVELS__medium__MODEL: "gpt-4o-mini"
-      DIALECTIC_LEVELS__medium__THINKING_BUDGET_TOKENS: "0"
+      DIALECTIC_LEVELS__medium__MODEL_CONFIG__TRANSPORT: "openai"
+      DIALECTIC_LEVELS__medium__MODEL_CONFIG__MODEL: "gpt-4o-mini"
+      DIALECTIC_LEVELS__medium__MODEL_CONFIG__THINKING_BUDGET_TOKENS: "0"
       DIALECTIC_LEVELS__medium__MAX_TOOL_ITERATIONS: "3"
-      DIALECTIC_LEVELS__high__PROVIDER: "openai"
-      DIALECTIC_LEVELS__high__MODEL: "gpt-4o-mini"
-      DIALECTIC_LEVELS__high__THINKING_BUDGET_TOKENS: "0"
+      DIALECTIC_LEVELS__high__MODEL_CONFIG__TRANSPORT: "openai"
+      DIALECTIC_LEVELS__high__MODEL_CONFIG__MODEL: "gpt-4o-mini"
+      DIALECTIC_LEVELS__high__MODEL_CONFIG__THINKING_BUDGET_TOKENS: "0"
       DIALECTIC_LEVELS__high__MAX_TOOL_ITERATIONS: "4"
-      DIALECTIC_LEVELS__max__PROVIDER: "openai"
-      DIALECTIC_LEVELS__max__MODEL: "gpt-4o-mini"
-      DIALECTIC_LEVELS__max__THINKING_BUDGET_TOKENS: "0"
+      DIALECTIC_LEVELS__max__MODEL_CONFIG__TRANSPORT: "openai"
+      DIALECTIC_LEVELS__max__MODEL_CONFIG__MODEL: "gpt-4o-mini"
+      DIALECTIC_LEVELS__max__MODEL_CONFIG__THINKING_BUDGET_TOKENS: "0"
       DIALECTIC_LEVELS__max__MAX_TOOL_ITERATIONS: "5"
 
   # ── Model router (OpenAI-compatible tier router) ───────────────────────────

--- a/docs/design/vendored-config-schema-guard.md
+++ b/docs/design/vendored-config-schema-guard.md
@@ -1,0 +1,262 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="../assets/azureagentforge-logo-dark.png">
+    <img alt="AzureAgentForge" src="../assets/azureagentforge-logo-light.png" width="440">
+  </picture>
+</p>
+
+# Vendored-config schema guard (A3)
+
+![status](https://img.shields.io/badge/status-shipped%20%E2%80%94%20CI%20enforcing-brightgreen)
+
+> **One sentence.** A CI job (`validate-vendored-config`) that validates every
+> config key AAF ships to a vendored app against the schema the *pinned vendored
+> source* actually reads, so a key the app silently drops fails the build instead
+> of silently degrading the deployment.
+
+**Audience.** An engineer maintaining a platform that vendors upstream apps
+(pinned submodules or pinned release builds) and ships its own config artifacts
+for them — compose env blocks, Terraform env, generated config files. The
+pattern generalizes; the app-specific adapters here are worked examples.
+
+---
+
+## 1. The failure class
+
+A vendored app's config schema is owned by the upstream; the config artifacts
+that feed it are owned by this repo. Nothing ties the two together. When the
+upstream changes its schema on a vendor bump, the shipped artifacts keep
+"working": the app boots, health checks pass, and the keys it no longer reads
+are **silently ignored** — the app runs on built-in defaults you did not choose.
+
+Two real incidents (observed on a private deployment of the same upstreams)
+define the class:
+
+1. **Honcho 3.0.7** replaced the flat per-specialist keys
+   (`SUMMARY_PROVIDER`, `DERIVER_MODEL`, `DIALECTIC_LEVELS__<lvl>__PROVIDER`, …)
+   with a nested `MODEL_CONFIG` sub-model. Every Honcho settings class uses
+   pydantic-settings `extra="ignore"`, so an un-migrated config boots clean and
+   **falls back to direct-OpenAI `gpt-5.4-mini`** for every specialist. No
+   error. You find out from the OpenAI bill.
+   (Documented in [`services/honcho/README.md`](../../services/honcho/README.md).)
+2. **Hermes 0.18.1** shifted its config schema and silently misrouted provider
+   credentials (symptom: `provider=openrouter, model=empty, 401`). The config
+   file parsed fine; the keys just no longer meant what the artifact thought.
+
+Both failures share one shape: **config the app no longer reads**. That is
+exactly what a schema guard can catch mechanically, before deploy.
+
+**And the guard found live instances on its first run** — see §7. The vendor
+bump that migrated `docker-compose.yml` and `.env.example` to the Honcho 3.0.7+
+schema missed `infrastructure/modules/container-apps/honcho.tf` (all three
+resources) and `deploy/mac-site/docker-compose.yml`: both still shipped the
+removed flat keys, meaning a Terraform or Mac-site deployment of the pinned
+Honcho 3.0.11 image would run every specialist on direct-OpenAI
+`gpt-5.4-mini` — incident (1), reproduced in-tree.
+
+## 2. Inventory: vendored apps × shipped config artifacts
+
+| Vendored app | Vendored how | Config surface | AAF-shipped artifacts that feed it |
+|---|---|---|---|
+| **Honcho** (`apps/honcho/src`) | git submodule, pinned `v3.0.11` | pydantic-settings classes in `src/config.py` (per-section `env_prefix`, `__` nested delimiter, `extra="ignore"`) | `docker-compose.yml` → `honcho.environment`; `deploy/mac-site/docker-compose.yml` → `honcho.environment`; `infrastructure/modules/container-apps/honcho.tf` → `env{}` blocks (3 resources: API app, deriver app, deriver job) |
+| **Hermes** (`apps/hermes/src`) | git submodule, pinned `v2026.5.16` | (a) `config.yaml` parsed by `hermes_cli/config.py` (`DEFAULT_CONFIG` tree + `_KNOWN_ROOT_KEYS`); (b) env vars read via `os.getenv`/`os.environ` across the tree | (a) the `config.yaml` heredoc generators — **discovered**, not hardcoded, across `apps/paperclip/*.sh` and `services/paperclip/*.sh` (currently `apps/paperclip/write-hermes-config.sh` (A1's canonical template) plus the copy inside `services/paperclip/docker-entrypoint.sh`); (b) `infrastructure/modules/container-apps/hermes.tf` → `env{}` blocks, scoped to the `hermes` container (the model-router sidecar is AAF-authored) |
+| **PaperClip** (not in-tree) | cloned at image build from the pinned release tag (`services/paperclip/Dockerfile`: `ARG PAPERCLIP_VERSION` + `PAPERCLIP_EXPECTED_SHA`) | env vars (upstream server + hermes-paperclip-adapter + AAF entrypoint/auth-proxy) | `docker-compose.yml` → `paperclip.environment`; `deploy/mac-site/docker-compose.yml` → `paperclip.environment`; `infrastructure/modules/container-apps/paperclip.tf` → `env{}` blocks |
+
+Out of scope (documented, deliberate):
+
+- **`.env.example` keys** are compose-interpolation *inputs* (`SUMMARY_TRANSPORT`
+  feeds `SUMMARY_MODEL_CONFIG__TRANSPORT`), not app-visible env. The injection
+  point — the compose/Terraform env key — is what the apps see, so that is what
+  is validated.
+- **`env_file: [.env]`** on the Mac-site services sprays the whole site `.env`
+  into each container. Validating that would flood on shared keys
+  (`POSTGRES_*`, router tiers). Only explicit `environment:` keys — the
+  intentional per-service interface — are validated. (Known consequence worth
+  knowing: a site `.env` `EMBEDDING_MODEL` also lands in Honcho, which has an
+  `EMBEDDING_` settings section. The guard can't referee intent inside a shared
+  env file.)
+- **Model-router, memory-governor, watchdog, bridges** are AAF-authored — their
+  config surface lives in this repo and drifts with its own code review; the
+  guard is for surfaces whose schema is owned *upstream*.
+
+## 3. Per-app validation strategy
+
+One principle drives all three adapters: **derive the accepted-key universe
+from the pinned vendored source wherever the source is in-tree and parseable;
+curate a manifest only where it is not — and pin every curated artifact to the
+vendor version so a bump forces re-validation.**
+
+### 3.1 Honcho — load the vendored pydantic Settings (dynamic, exact)
+
+`src/config.py` imports only `pydantic`, `pydantic-settings`, `python-dotenv`
+and stdlib, and has no package-relative imports, so the guard loads it
+standalone (`importlib.util.spec_from_file_location`, with
+`PYTHON_DOTENV_DISABLED=1`) and introspects the real `AppSettings` model — the
+same code the container executes. From it the guard derives every acceptable
+env key:
+
+- each settings class contributes `env_prefix + FIELD_NAME` for scalar fields;
+- classes with `env_nested_delimiter="__"` contribute nested paths through
+  `BaseModel`-typed fields (`SUMMARY_MODEL_CONFIG__TRANSPORT`,
+  `…__OVERRIDES__BASE_URL`), honoring `validation_alias`;
+- `dict[Literal[...], Model]` fields contribute one branch per literal key —
+  `DIALECTIC_LEVELS__minimal__MODEL_CONFIG__MODEL` is accepted,
+  `DIALECTIC_LEVELS__hgih__…` (typo'd level) is not;
+- matching is case-insensitive, mirroring pydantic-settings' default.
+
+Because the universe is *derived at validation time from the submodule commit
+the repo pins*, a Honcho vendor bump needs no manifest maintenance: the moment
+an upstream schema change invalidates a shipped key, the job fails — which is
+the point.
+
+A curated **removed-keys map** (from the 3.0.7 migration table in
+`services/honcho/README.md`) upgrades the error message for the known-removed
+flat keys from "unknown key" to "**removed in 3.0.7 — replace with
+`SUMMARY_MODEL_CONFIG__TRANSPORT`**". The map only improves diagnostics; the
+detection itself never depends on curation.
+
+### 3.2 Hermes `config.yaml` — AST-parse the vendored parser (static) + pinned manifest for polymorphic sections
+
+Importing `hermes_cli.config` would drag in the Hermes dependency tree, so the
+guard **AST-parses** `apps/hermes/src/hermes_cli/config.py` (no imports, no
+execution) and extracts:
+
+- the `DEFAULT_CONFIG` key tree (root keys + nested dict keys), and
+- `_KNOWN_ROOT_KEYS` (the upstream's own root-key set — incomplete upstream,
+  so the union of both is used).
+
+Every key path in the AAF-generated `config.yaml` (extracted from the
+`<<HERMES_EOF` heredocs, `${…}` placeholders neutralized, then YAML-parsed)
+must exist in that tree. The generator scripts themselves are **discovered**
+by scanning `apps/paperclip/*.sh` + `services/paperclip/*.sh` for the heredoc
+marker — A1 moved the generation from the entrypoint into
+`write-hermes-config.sh` mid-flight, which is exactly why hardcoded paths
+would rot; zero generators found is itself a finding (a Hermes booting on
+pure defaults is its own silent-config incident). Two honest gaps require a
+curated manifest ([`scripts/vendored-config/manifest-hermes.yaml`](../../scripts/vendored-config/manifest-hermes.yaml)):
+
+- **Polymorphic sections.** `DEFAULT_CONFIG["model"]` is `""` (string), but the
+  runtime also accepts a dict form whose keys (`provider`, `base_url`,
+  `api_mode`, …) are only visible as scattered `.get()` calls. The manifest
+  records those accepted subkeys with the source references used to curate them.
+- **Manifest staleness.** The manifest carries the **pinned submodule commit**;
+  the guard compares it against `git ls-tree HEAD apps/hermes/src` (the
+  superproject gitlink — works even before submodule checkout). On a Hermes
+  vendor bump the SHAs diverge and the job **fails loudly** until someone
+  re-validates the polymorphic sections against the new source and updates the
+  pin. That friction is deliberate: it converts "silent schema drift" into "a
+  human re-checked the schema".
+
+### 3.3 Hermes env vars — static consumption scan
+
+The accepted env universe for `hermes.tf` is the union of: every string literal
+passed to `os.getenv` / `os.environ.get` / `os.environ[...]` across the
+vendored Hermes Python tree (regex scan, ~1,700 files, sub-second); the keys of
+the parser's `REQUIRED_ENV_VARS` / `OPTIONAL_ENV_VARS` / `_EXTRA_ENV_KEYS`
+tables (AST-extracted); and `$VAR` / `${VAR}` reads in the AAF-authored
+override scripts baked into the same image (`apps/hermes/overrides/**/*.sh`).
+This over-accepts (any env the source *ever* reads is accepted) — fine, because
+this check's job is to catch keys the app **never** reads, which is the silent
+class.
+
+### 3.4 PaperClip — curated per-version manifest (source not in-tree)
+
+PaperClip source is cloned at image build time, so there is nothing in-tree to
+parse. The honest strategy is a curated manifest
+([`scripts/vendored-config/manifest-paperclip.yaml`](../../scripts/vendored-config/manifest-paperclip.yaml)):
+every accepted env key, annotated with its consumer (upstream server, adapter,
+AAF entrypoint, auth-proxy, or Hermes-inside-the-container), pinned to
+`PAPERCLIP_VERSION`. The guard cross-checks the manifest's pinned version
+against **both** the Dockerfile `ARG PAPERCLIP_VERSION` default and the compose
+`${PAPERCLIP_VERSION:-…}` default; any mismatch fails the job with
+"vendor bump — re-validate the manifest". Same loud-on-bump behavior as 3.2,
+enforced on the pin the build actually uses.
+
+## 4. Failure policy: hard-fail everything, allowlist with mandatory reasons
+
+Every finding is a **hard failure** — no warn tier. A warn tier for "probably
+fine" keys is how the last two incidents shipped: a warning in a green build is
+invisible. The pressure valve is an allowlist, not a severity downgrade:
+
+- [`scripts/vendored-config/allowlist.yaml`](../../scripts/vendored-config/allowlist.yaml)
+  holds `{app, key, reason}` entries; **an entry with a missing or empty
+  `reason` is itself a validation failure.** Every suppression is a reviewed,
+  explained decision in git history.
+- Typical legitimate entries: platform env consumed by the runtime rather than
+  the app's settings model (`AZURE_CLIENT_ID` → azure-identity,
+  `APPLICATIONINSIGHTS_CONNECTION_STRING` → App Insights agent).
+
+False-positive economics: the accepted universes are deliberately generous
+(case-insensitive; env-scan over-acceptance in 3.3; upstream's own key tables
+unioned in), so residual false positives are rare and the allowlist cost is a
+one-line entry with a sentence of justification. False *negatives* (an
+over-accepted key) cost nothing new — that is today's status quo for that key.
+
+## 5. Behavior on a vendor bump (by design)
+
+| App | What happens on bump | What un-breaks it |
+|---|---|---|
+| Honcho | Universe recomputed from new pinned source; job fails **iff** shipped keys became invalid | Migrate the flagged artifacts (that's the incident, caught) |
+| Hermes | Manifest pin ≠ new gitlink → job fails **always** | Re-validate polymorphic sections against new source; update manifest pin |
+| PaperClip | Manifest pin ≠ new Dockerfile/compose version → job fails **always** | Re-validate manifest env list against the new release; update pin |
+
+## 6. Implementation
+
+- **Validator**: [`scripts/validate_vendored_config.py`](../../scripts/validate_vendored_config.py)
+  — single-file Python (3.11+; needs `tomllib`-era stdlib only for parity with
+  Honcho's imports), deps `pydantic`, `pydantic-settings`, `python-dotenv`,
+  `PyYAML` ([`scripts/vendored-config/requirements.txt`](../../scripts/vendored-config/requirements.txt)).
+  Exit 0 = every shipped key accepted; exit 1 = findings (grouped per artifact,
+  each with file, key, verdict, and fix hint). `--self-test` runs seeded
+  known-bad fixtures (a removed Honcho flat key, an unknown env key, a typo'd
+  Hermes root key, a PaperClip version mismatch) and exits nonzero unless every
+  seeded fault is *detected* — the guard proves it can fail before it is trusted
+  to pass.
+- **Tests**: [`tests/vendored-config/`](../../tests/vendored-config/) (pytest)
+  — per-app unit tests: unknown key detected, removed-key-still-shipped
+  detected with migration hint, allowlisted key passes, allowlist-without-reason
+  rejected, manifest pin drift detected, plus a whole-repo run asserting the
+  current tree is clean.
+- **CI**: `validate-vendored-config` job in
+  [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) — checkout with
+  `submodules: recursive` (same as `build-context`), Python 3.12, install
+  requirements, run `--self-test`, run the guard, run the tests. Enforcing from
+  day one (unlike `build-context`, nothing is pending port — the guard is green
+  on the current tree after the §7 fixes).
+
+## 7. Real drift found (and fixed) on first run
+
+The guard's first honest run against the repo found incident class (1) alive
+in two shipped artifacts — both missed by the vendor-bump PR that migrated
+`docker-compose.yml` and `.env.example` (#111):
+
+1. **`infrastructure/modules/container-apps/honcho.tf`** — all three resources
+   (API app, always-on deriver, scheduled deriver job) shipped the pre-3.0.7
+   flat keys: `SUMMARY_PROVIDER`, `SUMMARY_MODEL`, `DERIVER_PROVIDER`,
+   `DERIVER_MODEL`, and `DIALECTIC_LEVELS__<lvl>__PROVIDER` / `__MODEL` /
+   `__THINKING_BUDGET_TOKENS` for all five levels — 57 removed env keys in
+   total. A Terraform deploy of the pinned Honcho 3.0.11 image would have run
+   every specialist and all five dialectic levels on direct-OpenAI
+   `gpt-5.4-mini`. Ironically the file's own comment warns that "the old
+   DIALECTIC_MINIMAL_PROVIDER style is silently ignored" — while using the
+   *other* silently-ignored style.
+2. **`deploy/mac-site/docker-compose.yml`** — the Honcho service's
+   `environment:` block shipped the same flat keys (19 removed keys), with a
+   comment correctly stating "the flat form is ignored" three lines above the
+   flat form being used.
+
+Both are migrated in this change to the `MODEL_CONFIG` schema (preserving each
+file's intended per-level `MAX_TOOL_ITERATIONS`, which survived 3.0.7 and stays
+flat). `DERIVER_FLUSH_ENABLED`, `DERIVER_STALE_SESSION_TIMEOUT_MINUTES`,
+`LOG_LEVEL`, `DB_CONNECTION_URI`, and `LLM_OPENAI_API_KEY` were verified
+still-valid against the vendored model and left alone.
+
+## 8. What this guard does NOT do
+
+- It cannot judge **values** (a wrong model name in a valid key still ships) —
+  it guards key routing, not semantics.
+- It cannot see keys delivered through `env_file:` or Key Vault secret *values*.
+- The PaperClip universe is curated, not derived; a manifest curator can be
+  wrong. The version pin bounds the damage to one release window and forces a
+  re-look at every bump.
+- It does not validate AAF-authored services' own config (see §2 out-of-scope).

--- a/infrastructure/modules/container-apps/hermes.tf
+++ b/infrastructure/modules/container-apps/hermes.tf
@@ -248,10 +248,9 @@ resource "azurerm_container_app" "hermes" {
         name  = "APPLICATIONINSIGHTS_CONNECTION_STRING"
         value = var.app_insights_connection_string
       }
-      env {
-        name  = "LOG_LEVEL"
-        value = "info" # was "debug" — excessive log volume in deployed environments
-      }
+      # NOTE: no LOG_LEVEL here — the pinned Hermes never reads it (verified
+      # against apps/hermes/src; enforced by scripts/validate_vendored_config.py).
+      # The model-router sidecar below DOES read LOG_LEVEL and keeps its own.
 
       # Tells Hermes where its persistent config/memory files live (Azure File Share).
       # The hermes-data share is mounted at /opt/data (see volume_mounts below).
@@ -260,19 +259,20 @@ resource "azurerm_container_app" "hermes" {
         value = "/opt/data"
       }
 
-      # Store state.db on the local container filesystem (/tmp) to avoid SQLite
-      # locking failures on Azure File Share (SMB/CIFS). Lost on redeploy, which
-      # is acceptable — Honcho holds the persistent memory layer.
-      env {
-        name  = "HERMES_DB_PATH"
-        value = "/tmp/hermes-state.db"
-      }
+      # NOTE: no HERMES_DB_PATH here — the pinned Hermes (v2026.5.16) has no
+      # such env override (hermes_state.py: DEFAULT_DB_PATH is always
+      # HERMES_HOME/state.db). The key used to be shipped as an SMB fix
+      # ("state.db on /tmp to avoid SQLite locking on the Azure File Share")
+      # and was SILENTLY IGNORED — state.db actually lives on the share.
+      # Removed by the vendored-config schema guard (A3); if SQLite locking on
+      # state.db bites, the fix must come from a vendor bump that supports a
+      # path override, not from shipping a key nothing reads.
 
-      # Same SMB fix for the kanban board DB. Without this, kanban.db resolves to
+      # SMB fix for the kanban board DB. Without this, kanban.db resolves to
       # HERMES_HOME (/opt/data, the Azure File Share) and `PRAGMA journal_mode=WAL`
       # fails on SMB as "database is locked", crashing the kanban dispatcher every
-      # tick. Pinning it to /tmp keeps WAL working. Ephemeral (lost on redeploy),
-      # consistent with HERMES_DB_PATH above.
+      # tick. Pinning it to /tmp keeps WAL working. Ephemeral (lost on redeploy).
+      # (Unlike HERMES_DB_PATH above, this one IS read: hermes_cli/kanban_db.py.)
       env {
         name  = "HERMES_KANBAN_DB"
         value = "/tmp/kanban.db"

--- a/infrastructure/modules/container-apps/honcho.tf
+++ b/infrastructure/modules/container-apps/honcho.tf
@@ -98,42 +98,49 @@ resource "azurerm_container_app" "honcho" {
         value = var.app_insights_connection_string
       }
 
-      # Summary: override Google default
+      # Per-specialist model config — Honcho >= 3.0.7 nested MODEL_CONFIG shape.
+      # The pre-3.0.7 flat keys (SUMMARY_PROVIDER, SUMMARY_MODEL, …) were
+      # REMOVED upstream and are silently ignored (pydantic-settings
+      # extra="ignore"): shipping them makes every specialist fall back to
+      # direct-OpenAI gpt-5.4-mini. See services/honcho/README.md; drift here
+      # is caught by CI (scripts/validate_vendored_config.py).
       env {
-        name  = "SUMMARY_PROVIDER"
+        name  = "SUMMARY_MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
 
       env {
-        name  = "SUMMARY_MODEL"
+        name  = "SUMMARY_MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
 
-      # Deriver: override Google default
       env {
-        name  = "DERIVER_PROVIDER"
+        name  = "DERIVER_MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
 
       env {
-        name  = "DERIVER_MODEL"
+        name  = "DERIVER_MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
 
-      # Dialectic: override all 5 levels (required by _validate_all_levels_present).
-      # DialecticSettings uses env_prefix="DIALECTIC_" + env_nested_delimiter="__",
-      # so the correct path is DIALECTIC_LEVELS__<level>__<FIELD>.
-      # The old DIALECTIC_MINIMAL_PROVIDER style is silently ignored by pydantic-settings.
+      # Dialectic: pin all 5 reasoning levels to the same small model. Nested
+      # path is env_prefix DIALECTIC_ + "__" delimiter + the MODEL_CONFIG
+      # sub-model: DIALECTIC_LEVELS__<level>__MODEL_CONFIG__<field>.
+      # MAX_TOOL_ITERATIONS survived 3.0.7 and stays a per-level field (NOT
+      # under MODEL_CONFIG). 3.0.11 fills omitted levels from built-in
+      # defaults (openai/gpt-5.4-mini), so pinning all five keeps the model
+      # choice ours rather than upstream's.
       env {
-        name  = "DIALECTIC_LEVELS__minimal__PROVIDER"
+        name  = "DIALECTIC_LEVELS__minimal__MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
       env {
-        name  = "DIALECTIC_LEVELS__minimal__MODEL"
+        name  = "DIALECTIC_LEVELS__minimal__MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
       env {
-        name  = "DIALECTIC_LEVELS__minimal__THINKING_BUDGET_TOKENS"
+        name  = "DIALECTIC_LEVELS__minimal__MODEL_CONFIG__THINKING_BUDGET_TOKENS"
         value = "0"
       }
       env {
@@ -142,15 +149,15 @@ resource "azurerm_container_app" "honcho" {
       }
 
       env {
-        name  = "DIALECTIC_LEVELS__low__PROVIDER"
+        name  = "DIALECTIC_LEVELS__low__MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
       env {
-        name  = "DIALECTIC_LEVELS__low__MODEL"
+        name  = "DIALECTIC_LEVELS__low__MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
       env {
-        name  = "DIALECTIC_LEVELS__low__THINKING_BUDGET_TOKENS"
+        name  = "DIALECTIC_LEVELS__low__MODEL_CONFIG__THINKING_BUDGET_TOKENS"
         value = "0"
       }
       env {
@@ -159,15 +166,15 @@ resource "azurerm_container_app" "honcho" {
       }
 
       env {
-        name  = "DIALECTIC_LEVELS__medium__PROVIDER"
+        name  = "DIALECTIC_LEVELS__medium__MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
       env {
-        name  = "DIALECTIC_LEVELS__medium__MODEL"
+        name  = "DIALECTIC_LEVELS__medium__MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
       env {
-        name  = "DIALECTIC_LEVELS__medium__THINKING_BUDGET_TOKENS"
+        name  = "DIALECTIC_LEVELS__medium__MODEL_CONFIG__THINKING_BUDGET_TOKENS"
         value = "0"
       }
       env {
@@ -176,15 +183,15 @@ resource "azurerm_container_app" "honcho" {
       }
 
       env {
-        name  = "DIALECTIC_LEVELS__high__PROVIDER"
+        name  = "DIALECTIC_LEVELS__high__MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
       env {
-        name  = "DIALECTIC_LEVELS__high__MODEL"
+        name  = "DIALECTIC_LEVELS__high__MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
       env {
-        name  = "DIALECTIC_LEVELS__high__THINKING_BUDGET_TOKENS"
+        name  = "DIALECTIC_LEVELS__high__MODEL_CONFIG__THINKING_BUDGET_TOKENS"
         value = "0"
       }
       env {
@@ -193,15 +200,15 @@ resource "azurerm_container_app" "honcho" {
       }
 
       env {
-        name  = "DIALECTIC_LEVELS__max__PROVIDER"
+        name  = "DIALECTIC_LEVELS__max__MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
       env {
-        name  = "DIALECTIC_LEVELS__max__MODEL"
+        name  = "DIALECTIC_LEVELS__max__MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
       env {
-        name  = "DIALECTIC_LEVELS__max__THINKING_BUDGET_TOKENS"
+        name  = "DIALECTIC_LEVELS__max__MODEL_CONFIG__THINKING_BUDGET_TOKENS"
         value = "0"
       }
       env {
@@ -336,12 +343,12 @@ resource "azurerm_container_app" "honcho_deriver" {
       }
 
       env {
-        name  = "DERIVER_PROVIDER"
+        name  = "DERIVER_MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
 
       env {
-        name  = "DERIVER_MODEL"
+        name  = "DERIVER_MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
 
@@ -361,27 +368,28 @@ resource "azurerm_container_app" "honcho_deriver" {
 
       # Summary is also used by the deriver worker
       env {
-        name  = "SUMMARY_PROVIDER"
+        name  = "SUMMARY_MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
 
       env {
-        name  = "SUMMARY_MODEL"
+        name  = "SUMMARY_MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
 
-      # Dialectic: all 5 levels must be configured (same fix as API app).
-      # Deriver itself doesn't run Dialectic, but shared config init validates all levels.
+      # Dialectic: same nested MODEL_CONFIG shape as the API app (the flat
+      # pre-3.0.7 keys are removed upstream and silently ignored). Deriver
+      # itself doesn't run Dialectic, but shared config init resolves all levels.
       env {
-        name  = "DIALECTIC_LEVELS__minimal__PROVIDER"
+        name  = "DIALECTIC_LEVELS__minimal__MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
       env {
-        name  = "DIALECTIC_LEVELS__minimal__MODEL"
+        name  = "DIALECTIC_LEVELS__minimal__MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
       env {
-        name  = "DIALECTIC_LEVELS__minimal__THINKING_BUDGET_TOKENS"
+        name  = "DIALECTIC_LEVELS__minimal__MODEL_CONFIG__THINKING_BUDGET_TOKENS"
         value = "0"
       }
       env {
@@ -390,15 +398,15 @@ resource "azurerm_container_app" "honcho_deriver" {
       }
 
       env {
-        name  = "DIALECTIC_LEVELS__low__PROVIDER"
+        name  = "DIALECTIC_LEVELS__low__MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
       env {
-        name  = "DIALECTIC_LEVELS__low__MODEL"
+        name  = "DIALECTIC_LEVELS__low__MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
       env {
-        name  = "DIALECTIC_LEVELS__low__THINKING_BUDGET_TOKENS"
+        name  = "DIALECTIC_LEVELS__low__MODEL_CONFIG__THINKING_BUDGET_TOKENS"
         value = "0"
       }
       env {
@@ -407,15 +415,15 @@ resource "azurerm_container_app" "honcho_deriver" {
       }
 
       env {
-        name  = "DIALECTIC_LEVELS__medium__PROVIDER"
+        name  = "DIALECTIC_LEVELS__medium__MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
       env {
-        name  = "DIALECTIC_LEVELS__medium__MODEL"
+        name  = "DIALECTIC_LEVELS__medium__MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
       env {
-        name  = "DIALECTIC_LEVELS__medium__THINKING_BUDGET_TOKENS"
+        name  = "DIALECTIC_LEVELS__medium__MODEL_CONFIG__THINKING_BUDGET_TOKENS"
         value = "0"
       }
       env {
@@ -424,15 +432,15 @@ resource "azurerm_container_app" "honcho_deriver" {
       }
 
       env {
-        name  = "DIALECTIC_LEVELS__high__PROVIDER"
+        name  = "DIALECTIC_LEVELS__high__MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
       env {
-        name  = "DIALECTIC_LEVELS__high__MODEL"
+        name  = "DIALECTIC_LEVELS__high__MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
       env {
-        name  = "DIALECTIC_LEVELS__high__THINKING_BUDGET_TOKENS"
+        name  = "DIALECTIC_LEVELS__high__MODEL_CONFIG__THINKING_BUDGET_TOKENS"
         value = "0"
       }
       env {
@@ -441,15 +449,15 @@ resource "azurerm_container_app" "honcho_deriver" {
       }
 
       env {
-        name  = "DIALECTIC_LEVELS__max__PROVIDER"
+        name  = "DIALECTIC_LEVELS__max__MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
       env {
-        name  = "DIALECTIC_LEVELS__max__MODEL"
+        name  = "DIALECTIC_LEVELS__max__MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
       env {
-        name  = "DIALECTIC_LEVELS__max__THINKING_BUDGET_TOKENS"
+        name  = "DIALECTIC_LEVELS__max__MODEL_CONFIG__THINKING_BUDGET_TOKENS"
         value = "0"
       }
       env {
@@ -544,11 +552,11 @@ resource "azurerm_container_app_job" "honcho_deriver" {
         value = var.app_insights_connection_string
       }
       env {
-        name  = "DERIVER_PROVIDER"
+        name  = "DERIVER_MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
       env {
-        name  = "DERIVER_MODEL"
+        name  = "DERIVER_MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
       env {
@@ -560,23 +568,23 @@ resource "azurerm_container_app_job" "honcho_deriver" {
         value = "1"
       }
       env {
-        name  = "SUMMARY_PROVIDER"
+        name  = "SUMMARY_MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
       env {
-        name  = "SUMMARY_MODEL"
+        name  = "SUMMARY_MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
       env {
-        name  = "DIALECTIC_LEVELS__minimal__PROVIDER"
+        name  = "DIALECTIC_LEVELS__minimal__MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
       env {
-        name  = "DIALECTIC_LEVELS__minimal__MODEL"
+        name  = "DIALECTIC_LEVELS__minimal__MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
       env {
-        name  = "DIALECTIC_LEVELS__minimal__THINKING_BUDGET_TOKENS"
+        name  = "DIALECTIC_LEVELS__minimal__MODEL_CONFIG__THINKING_BUDGET_TOKENS"
         value = "0"
       }
       env {
@@ -584,15 +592,15 @@ resource "azurerm_container_app_job" "honcho_deriver" {
         value = "1"
       }
       env {
-        name  = "DIALECTIC_LEVELS__low__PROVIDER"
+        name  = "DIALECTIC_LEVELS__low__MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
       env {
-        name  = "DIALECTIC_LEVELS__low__MODEL"
+        name  = "DIALECTIC_LEVELS__low__MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
       env {
-        name  = "DIALECTIC_LEVELS__low__THINKING_BUDGET_TOKENS"
+        name  = "DIALECTIC_LEVELS__low__MODEL_CONFIG__THINKING_BUDGET_TOKENS"
         value = "0"
       }
       env {
@@ -600,15 +608,15 @@ resource "azurerm_container_app_job" "honcho_deriver" {
         value = "5"
       }
       env {
-        name  = "DIALECTIC_LEVELS__medium__PROVIDER"
+        name  = "DIALECTIC_LEVELS__medium__MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
       env {
-        name  = "DIALECTIC_LEVELS__medium__MODEL"
+        name  = "DIALECTIC_LEVELS__medium__MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
       env {
-        name  = "DIALECTIC_LEVELS__medium__THINKING_BUDGET_TOKENS"
+        name  = "DIALECTIC_LEVELS__medium__MODEL_CONFIG__THINKING_BUDGET_TOKENS"
         value = "0"
       }
       env {
@@ -616,15 +624,15 @@ resource "azurerm_container_app_job" "honcho_deriver" {
         value = "2"
       }
       env {
-        name  = "DIALECTIC_LEVELS__high__PROVIDER"
+        name  = "DIALECTIC_LEVELS__high__MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
       env {
-        name  = "DIALECTIC_LEVELS__high__MODEL"
+        name  = "DIALECTIC_LEVELS__high__MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
       env {
-        name  = "DIALECTIC_LEVELS__high__THINKING_BUDGET_TOKENS"
+        name  = "DIALECTIC_LEVELS__high__MODEL_CONFIG__THINKING_BUDGET_TOKENS"
         value = "0"
       }
       env {
@@ -632,15 +640,15 @@ resource "azurerm_container_app_job" "honcho_deriver" {
         value = "4"
       }
       env {
-        name  = "DIALECTIC_LEVELS__max__PROVIDER"
+        name  = "DIALECTIC_LEVELS__max__MODEL_CONFIG__TRANSPORT"
         value = "openai"
       }
       env {
-        name  = "DIALECTIC_LEVELS__max__MODEL"
+        name  = "DIALECTIC_LEVELS__max__MODEL_CONFIG__MODEL"
         value = "gpt-4o-mini"
       }
       env {
-        name  = "DIALECTIC_LEVELS__max__THINKING_BUDGET_TOKENS"
+        name  = "DIALECTIC_LEVELS__max__MODEL_CONFIG__THINKING_BUDGET_TOKENS"
         value = "0"
       }
       env {

--- a/scripts/validate_vendored_config.py
+++ b/scripts/validate_vendored_config.py
@@ -1,0 +1,756 @@
+#!/usr/bin/env python3
+"""Vendored-config schema guard (A3).
+
+Validates every config key AAF ships to a vendored app (compose env blocks,
+Terraform env blocks, the generated Hermes config.yaml) against the schema the
+*pinned vendored source* actually reads. A key the app silently drops — the
+Honcho 3.0.7 flat-key removal, the Hermes config-schema shift — fails CI here
+instead of silently degrading a deployment.
+
+Strategy per app (docs/design/vendored-config-schema-guard.md):
+  * Honcho    — dynamically load the vendored pydantic-settings model
+                (apps/honcho/src/src/config.py) and derive every acceptable
+                env key from it. Exact, zero curation, auto-tracks bumps.
+  * Hermes    — config.yaml keys: AST-parse the vendored parser's
+                DEFAULT_CONFIG tree (no imports); polymorphic sections come
+                from a manifest pinned to the submodule commit (a bump fails
+                loudly until re-validated). Env keys: static consumption scan
+                of the vendored tree + AAF override scripts.
+  * PaperClip — source is not in-tree (cloned at image build), so a curated
+                manifest pinned to PAPERCLIP_VERSION; the pin is cross-checked
+                against the Dockerfile ARG and compose default.
+
+Findings are HARD failures. Suppression happens only through
+scripts/vendored-config/allowlist.yaml, where every entry must carry a
+non-empty reason.
+
+Usage:
+    python scripts/validate_vendored_config.py [--repo PATH]
+    python scripts/validate_vendored_config.py --self-test
+
+Exit codes: 0 = clean, 1 = findings (or self-test failure), 2 = cannot run
+(missing submodule checkout, missing deps).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib.util
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    print("error: PyYAML is required (pip install -r scripts/vendored-config/requirements.txt)")
+    sys.exit(2)
+
+REPO = Path(__file__).resolve().parents[1]
+GUARD_DIR = "scripts/vendored-config"
+
+ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class Finding:
+    app: str  # honcho | hermes | paperclip | guard
+    artifact: str  # repo-relative path (plus locator, e.g. service name)
+    key: str  # offending key / dotted config path
+    message: str
+
+    def __str__(self) -> str:
+        return f"[{self.app}] {self.artifact}: {self.key}\n      {self.message}"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Allowlist
+# ──────────────────────────────────────────────────────────────────────────────
+
+def load_allowlist(repo: Path) -> tuple[set[tuple[str, str]], list[Finding]]:
+    """Return ({(app, KEY_UPPER)}, findings-about-the-allowlist-itself)."""
+    path = repo / GUARD_DIR / "allowlist.yaml"
+    findings: list[Finding] = []
+    entries: set[tuple[str, str]] = set()
+    if not path.exists():
+        return entries, findings
+    data = yaml.safe_load(path.read_text()) or {}
+    for i, entry in enumerate(data.get("allow", []) or []):
+        if not isinstance(entry, dict):
+            findings.append(Finding("guard", f"{GUARD_DIR}/allowlist.yaml", f"entry[{i}]",
+                                    "allowlist entries must be mappings with app/key/reason"))
+            continue
+        app, key, reason = entry.get("app"), entry.get("key"), entry.get("reason")
+        if not app or not key:
+            findings.append(Finding("guard", f"{GUARD_DIR}/allowlist.yaml", f"entry[{i}]",
+                                    "allowlist entry missing 'app' or 'key'"))
+            continue
+        if not isinstance(reason, str) or not reason.strip():
+            findings.append(Finding("guard", f"{GUARD_DIR}/allowlist.yaml", str(key),
+                                    "allowlist entry has no non-empty 'reason' — every "
+                                    "suppression must be an explained, reviewed decision"))
+            continue
+        entries.add((str(app), str(key).upper()))
+    return entries, findings
+
+
+def allowed(allowlist: set[tuple[str, str]], app: str, key: str) -> bool:
+    return (app, key.upper()) in allowlist
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Shipped-artifact parsing (compose env blocks, Terraform env blocks)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def compose_env_keys(compose_path: Path, service: str) -> list[str]:
+    """Explicit `environment:` keys of one compose service (dict or list form)."""
+    doc = yaml.safe_load(compose_path.read_text()) or {}
+    svc = (doc.get("services") or {}).get(service) or {}
+    env = svc.get("environment")
+    if env is None:
+        return []
+    if isinstance(env, dict):
+        return [str(k) for k in env]
+    keys = []
+    for item in env:  # list form: "KEY=value"
+        keys.append(str(item).split("=", 1)[0])
+    return keys
+
+
+_TF_ENV_RE = re.compile(r'env\s*\{[^{}]*?\bname\s*=\s*"([A-Za-z_][A-Za-z0-9_]*)"', re.S)
+_TF_CONTAINER_RE = re.compile(r"\bcontainer\s*\{")
+_TF_NAME_RE = re.compile(r'\bname\s*=\s*"([A-Za-z0-9_-]+)"')
+
+
+def _tf_container_blocks(text: str) -> list[tuple[str, str]]:
+    """(container_name, block_text) for every container{} block (brace-matched)."""
+    blocks: list[tuple[str, str]] = []
+    for match in _TF_CONTAINER_RE.finditer(text):
+        depth = 0
+        start = match.end() - 1  # at the opening brace
+        for i in range(start, len(text)):
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    block = text[start:i + 1]
+                    name = _TF_NAME_RE.search(block)
+                    blocks.append((name.group(1) if name else "", block))
+                    break
+    return blocks
+
+
+def terraform_env_keys(tf_path: Path, containers: list[str] | None = None) -> list[str]:
+    """env{ name = "..." } entries, optionally scoped to named container blocks.
+
+    A Container App template can carry several containers (e.g. the hermes
+    gateway plus its model-router sidecar); each container's env belongs to a
+    different consuming app, so callers scope to the vendored one.
+    """
+    text = tf_path.read_text()
+    if containers is None:
+        return _TF_ENV_RE.findall(text)
+    keys: list[str] = []
+    for name, block in _tf_container_blocks(text):
+        if name in containers:
+            keys += _TF_ENV_RE.findall(block)
+    return keys
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Honcho — dynamic pydantic-settings introspection
+# ──────────────────────────────────────────────────────────────────────────────
+
+def load_honcho_settings_module(repo: Path):
+    cfg = repo / "apps/honcho/src/src/config.py"
+    if not cfg.exists():
+        raise FileNotFoundError(
+            f"{cfg} missing — initialize the honcho submodule (git submodule update --init)")
+    os.environ.setdefault("PYTHON_DOTENV_DISABLED", "1")
+    spec = importlib.util.spec_from_file_location("_aaf_vendored_honcho_config", cfg)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _alias_names(field: Any, default_name: str) -> set[str]:
+    names = {default_name}
+    alias = getattr(field, "validation_alias", None)
+    if isinstance(alias, str):
+        names.add(alias)
+    elif alias is not None and hasattr(alias, "choices"):
+        for c in alias.choices:
+            if isinstance(c, str):
+                names.add(c)
+    return names
+
+
+def _find_model_class(annotation: Any) -> Any:
+    """First pydantic BaseModel subclass reachable in a type annotation."""
+    import typing
+
+    from pydantic import BaseModel
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return annotation
+    for arg in typing.get_args(annotation):
+        found = _find_model_class(arg)
+        if found is not None:
+            return found
+    return None
+
+
+def _dict_field_parts(annotation: Any) -> tuple[list[str] | None, Any] | None:
+    """For dict[...] annotations: (closed key list or None if open, value model or None)."""
+    import typing
+    origin = typing.get_origin(annotation)
+    if origin is not dict:
+        # unwrap Optional/Annotated one level
+        for arg in typing.get_args(annotation):
+            if typing.get_origin(arg) is dict:
+                annotation, origin = arg, dict
+                break
+        else:
+            return None
+    key_t, val_t = typing.get_args(annotation)
+    literal_keys = None
+    if typing.get_origin(key_t) is typing.Literal:
+        literal_keys = [str(a) for a in typing.get_args(key_t)]
+    return literal_keys, _find_model_class(val_t)
+
+
+def _walk_model_env(model_cls: Any, prefix: str, delimiter: str | None,
+                    exact: set[str], patterns: list[re.Pattern[str]], depth: int = 0) -> None:
+    if depth > 6:  # defensive: pydantic models are shallow; avoid cycles
+        return
+    for fname, field in model_cls.model_fields.items():
+        for name in _alias_names(field, fname):
+            exact.add((prefix + name).upper())
+            if not delimiter:
+                continue
+            ann = field.annotation
+            nested = _find_model_class(ann)
+            dict_parts = _dict_field_parts(ann)
+            if dict_parts is not None:
+                literal_keys, val_model = dict_parts
+                base = prefix + name + delimiter
+                if literal_keys is not None and val_model is not None:
+                    for k in literal_keys:
+                        _walk_model_env(val_model, base + k + delimiter, delimiter,
+                                        exact, patterns, depth + 1)
+                else:
+                    # open dict: accept any sub-path (values or nested models)
+                    patterns.append(re.compile(re.escape(base.upper()) + r"[A-Z0-9_]+$"))
+            elif nested is not None:
+                _walk_model_env(nested, prefix + name + delimiter, delimiter,
+                                exact, patterns, depth + 1)
+
+
+def honcho_accepted_env(mod: Any) -> tuple[set[str], list[re.Pattern[str]]]:
+    """Every env key the vendored Honcho AppSettings tree can consume."""
+    from pydantic_settings import BaseSettings
+    exact: set[str] = set()
+    patterns: list[re.Pattern[str]] = []
+    app_cls = type(mod.settings)
+    # 1) AppSettings itself (env_prefix "", delimiter "__")
+    _walk_model_env(app_cls,
+                    app_cls.model_config.get("env_prefix", "") or "",
+                    app_cls.model_config.get("env_nested_delimiter"),
+                    exact, patterns)
+    # 2) each nested settings class with its OWN prefix/delimiter (this is how
+    #    the container is actually configured: SUMMARY_MODEL_CONFIG__MODEL etc.)
+    for field in app_cls.model_fields.values():
+        sub = _find_model_class(field.annotation)
+        if sub is not None and issubclass(sub, BaseSettings):
+            _walk_model_env(sub,
+                            sub.model_config.get("env_prefix", "") or "",
+                            sub.model_config.get("env_nested_delimiter"),
+                            exact, patterns)
+    return exact, patterns
+
+
+# Known-removed keys (Honcho 3.0.7, upstream #459) — upgrades the diagnostic
+# from "unknown key" to a migration hint. Detection never depends on this map.
+_HONCHO_REMOVED: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"^SUMMARY_PROVIDER$"), "SUMMARY_MODEL_CONFIG__TRANSPORT"),
+    (re.compile(r"^SUMMARY_MODEL$"), "SUMMARY_MODEL_CONFIG__MODEL"),
+    (re.compile(r"^DERIVER_PROVIDER$"), "DERIVER_MODEL_CONFIG__TRANSPORT"),
+    (re.compile(r"^DERIVER_MODEL$"), "DERIVER_MODEL_CONFIG__MODEL"),
+    (re.compile(r"^DIALECTIC_LEVELS__([A-Z]+)__PROVIDER$"),
+     "DIALECTIC_LEVELS__<level>__MODEL_CONFIG__TRANSPORT"),
+    (re.compile(r"^DIALECTIC_LEVELS__([A-Z]+)__MODEL$"),
+     "DIALECTIC_LEVELS__<level>__MODEL_CONFIG__MODEL"),
+    (re.compile(r"^DIALECTIC_LEVELS__([A-Z]+)__THINKING_BUDGET_TOKENS$"),
+     "DIALECTIC_LEVELS__<level>__MODEL_CONFIG__THINKING_BUDGET_TOKENS"),
+]
+
+
+def check_env_keys(app: str, artifact: str, keys: list[str],
+                   exact: set[str], patterns: list[re.Pattern[str]],
+                   allowlist: set[tuple[str, str]],
+                   removed_map: list[tuple[re.Pattern[str], str]] | None = None) -> list[Finding]:
+    findings: list[Finding] = []
+    for key in keys:
+        k = key.upper()
+        if k in exact or any(p.match(k) for p in patterns):
+            continue
+        if allowed(allowlist, app, k):
+            continue
+        hint = None
+        for pat, replacement in removed_map or []:
+            if pat.match(k):
+                hint = replacement
+                break
+        if hint:
+            msg = (f"REMOVED key — the pinned vendored {app} no longer reads it and "
+                   f"silently ignores it (extra='ignore'). Replace with {hint}.")
+        else:
+            msg = (f"unknown key — the pinned vendored {app} does not read it; it will be "
+                   f"silently dropped. Fix the key, or allowlist it in "
+                   f"{GUARD_DIR}/allowlist.yaml with a reason.")
+        findings.append(Finding(app, artifact, key, msg))
+    return findings
+
+
+def validate_honcho(repo: Path, allowlist: set[tuple[str, str]]) -> list[Finding]:
+    mod = load_honcho_settings_module(repo)
+    exact, patterns = honcho_accepted_env(mod)
+    findings: list[Finding] = []
+    targets = [
+        ("docker-compose.yml (service: honcho)",
+         compose_env_keys(repo / "docker-compose.yml", "honcho")),
+        ("deploy/mac-site/docker-compose.yml (service: honcho)",
+         compose_env_keys(repo / "deploy/mac-site/docker-compose.yml", "honcho")),
+        ("infrastructure/modules/container-apps/honcho.tf",
+         terraform_env_keys(repo / "infrastructure/modules/container-apps/honcho.tf")),
+    ]
+    for artifact, keys in targets:
+        findings += check_env_keys("honcho", artifact, keys, exact, patterns,
+                                   allowlist, _HONCHO_REMOVED)
+    return findings
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Hermes — static AST parse of the vendored config parser
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _ast_key_tree(node: ast.expr) -> dict[str, Any] | None:
+    """Key tree of a dict literal: {key: subtree-or-None}. Non-dict → None."""
+    if not isinstance(node, ast.Dict):
+        return None
+    out: dict[str, Any] = {}
+    for k, v in zip(node.keys, node.values):
+        if isinstance(k, ast.Constant) and isinstance(k.value, str):
+            out[k.value] = _ast_key_tree(v)
+    return out
+
+
+def _ast_string_elements(node: ast.expr) -> set[str]:
+    """String constants that are set elements / dict keys of a literal expr."""
+    out: set[str] = set()
+    if isinstance(node, ast.Call):  # frozenset({...})
+        for arg in node.args:
+            out |= _ast_string_elements(arg)
+    elif isinstance(node, ast.Set):
+        for el in node.elts:
+            if isinstance(el, ast.Constant) and isinstance(el.value, str):
+                out.add(el.value)
+    elif isinstance(node, ast.Dict):
+        for k in node.keys:
+            if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                out.add(k.value)
+    return out
+
+
+def parse_hermes_config_source(repo: Path) -> dict[str, Any]:
+    """AST-extract DEFAULT_CONFIG tree, _KNOWN_ROOT_KEYS and env-key tables."""
+    src_path = repo / "apps/hermes/src/hermes_cli/config.py"
+    if not src_path.exists():
+        raise FileNotFoundError(
+            f"{src_path} missing — initialize the hermes submodule (git submodule update --init)")
+    tree = ast.parse(src_path.read_text())
+    result: dict[str, Any] = {"default_config": {}, "known_root_keys": set(), "env_tables": set()}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if not isinstance(target, ast.Name):
+                continue
+            if target.id == "DEFAULT_CONFIG":
+                result["default_config"] = _ast_key_tree(node.value) or {}
+            elif target.id == "_KNOWN_ROOT_KEYS":
+                result["known_root_keys"] = _ast_string_elements(node.value)
+            elif target.id in ("_EXTRA_ENV_KEYS", "OPTIONAL_ENV_VARS", "REQUIRED_ENV_VARS"):
+                result["env_tables"] |= _ast_string_elements(node.value)
+    if not result["default_config"]:
+        raise RuntimeError("could not locate DEFAULT_CONFIG in vendored hermes_cli/config.py "
+                           "— upstream restructured; the guard needs updating")
+    return result
+
+
+def gitlink_sha(repo: Path, submodule_path: str) -> str | None:
+    """Pinned submodule commit from the superproject tree (no checkout needed)."""
+    try:
+        out = subprocess.run(["git", "ls-tree", "HEAD", submodule_path],
+                             cwd=repo, capture_output=True, text=True, check=True).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    m = re.search(r"^160000 commit ([0-9a-f]{40})\t", out, re.M)
+    return m.group(1) if m else None
+
+
+def load_manifest(repo: Path, name: str) -> dict[str, Any]:
+    path = repo / GUARD_DIR / name
+    if not path.exists():
+        raise FileNotFoundError(f"{path} missing")
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def hermes_config_generators(repo: Path, marker: str = "HERMES_EOF") -> list[Path]:
+    """Every shipped shell script that generates a Hermes config.yaml heredoc.
+
+    Discovered, not hardcoded: A1 moved the generation from the entrypoint
+    into write-hermes-config.sh mid-flight — hardcoded paths would validate
+    a file that no longer generates anything while the real generator drifts
+    unchecked."""
+    found: list[Path] = []
+    for d in ("apps/paperclip", "services/paperclip"):
+        for sh in sorted((repo / d).glob("*.sh")):
+            if f"<<{marker}" in sh.read_text(errors="ignore"):
+                found.append(sh)
+    return found
+
+
+def extract_heredoc_yaml(script_path: Path, marker: str = "HERMES_EOF") -> dict[str, Any]:
+    """Parse the config.yaml generated by an entrypoint heredoc."""
+    lines = script_path.read_text().splitlines()
+    collecting = False
+    collected: list[str] = []
+    for line in lines:
+        if not collecting and f"<<{marker}" in line:
+            collecting = True
+            continue
+        if collecting:
+            if line.strip() == marker:
+                break
+            collected.append(line)
+    body = "\n".join(collected)
+    body = re.sub(r"\$\{[^}]*\}", "placeholder", body)  # neutralize shell expansions
+    body = re.sub(r"\$\([^)]*\)", "placeholder", body)
+    return yaml.safe_load(body) or {}
+
+
+def _check_yaml_paths(app: str, artifact: str, node: dict[str, Any],
+                      accepted: dict[str, Any] | None, poly: dict[str, Any],
+                      known_root: set[str], allowlist: set[tuple[str, str]],
+                      path: tuple[str, ...] = ()) -> list[Finding]:
+    findings: list[Finding] = []
+    for key, value in node.items():
+        dotted = ".".join(path + (str(key),))
+        sub_accepted = None
+        ok = False
+        if accepted is not None and key in accepted:
+            ok = True
+            sub_accepted = accepted[key]
+        elif not path and key in known_root:
+            ok = True
+        # polymorphic manifest sections (e.g. `model:` whose vendored default
+        # is a scalar so the AST tree can't see its dict-form keys)
+        poly_here = poly.get(".".join(path)) if path else None
+        if not ok and path and poly_here and key in poly_here:
+            ok = True
+        if not ok and allowed(allowlist, app, dotted):
+            ok = True
+        if not ok:
+            findings.append(Finding(
+                app, artifact, dotted,
+                "unknown config.yaml key — the pinned vendored hermes parser does not "
+                "read it; it will be silently ignored. Fix the key, update "
+                f"{GUARD_DIR}/manifest-hermes.yaml (if the runtime reads it outside "
+                f"DEFAULT_CONFIG), or allowlist it with a reason."))
+            continue
+        if isinstance(value, dict):
+            findings += _check_yaml_paths(app, artifact, value, sub_accepted, poly,
+                                          known_root, allowlist, path + (str(key),))
+    return findings
+
+
+def validate_hermes_yaml(repo: Path, allowlist: set[tuple[str, str]]) -> list[Finding]:
+    findings: list[Finding] = []
+    manifest = load_manifest(repo, "manifest-hermes.yaml")
+    pinned = str(manifest.get("pinned_commit", ""))
+    actual = gitlink_sha(repo, "apps/hermes/src")
+    if actual and pinned != actual:
+        findings.append(Finding(
+            "hermes", f"{GUARD_DIR}/manifest-hermes.yaml", "pinned_commit",
+            f"manifest pinned to {pinned[:12]} but the hermes submodule gitlink is "
+            f"{actual[:12]} — vendor bump detected. Re-validate the polymorphic "
+            f"sections against the new source, then update pinned_commit. "
+            f"(Failing loudly here is the point: nothing re-checked the schema yet.)"))
+    parsed = parse_hermes_config_source(repo)
+    poly = {section: set(keys or [])
+            for section, keys in (manifest.get("polymorphic_sections") or {}).items()}
+    generators = hermes_config_generators(repo)
+    if not generators:
+        findings.append(Finding(
+            "hermes", "apps/paperclip + services/paperclip", "<config.yaml heredoc>",
+            "no shipped script generates a Hermes config.yaml (HERMES_EOF heredoc) "
+            "anymore — either the generation moved somewhere this guard doesn't "
+            "scan (update hermes_config_generators), or the container now boots "
+            "Hermes on pure defaults, which is its own silent-config incident."))
+    for script in generators:
+        rel = str(script.relative_to(repo))
+        cfg = extract_heredoc_yaml(script)
+        if not cfg:
+            findings.append(Finding("hermes", rel, "<config.yaml heredoc>",
+                                    "HERMES_EOF heredoc present but no config keys could "
+                                    "be extracted — guard needs updating"))
+            continue
+        findings += _check_yaml_paths("hermes", f"{rel} (generated config.yaml)",
+                                      cfg, parsed["default_config"], poly,
+                                      parsed["known_root_keys"], allowlist)
+    return findings
+
+
+_ENV_READ_PATTERNS = [
+    re.compile(r"""\bos\.getenv\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']"""),
+    re.compile(r"""\bgetenv\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']"""),
+    re.compile(r"""\bos\.environ\.get\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']"""),
+    re.compile(r"""\bos\.environ\[\s*["']([A-Za-z_][A-Za-z0-9_]*)["']\s*\]"""),
+    re.compile(r"""\benviron\.setdefault\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']"""),
+]
+_SHELL_VAR_RE = re.compile(r"\$\{?([A-Za-z_][A-Za-z0-9_]*)")
+_MJS_ENV_RE = [
+    re.compile(r"process\.env\.([A-Za-z_][A-Za-z0-9_]*)"),
+    re.compile(r"""process\.env\[\s*["']([A-Za-z_][A-Za-z0-9_]*)["']\s*\]"""),
+]
+
+
+def scan_env_reads_py(root: Path) -> set[str]:
+    out: set[str] = set()
+    for py in root.rglob("*.py"):
+        if "node_modules" in py.parts:
+            continue
+        try:
+            text = py.read_text(errors="ignore")
+        except OSError:
+            continue
+        for pat in _ENV_READ_PATTERNS:
+            out.update(m.upper() for m in pat.findall(text))
+    return out
+
+
+def scan_env_reads_sh(root: Path) -> set[str]:
+    out: set[str] = set()
+    for sh in root.rglob("*.sh"):
+        out.update(m.upper() for m in _SHELL_VAR_RE.findall(sh.read_text(errors="ignore")))
+    return out
+
+
+def scan_env_reads_mjs(root: Path) -> set[str]:
+    out: set[str] = set()
+    for mjs in root.rglob("*.mjs"):
+        text = mjs.read_text(errors="ignore")
+        for pat in _MJS_ENV_RE:
+            out.update(m.upper() for m in pat.findall(text))
+    return out
+
+
+def hermes_env_universe(repo: Path) -> set[str]:
+    """Env keys the vendored hermes tree (or bundled AAF override scripts) reads."""
+    universe = scan_env_reads_py(repo / "apps/hermes/src")
+    universe |= {k.upper() for k in parse_hermes_config_source(repo)["env_tables"]}
+    universe |= scan_env_reads_sh(repo / "apps/hermes/overrides")
+    return universe
+
+
+def validate_hermes_env(repo: Path, allowlist: set[tuple[str, str]]) -> list[Finding]:
+    # Only the "hermes" container — its sidecars (model-router) are AAF-authored
+    # apps with their own in-repo config surface, outside this guard's scope.
+    # The hermes gateway image is built from services/agent-runtime/, whose
+    # entrypoint consumes additional env (OPENAI_MODEL, ...) — include its reads.
+    universe = hermes_env_universe(repo) | scan_env_reads_sh(repo / "services/agent-runtime")
+    keys = terraform_env_keys(repo / "infrastructure/modules/container-apps/hermes.tf",
+                              containers=["hermes"])
+    return check_env_keys("hermes",
+                          "infrastructure/modules/container-apps/hermes.tf (container: hermes)",
+                          keys, universe, [], allowlist)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# PaperClip — curated per-version manifest
+# ──────────────────────────────────────────────────────────────────────────────
+
+def paperclip_pinned_versions(repo: Path) -> dict[str, str]:
+    """PAPERCLIP_VERSION defaults from the Dockerfile ARG and compose."""
+    versions: dict[str, str] = {}
+    docker = (repo / "services/paperclip/Dockerfile").read_text()
+    m = re.search(r"^ARG PAPERCLIP_VERSION=(\S+)", docker, re.M)
+    if m:
+        versions["services/paperclip/Dockerfile"] = m.group(1)
+    compose = (repo / "docker-compose.yml").read_text()
+    m = re.search(r"PAPERCLIP_VERSION:\s*\$\{PAPERCLIP_VERSION:-([^}]+)\}", compose)
+    if m:
+        versions["docker-compose.yml"] = m.group(1)
+    return versions
+
+
+def validate_paperclip(repo: Path, allowlist: set[tuple[str, str]]) -> list[Finding]:
+    findings: list[Finding] = []
+    manifest = load_manifest(repo, "manifest-paperclip.yaml")
+    pinned = str(manifest.get("pinned_version", ""))
+    for source, version in paperclip_pinned_versions(repo).items():
+        if version != pinned:
+            findings.append(Finding(
+                "paperclip", f"{GUARD_DIR}/manifest-paperclip.yaml", "pinned_version",
+                f"manifest curated against {pinned!r} but {source} pins {version!r} — "
+                f"vendor bump detected. Re-validate accepted_env against the new "
+                f"release, then update pinned_version."))
+    accepted = {str(e["key"]).upper()
+                for e in (manifest.get("accepted_env") or []) if isinstance(e, dict) and "key" in e}
+    # The paperclip container also runs the vendored Hermes CLI (the adapter
+    # spawns it per task) plus AAF-authored entrypoint/auth-proxy/patch scripts,
+    # so env any of those read is valid here too — all derived from source;
+    # the curated manifest only carries keys the (not-in-tree) upstream reads.
+    accepted |= hermes_env_universe(repo)
+    accepted |= scan_env_reads_mjs(repo / "apps/paperclip")
+    accepted |= scan_env_reads_sh(repo / "apps/paperclip")
+    accepted |= scan_env_reads_sh(repo / "services/paperclip")
+    targets = [
+        ("docker-compose.yml (service: paperclip)",
+         compose_env_keys(repo / "docker-compose.yml", "paperclip")),
+        ("deploy/mac-site/docker-compose.yml (service: paperclip)",
+         compose_env_keys(repo / "deploy/mac-site/docker-compose.yml", "paperclip")),
+        ("infrastructure/modules/container-apps/paperclip.tf (container: paperclip)",
+         terraform_env_keys(repo / "infrastructure/modules/container-apps/paperclip.tf",
+                            containers=["paperclip"])),
+    ]
+    for artifact, keys in targets:
+        findings += check_env_keys("paperclip", artifact, keys, accepted, [], allowlist)
+    return findings
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Orchestration
+# ──────────────────────────────────────────────────────────────────────────────
+
+def validate_all(repo: Path) -> list[Finding]:
+    allowlist, findings = load_allowlist(repo)
+    findings += validate_honcho(repo, allowlist)
+    findings += validate_hermes_yaml(repo, allowlist)
+    findings += validate_hermes_env(repo, allowlist)
+    findings += validate_paperclip(repo, allowlist)
+    return findings
+
+
+def self_test(repo: Path) -> int:
+    """Prove the guard can FAIL: seed known-bad keys, assert each is detected."""
+    failures: list[str] = []
+
+    def expect(name: str, findings: list[Finding], key: str) -> None:
+        if not any(f.key.upper() == key.upper() for f in findings):
+            failures.append(f"self-test '{name}': seeded bad key {key} was NOT detected")
+
+    # 1) Honcho: removed flat key + unknown key must both be flagged; valid must pass
+    mod = load_honcho_settings_module(repo)
+    exact, patterns = honcho_accepted_env(mod)
+    f = check_env_keys("honcho", "<self-test>", ["SUMMARY_PROVIDER"], exact, patterns,
+                       set(), _HONCHO_REMOVED)
+    expect("honcho removed key", f, "SUMMARY_PROVIDER")
+    if f and "REMOVED" not in f[0].message:
+        failures.append("self-test 'honcho removed key': missing migration hint")
+    expect("honcho unknown key",
+           check_env_keys("honcho", "<self-test>", ["HONCHO_TYPO_KEY"], exact, patterns, set()),
+           "HONCHO_TYPO_KEY")
+    expect("honcho typo'd dialectic level",
+           check_env_keys("honcho", "<self-test>",
+                          ["DIALECTIC_LEVELS__HGIH__MODEL_CONFIG__MODEL"], exact, patterns, set()),
+           "DIALECTIC_LEVELS__HGIH__MODEL_CONFIG__MODEL")
+    good = ["DB_CONNECTION_URI", "LLM_OPENAI_API_KEY", "SUMMARY_MODEL_CONFIG__TRANSPORT",
+            "DIALECTIC_LEVELS__minimal__MODEL_CONFIG__MODEL",
+            "DERIVER_MODEL_CONFIG__OVERRIDES__BASE_URL", "LOG_LEVEL"]
+    leftover = check_env_keys("honcho", "<self-test>", good, exact, patterns, set())
+    if leftover:
+        failures.append(f"self-test 'honcho valid keys': false positives: "
+                        f"{[x.key for x in leftover]}")
+
+    # 2) Hermes yaml: typo'd root key must be flagged; the real generated config must pass
+    parsed = parse_hermes_config_source(repo)
+    manifest = load_manifest(repo, "manifest-hermes.yaml")
+    poly = {s: set(k or []) for s, k in (manifest.get("polymorphic_sections") or {}).items()}
+    bad_cfg = {"prompt_cachng": {"cache_ttl": "1h"},  # seeded typo
+               "model": {"provider": "custom", "baseurl": "x"}}  # seeded bad subkey
+    f = _check_yaml_paths("hermes", "<self-test>", bad_cfg, parsed["default_config"], poly,
+                          parsed["known_root_keys"], set())
+    expect("hermes typo root key", f, "prompt_cachng")
+    expect("hermes typo model subkey", f, "model.baseurl")
+    good_cfg = {"model": {"provider": "custom", "base_url": "x", "api_mode": "anthropic_messages"},
+                "prompt_caching": {"cache_ttl": "1h"}}
+    leftover = _check_yaml_paths("hermes", "<self-test>", good_cfg, parsed["default_config"],
+                                 poly, parsed["known_root_keys"], set())
+    if leftover:
+        failures.append(f"self-test 'hermes valid config': false positives: "
+                        f"{[x.key for x in leftover]}")
+
+    # 3) PaperClip: a version-pin mismatch and an unknown env key must be flagged
+    pc_manifest = load_manifest(repo, "manifest-paperclip.yaml")
+    if str(pc_manifest.get("pinned_version")) == "v0.0.0-selftest":
+        failures.append("self-test 'paperclip pin': manifest unexpectedly pinned to sentinel")
+    accepted = {str(e["key"]).upper() for e in (pc_manifest.get("accepted_env") or [])}
+    expect("paperclip unknown key",
+           check_env_keys("paperclip", "<self-test>", ["PAPERCLIP_TYPO_KEY"], accepted, [], set()),
+           "PAPERCLIP_TYPO_KEY")
+
+    # 4) Allowlist: an allowlisted key must pass; a reason-less entry must fail
+    f = check_env_keys("honcho", "<self-test>", ["HONCHO_TYPO_KEY"], exact, patterns,
+                       {("honcho", "HONCHO_TYPO_KEY")})
+    if f:
+        failures.append("self-test 'allowlist suppression': allowlisted key still flagged")
+
+    if failures:
+        print("SELF-TEST FAILED — the guard cannot be trusted to detect drift:")
+        for msg in failures:
+            print(f"  ✗ {msg}")
+        return 1
+    print("self-test OK: seeded removed/unknown/typo'd keys all detected; "
+          "valid keys and allowlisted keys pass")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=REPO)
+    parser.add_argument("--self-test", action="store_true",
+                        help="seed known-bad keys and assert the guard detects them")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test(args.repo)
+
+    try:
+        findings = validate_all(args.repo)
+    except FileNotFoundError as exc:
+        print(f"error: {exc}")
+        return 2
+
+    if findings:
+        print(f"vendored-config schema guard: {len(findings)} finding(s)\n")
+        for f in findings:
+            print(f"  ✗ {f}\n")
+        print("Every key above is shipped by this repo but not read by the pinned "
+              "vendored source — the exact class of silent degradation this guard "
+              "exists to catch. See docs/design/vendored-config-schema-guard.md.")
+        return 1
+    print("vendored-config schema guard: clean — every shipped key is read by the "
+          "pinned vendored source (or explicitly allowlisted with a reason)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/vendored-config/allowlist.yaml
+++ b/scripts/vendored-config/allowlist.yaml
@@ -1,0 +1,36 @@
+# Vendored-config schema guard — allowlist (A3).
+#
+# Suppressions for keys the guard flags that are legitimately shipped anyway.
+# EVERY entry requires a non-empty `reason` — the guard fails on reason-less
+# entries. An entry here is a reviewed decision with git history; if you are
+# tempted to add one to silence a finding, first check whether the finding is
+# the incident (a key the vendored app really no longer reads).
+allow:
+  # ── Platform env consumed by the container runtime / SDKs, not by the
+  #    vendored app's own config surface ─────────────────────────────────────
+  - app: honcho
+    key: AZURE_CLIENT_ID
+    reason: consumed by azure-identity (user-assigned managed identity selection), not by Honcho's settings model
+  - app: honcho
+    key: APPLICATIONINSIGHTS_CONNECTION_STRING
+    reason: consumed by the Application Insights exporter/agent, not by Honcho's settings model
+  - app: hermes
+    key: AZURE_CLIENT_ID
+    reason: consumed by azure-identity (user-assigned managed identity selection), not by Hermes
+  - app: hermes
+    key: APPLICATIONINSIGHTS_CONNECTION_STRING
+    reason: consumed by the Application Insights exporter/agent, not by Hermes
+  - app: paperclip
+    key: AZURE_CLIENT_ID
+    reason: consumed by azure-identity (user-assigned managed identity selection), not by PaperClip
+  - app: paperclip
+    key: APPLICATIONINSIGHTS_CONNECTION_STRING
+    reason: consumed by the Application Insights exporter/agent, not by PaperClip
+
+  # ── Env consumed by a non-Python binary the scanners cannot see ───────────
+  - app: hermes
+    key: GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE
+    reason: read by the external gws CLI binary the google-workspace skill shells out to (the skill's google_api.py propagates it into the subprocess env); not an os.getenv read the scanner can detect
+  - app: paperclip
+    key: GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE
+    reason: same gws CLI binary, bundled in the paperclip image for Hermes skills

--- a/scripts/vendored-config/manifest-hermes.yaml
+++ b/scripts/vendored-config/manifest-hermes.yaml
@@ -1,0 +1,33 @@
+# Vendored-config schema guard — Hermes manifest (A3).
+#
+# The guard derives the accepted config.yaml key tree by AST-parsing the
+# vendored parser (apps/hermes/src/hermes_cli/config.py: DEFAULT_CONFIG +
+# _KNOWN_ROOT_KEYS). This manifest only covers what that parse CANNOT see:
+# sections whose vendored default is a scalar (polymorphic), where the dict
+# form's accepted subkeys exist only as scattered runtime reads.
+#
+# pinned_commit MUST equal the apps/hermes/src submodule gitlink. On a vendor
+# bump the guard fails until someone re-validates the sections below against
+# the new source and updates this pin — deliberately loud, that's the guard's
+# whole point. Re-validate with:
+#   git -C apps/hermes/src grep -n 'model_cfg.get\|_model_cfg.get'
+pinned_commit: a91a57fa5a13d516c38b07a141a9ce8a3daabeb0  # v2026.5.16 (v0.14.0)
+
+polymorphic_sections:
+  # DEFAULT_CONFIG has `model: ""` (string), but the runtime equally accepts a
+  # dict form. Accepted subkeys, curated from the pinned source:
+  #   hermes_cli/runtime_provider.py (resolve_requested_provider,
+  #   _get_model_config consumers), hermes_cli/config.py
+  #   (get_custom_provider_context_length), run_agent.py (_model_cfg reads).
+  model:
+    - provider
+    - model
+    - default
+    - base_url
+    - api_key
+    - api_mode
+    - max_tokens
+    - context_length
+    - ollama_num_ctx
+    - name
+    - openai_runtime

--- a/scripts/vendored-config/manifest-paperclip.yaml
+++ b/scripts/vendored-config/manifest-paperclip.yaml
@@ -1,0 +1,33 @@
+# Vendored-config schema guard — PaperClip manifest (A3).
+#
+# PaperClip source is NOT in-tree (services/paperclip/Dockerfile clones the
+# pinned release tag at image build), so its env surface cannot be derived by
+# parsing — this curated manifest carries ONLY the keys the upstream server /
+# agent runtime consume. Keys read by in-tree code (the AAF entrypoint,
+# auth-proxy.mjs, the adapter patches, and the vendored Hermes CLI bundled in
+# the same image) are derived by scanning that source and must NOT be listed
+# here.
+#
+# pinned_version MUST equal the PAPERCLIP_VERSION default in BOTH
+# services/paperclip/Dockerfile (ARG) and docker-compose.yml. On a version
+# bump the guard fails until someone re-validates this list against the new
+# release and updates the pin — deliberately loud.
+pinned_version: v2026.707.0
+
+accepted_env:
+  - key: DATABASE_URL
+    consumer: upstream server — Postgres connection (drizzle)
+  - key: HOST
+    consumer: upstream server — bind address
+  - key: SERVE_UI
+    consumer: upstream server — serve the built UI from the server process
+  - key: BETTER_AUTH_SECRET
+    consumer: upstream server — better-auth signing secret
+  - key: BETTER_AUTH_URL
+    consumer: upstream server — better-auth base URL
+  - key: PAPERCLIP_AGENT_JWT_SECRET
+    consumer: upstream server — agent-JWT mint/validation secret
+  - key: PAPERCLIP_API_URL
+    consumer: upstream agent runtime — API base URL for in-container agents
+  - key: LOG_LEVEL
+    consumer: upstream server — logger level

--- a/scripts/vendored-config/requirements.txt
+++ b/scripts/vendored-config/requirements.txt
@@ -1,0 +1,7 @@
+# Deps for scripts/validate_vendored_config.py (A3 vendored-config schema guard).
+# pydantic + pydantic-settings are needed to LOAD the vendored Honcho settings
+# model (apps/honcho/src/src/config.py); python-dotenv is imported by it.
+PyYAML>=6.0
+pydantic>=2.7
+pydantic-settings>=2.3
+python-dotenv>=1.0

--- a/tests/vendored-config/test_validator.py
+++ b/tests/vendored-config/test_validator.py
@@ -1,0 +1,267 @@
+"""A3 — vendored-config schema guard unit tests.
+
+Prove the guard DETECTS the incident class (removed/unknown keys shipped to a
+vendored app), that legitimate suppression paths work (allowlist with a
+mandatory reason), that vendor bumps fail loudly (manifest pin drift), and
+that the current repo state is clean.
+
+Requires the vendored submodules (apps/honcho/src, apps/hermes/src) checked
+out plus pydantic-settings — exactly what the validate-vendored-config CI job
+provides; tests that need more skip gracefully elsewhere (e.g. the generic
+`python` CI job never collects this directory).
+See docs/design/vendored-config-schema-guard.md.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "scripts"))
+os.environ.setdefault("PYTHON_DOTENV_DISABLED", "1")
+
+import validate_vendored_config as guard  # noqa: E402
+
+HONCHO_AVAILABLE = (REPO / "apps/honcho/src/src/config.py").exists()
+HERMES_AVAILABLE = (REPO / "apps/hermes/src/hermes_cli/config.py").exists()
+
+needs_honcho = pytest.mark.skipif(not HONCHO_AVAILABLE, reason="honcho submodule not checked out")
+needs_hermes = pytest.mark.skipif(not HERMES_AVAILABLE, reason="hermes submodule not checked out")
+
+
+# ── Honcho: dynamic pydantic universe ────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def honcho_universe():
+    if not HONCHO_AVAILABLE:
+        pytest.skip("honcho submodule not checked out")
+    mod = guard.load_honcho_settings_module(REPO)
+    return guard.honcho_accepted_env(mod)
+
+
+@needs_honcho
+def test_honcho_removed_flat_key_detected_with_migration_hint(honcho_universe):
+    """The exact Honcho 3.0.7 incident: a removed flat key must be flagged,
+    and the message must carry the nested MODEL_CONFIG replacement."""
+    exact, patterns = honcho_universe
+    findings = guard.check_env_keys("honcho", "<fixture>", ["SUMMARY_PROVIDER"],
+                                    exact, patterns, set(), guard._HONCHO_REMOVED)
+    assert len(findings) == 1
+    assert "REMOVED" in findings[0].message
+    assert "SUMMARY_MODEL_CONFIG__TRANSPORT" in findings[0].message
+
+
+@needs_honcho
+def test_honcho_removed_dialectic_level_keys_detected(honcho_universe):
+    exact, patterns = honcho_universe
+    shipped = ["DIALECTIC_LEVELS__minimal__PROVIDER",
+               "DIALECTIC_LEVELS__max__MODEL",
+               "DIALECTIC_LEVELS__high__THINKING_BUDGET_TOKENS"]
+    findings = guard.check_env_keys("honcho", "<fixture>", shipped,
+                                    exact, patterns, set(), guard._HONCHO_REMOVED)
+    assert {f.key for f in findings} == set(shipped)
+    assert all("MODEL_CONFIG" in f.message for f in findings)
+
+
+@needs_honcho
+def test_honcho_unknown_key_detected(honcho_universe):
+    exact, patterns = honcho_universe
+    findings = guard.check_env_keys("honcho", "<fixture>", ["HONCHO_TYPO_KEY"],
+                                    exact, patterns, set())
+    assert [f.key for f in findings] == ["HONCHO_TYPO_KEY"]
+    assert "unknown key" in findings[0].message
+
+
+@needs_honcho
+def test_honcho_typoed_dialectic_level_name_detected(honcho_universe):
+    """dict[Literal[...]] closes the level-name set: a typo'd level would
+    silently CREATE a new level upstream — must be flagged."""
+    exact, patterns = honcho_universe
+    findings = guard.check_env_keys(
+        "honcho", "<fixture>", ["DIALECTIC_LEVELS__hgih__MODEL_CONFIG__MODEL"],
+        exact, patterns, set())
+    assert len(findings) == 1
+
+
+@needs_honcho
+def test_honcho_valid_keys_pass(honcho_universe):
+    """Every key shape the repo actually ships (nested MODEL_CONFIG paths,
+    per-section prefixes, OVERRIDES sub-model, case-insensitive levels)."""
+    exact, patterns = honcho_universe
+    good = [
+        "DB_CONNECTION_URI",
+        "LLM_OPENAI_API_KEY", "LLM_ANTHROPIC_API_KEY", "LLM_GEMINI_API_KEY",
+        "LOG_LEVEL",
+        "SUMMARY_MODEL_CONFIG__TRANSPORT", "SUMMARY_MODEL_CONFIG__MODEL",
+        "DERIVER_MODEL_CONFIG__TRANSPORT", "DERIVER_MODEL_CONFIG__MODEL",
+        "DERIVER_FLUSH_ENABLED", "DERIVER_STALE_SESSION_TIMEOUT_MINUTES",
+        "DERIVER_MODEL_CONFIG__OVERRIDES__BASE_URL",
+        "DIALECTIC_LEVELS__minimal__MODEL_CONFIG__TRANSPORT",
+        "DIALECTIC_LEVELS__max__MODEL_CONFIG__THINKING_BUDGET_TOKENS",
+        "DIALECTIC_LEVELS__low__MAX_TOOL_ITERATIONS",
+    ]
+    findings = guard.check_env_keys("honcho", "<fixture>", good, exact, patterns, set())
+    assert findings == [], [f.key for f in findings]
+
+
+@needs_honcho
+def test_honcho_allowlisted_key_passes(honcho_universe):
+    exact, patterns = honcho_universe
+    findings = guard.check_env_keys("honcho", "<fixture>", ["AZURE_CLIENT_ID"],
+                                    exact, patterns, {("honcho", "AZURE_CLIENT_ID")})
+    assert findings == []
+
+
+# ── Allowlist hygiene ────────────────────────────────────────────────────────
+
+def test_allowlist_entry_without_reason_is_a_finding(tmp_path, monkeypatch):
+    bad = {"allow": [{"app": "honcho", "key": "WHATEVER"}]}
+    (tmp_path / "scripts" / "vendored-config").mkdir(parents=True)
+    (tmp_path / "scripts" / "vendored-config" / "allowlist.yaml").write_text(yaml.dump(bad))
+    entries, findings = guard.load_allowlist(tmp_path)
+    assert entries == set()
+    assert len(findings) == 1
+    assert "reason" in findings[0].message
+
+
+def test_repo_allowlist_all_entries_have_reasons():
+    entries, findings = guard.load_allowlist(REPO)
+    assert findings == [], [str(f) for f in findings]
+    assert entries  # the platform-env entries exist
+
+
+# ── Hermes config.yaml: AST universe + manifest ──────────────────────────────
+
+@pytest.fixture(scope="module")
+def hermes_parsed():
+    if not HERMES_AVAILABLE:
+        pytest.skip("hermes submodule not checked out")
+    return guard.parse_hermes_config_source(REPO)
+
+
+@pytest.fixture(scope="module")
+def hermes_poly():
+    manifest = guard.load_manifest(REPO, "manifest-hermes.yaml")
+    return {s: set(k or []) for s, k in (manifest.get("polymorphic_sections") or {}).items()}
+
+
+@needs_hermes
+def test_hermes_unknown_root_key_detected(hermes_parsed, hermes_poly):
+    cfg = {"prompt_cachng": {"cache_ttl": "1h"}}  # seeded typo of prompt_caching
+    findings = guard._check_yaml_paths("hermes", "<fixture>", cfg,
+                                       hermes_parsed["default_config"], hermes_poly,
+                                       hermes_parsed["known_root_keys"], set())
+    assert [f.key for f in findings] == ["prompt_cachng"]
+
+
+@needs_hermes
+def test_hermes_unknown_nested_key_detected(hermes_parsed, hermes_poly):
+    cfg = {"prompt_caching": {"cache_ttll": "1h"},        # typo'd leaf
+           "model": {"provider": "custom", "baseurl": "x"}}  # typo'd polymorphic subkey
+    findings = guard._check_yaml_paths("hermes", "<fixture>", cfg,
+                                       hermes_parsed["default_config"], hermes_poly,
+                                       hermes_parsed["known_root_keys"], set())
+    assert {f.key for f in findings} == {"prompt_caching.cache_ttll", "model.baseurl"}
+
+
+@needs_hermes
+def test_hermes_generated_configs_valid(hermes_parsed, hermes_poly):
+    """Every shipped config.yaml generator's output must be accepted."""
+    generators = guard.hermes_config_generators(REPO)
+    assert generators, "no Hermes config.yaml generator found in the repo"
+    # A1 keeps the canonical generator in write-hermes-config.sh plus a copy
+    # in the services/ entrypoint — discovery must see both.
+    names = {g.name for g in generators}
+    assert "write-hermes-config.sh" in names
+    for script in generators:
+        cfg = guard.extract_heredoc_yaml(script)
+        assert cfg, f"no heredoc config extracted from {script}"
+        findings = guard._check_yaml_paths("hermes", str(script), cfg,
+                                           hermes_parsed["default_config"], hermes_poly,
+                                           hermes_parsed["known_root_keys"], set())
+        assert findings == [], [str(f) for f in findings]
+
+
+@needs_hermes
+def test_hermes_manifest_pin_matches_submodule_gitlink():
+    """Vendor-bump tripwire: manifest pin == superproject gitlink."""
+    manifest = guard.load_manifest(REPO, "manifest-hermes.yaml")
+    actual = guard.gitlink_sha(REPO, "apps/hermes/src")
+    if actual is None:
+        pytest.skip("not a git checkout")
+    assert manifest["pinned_commit"] == actual, (
+        "hermes vendor bump detected — re-validate manifest-hermes.yaml "
+        "polymorphic sections against the new source, then update pinned_commit")
+
+
+@needs_hermes
+def test_hermes_env_universe_detects_never_read_key():
+    universe = guard.hermes_env_universe(REPO)
+    findings = guard.check_env_keys("hermes", "<fixture>",
+                                    ["HERMES_DB_PATH"], universe, [], set())
+    # the pinned hermes has no HERMES_DB_PATH override — the guard must say so
+    assert [f.key for f in findings] == ["HERMES_DB_PATH"]
+    assert guard.check_env_keys("hermes", "<fixture>",
+                                ["HERMES_KANBAN_DB", "HERMES_HOME"],
+                                universe, [], set()) == []
+
+
+# ── PaperClip: curated manifest + version-pin tripwire ───────────────────────
+
+def test_paperclip_manifest_pin_matches_dockerfile_and_compose():
+    manifest = guard.load_manifest(REPO, "manifest-paperclip.yaml")
+    versions = guard.paperclip_pinned_versions(REPO)
+    assert versions, "could not extract PAPERCLIP_VERSION pins"
+    for source, version in versions.items():
+        assert version == manifest["pinned_version"], (
+            f"{source} pins {version}, manifest pins {manifest['pinned_version']} — "
+            "vendor bump: re-validate manifest-paperclip.yaml")
+
+
+def test_paperclip_unknown_key_detected():
+    manifest = guard.load_manifest(REPO, "manifest-paperclip.yaml")
+    accepted = {str(e["key"]).upper() for e in manifest["accepted_env"]}
+    findings = guard.check_env_keys("paperclip", "<fixture>",
+                                    ["PAPERCLIP_TYPO_KEY"], accepted, [], set())
+    assert [f.key for f in findings] == ["PAPERCLIP_TYPO_KEY"]
+
+
+# ── Terraform / compose artifact parsing ─────────────────────────────────────
+
+def test_tf_container_scoping_excludes_sidecar_env():
+    """hermes.tf carries a model-router sidecar; its env must not be attributed
+    to the hermes container."""
+    tf = REPO / "infrastructure/modules/container-apps/hermes.tf"
+    hermes_keys = set(guard.terraform_env_keys(tf, containers=["hermes"]))
+    all_keys = set(guard.terraform_env_keys(tf))
+    assert hermes_keys < all_keys
+    assert "OPENAI_BASE_URL" in hermes_keys
+    # router-tier env lives only in the sidecar
+    assert "PHI_BASE_URL" not in hermes_keys
+    assert "PHI_BASE_URL" in all_keys
+
+
+def test_compose_env_keys_reads_dict_form():
+    keys = guard.compose_env_keys(REPO / "docker-compose.yml", "honcho")
+    assert "DB_CONNECTION_URI" in keys
+    assert "SUMMARY_MODEL_CONFIG__TRANSPORT" in keys
+
+
+# ── The bottom line ──────────────────────────────────────────────────────────
+
+@needs_honcho
+@needs_hermes
+def test_repo_is_clean():
+    """The whole guard, against the real repo: no shipped key may be unread by
+    its pinned vendored consumer. This is the check CI enforces."""
+    findings = guard.validate_all(REPO)
+    assert findings == [], "\n".join(str(f) for f in findings)
+
+
+@needs_honcho
+@needs_hermes
+def test_self_test_passes():
+    assert guard.self_test(REPO) == 0


### PR DESCRIPTION
## What

A new **`validate-vendored-config`** CI job that validates every config key AAF ships to a vendored app (compose env blocks, Terraform env blocks, the generated Hermes `config.yaml`) against the schema the **pinned vendored source** actually reads. A key the app silently drops — the exact class behind the Honcho 3.0.7 flat-key incident ("boots clean, runs every specialist on direct-OpenAI gpt-5.4-mini") and the Hermes config-schema-shift incident ("provider=openrouter, model=empty, 401") — now **fails the build** instead of silently degrading a deployment.

Design doc first, as specified: **`docs/design/vendored-config-schema-guard.md`**.

## REAL DRIFT FOUND (the headline)

The guard's first honest run found the Honcho 3.0.7 incident **alive in this repo** — the vendor bump that migrated `docker-compose.yml` and `.env.example` (#111) missed two artifacts:

1. **`infrastructure/modules/container-apps/honcho.tf`** — all three resources (API app, always-on deriver, scheduled deriver job) still shipped the pre-3.0.7 flat keys (`SUMMARY_PROVIDER`, `SUMMARY_MODEL`, `DERIVER_PROVIDER`, `DERIVER_MODEL`, `DIALECTIC_LEVELS__<lvl>__PROVIDER/__MODEL/__THINKING_BUDGET_TOKENS` × 5 levels) — **57 removed env keys**, all silently ignored (`extra="ignore"`). A Terraform deploy of the pinned Honcho 3.0.11 image would have run every specialist and all five dialectic levels on direct-OpenAI `gpt-5.4-mini`. The file's own comment even warns about "the old DIALECTIC_MINIMAL_PROVIDER style is silently ignored" — while using the *other* silently-ignored style. **Fixed**: migrated to the nested `MODEL_CONFIG` shape (values preserved; `MAX_TOOL_ITERATIONS` survived 3.0.7 and stays a per-level field).
2. **`deploy/mac-site/docker-compose.yml`** — same flat keys in the honcho service (**19 keys**), three lines below a comment correctly stating "the flat form is ignored". **Fixed** the same way.
3. **`infrastructure/modules/container-apps/hermes.tf`** — `HERMES_DB_PATH` appears **nowhere** in the pinned Hermes (v2026.5.16): `hermes_state.py` has no path override, so the documented SQLite-on-SMB mitigation for `state.db` was silently inert (state.db actually lives on the Azure File Share). Removed with an honest note; the twin `HERMES_KANBAN_DB` fix IS read (`hermes_cli/kanban_db.py`) and stays. Also removed the unread `LOG_LEVEL` from the hermes container (the model-router sidecar reads its own and keeps it). `.env.example`'s dead `HERMES_DB_PATH` knob dropped too.
   *Observation, not changed here: `apps/paperclip/patch-adapter.mjs` sets a per-session `HERMES_DB_PATH` for the same reason — equally a no-op on this pin; worth revisiting at the next Hermes bump.*

## Per-app validation strategy

| App | Strategy |
|---|---|
| **Honcho** | **Load the vendored pydantic-settings model** (`apps/honcho/src/src/config.py`, standalone import) and derive the full accepted env-key universe: per-section `env_prefix`, `__` nested paths through sub-models (incl. `…MODEL_CONFIG__OVERRIDES__BASE_URL`), `dict[Literal[…]]` closes the dialectic level-name set (a typo'd level is flagged), aliases honored, case-insensitive. Zero curation — a vendor bump recomputes the universe and fails iff shipped keys became invalid. A curated removed-keys map upgrades diagnostics to migration hints (`SUMMARY_PROVIDER` → "REMOVED in 3.0.7 — replace with `SUMMARY_MODEL_CONFIG__TRANSPORT`"). |
| **Hermes `config.yaml`** | **AST-parse the vendored parser** (`hermes_cli/config.py` `DEFAULT_CONFIG` tree ∪ `_KNOWN_ROOT_KEYS`; no imports, no heavy deps) and validate the entrypoint-heredoc-generated config. Polymorphic sections (dict-form `model:` whose vendored default is a scalar) come from `scripts/vendored-config/manifest-hermes.yaml`, **pinned to the submodule gitlink** — a Hermes bump fails the job until the manifest is re-validated. That loud failure is the point. |
| **Hermes env** | Static consumption scan (os.getenv/os.environ literals across the vendored tree + the parser's env tables + `$VAR` reads in bundled AAF override/agent-runtime scripts). Over-accepts by design — its job is catching keys the app **never** reads. Terraform env is scoped per-container so the model-router sidecar isn't validated against Hermes. |
| **PaperClip** | Source is cloned at image build (not in-tree), so a **curated manifest** (`manifest-paperclip.yaml`) carries only upstream-consumed keys, **pinned to `PAPERCLIP_VERSION`** and cross-checked against both the Dockerfile `ARG` and the compose default — a version bump fails until re-validated. Everything in-tree (entrypoint, auth-proxy.mjs, patches, bundled Hermes CLI) is derived by scanning, not curated. |

**Failure policy**: every finding is a hard fail — no warn tier (warnings in green builds are how the incidents shipped). Suppression only via `scripts/vendored-config/allowlist.yaml`, where an entry **without a non-empty `reason` is itself a failure**. Current allowlist: platform env consumed by the runtime, not the app (`AZURE_CLIENT_ID` → azure-identity, `APPLICATIONINSIGHTS_CONNECTION_STRING` → App Insights, `GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE` → the gws CLI binary).

## Test evidence

Local run (Python 3.13, pydantic 2.13.4 / pydantic-settings 2.14.2):

```
$ python scripts/validate_vendored_config.py          # before fixes: 78 findings
vendored-config schema guard: 78 finding(s)           # 76 honcho removed-key + 2 dead hermes keys
$ python scripts/validate_vendored_config.py          # after fixes
vendored-config schema guard: clean — every shipped key is read by the pinned vendored source (or explicitly allowlisted with a reason)
$ python scripts/validate_vendored_config.py --self-test
self-test OK: seeded removed/unknown/typo'd keys all detected; valid keys and allowlisted keys pass
$ pytest -q tests/vendored-config
19 passed in 4.22s
```

Unit tests cover: removed-flat-key detected with migration hint; unknown key detected per app; typo'd dialectic level name detected (closed Literal set); valid nested/OVERRIDES/case shapes pass; allowlisted key passes; reason-less allowlist entry rejected; both manifest version-pin tripwires; heredoc-generated configs validate; per-container tf scoping excludes the sidecar; whole-repo clean run; self-test passes. `terraform fmt`/`validate` and `docker compose config -q` still green.

## Vendor-bump behavior (by design)

- **Honcho**: universe recomputed from the new pin → fails iff shipped keys became invalid (that IS the incident, caught).
- **Hermes**: manifest `pinned_commit` ≠ new gitlink → fails **always** until the polymorphic sections are re-validated.
- **PaperClip**: manifest `pinned_version` ≠ Dockerfile/compose pin → fails **always** until the env list is re-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)