### PR TITLE
docs(notes): preserve design specs + plans from stale branches

### DIFF
--- a/docs/notes/plans/2026-06-25-aca-sandbox-finish.md
+++ b/docs/notes/plans/2026-06-25-aca-sandbox-finish.md
@@ -1,0 +1,346 @@
+# ACA Sandbox Finish — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the shipped-but-inert sandbox seam into a real isolated-execution feature by adding an `aca-job` provider (Azure Container Apps dynamic sessions) and wiring the seam into the adapter spawn path behind a default-`local` flag.
+
+**Architecture:** The seam (`apps/paperclip/sandbox.mjs`) already defines the contract, the `local` adapter, and a fail-closed `createSandbox` factory with a `PROVIDERS` registry. We add an `AcaJobSandbox` class that implements the same `exec()` contract by delegating to an **injected HTTP transport** (so all provider logic is unit-testable offline); the single real Azure REST call is isolated in one small function. Wiring into the upstream adapter's `execute.js` is a build-time string patch in `patch-adapter.mjs`, gated on `SANDBOX_PROVIDER` so the default path is unchanged.
+
+**Tech Stack:** Node.js ESM (`.mjs`), `node:test`, ACA dynamic sessions REST API, managed-identity bearer auth.
+
+---
+
+### Task 0: Spike the ACA dynamic-sessions exec API (de-risk before coding)
+
+**Why:** The `aca-job` provider's correctness depends on the exact ACA dynamic-sessions request/response shape, which is not verified in this repo. Spike it like the Voice Live STT spike — prove the call before writing the provider.
+
+**Files:**
+- Create: `docs/superpowers/spikes/aca-sandbox/spike.mjs`
+- Create: `docs/superpowers/spikes/aca-sandbox/FINDINGS.md`
+
+- [ ] **Step 1:** Write `spike.mjs` that, given `ACA_SESSION_POOL_ENDPOINT` + a bearer token, (a) creates/targets a session by identifier, (b) executes `echo hello` (or a custom-container command), (c) prints the full response JSON and the mapped `{exitCode, stdout, stderr}`.
+- [ ] **Step 2:** Run against a real ACA session pool (operator-provided). Capture: the exact execute endpoint + `api-version`, the request body schema, the response field names for stdout/stderr/exit status, and round-trip latency.
+- [ ] **Step 3:** Write `FINDINGS.md` with the verified endpoint, payload, response mapping, and auth (MI scope). **This file is the source of truth for Task 2's transport.**
+- [ ] **Step 4:** Commit.
+
+```bash
+git add docs/superpowers/spikes/aca-sandbox/
+git commit -m "spike(sandbox): verify ACA dynamic-sessions exec API shape"
+```
+
+> If a live pool isn't available this weekend, STOP after Task 1 and ship Tasks 3–4 as the provider scaffold with the transport behind a clearly-marked, unit-tested seam; mark the live REST mapping as the one unverified line and do not enable `aca-job` in any environment until the spike runs.
+
+---
+
+### Task 1: `AcaJobSandbox` class + fail-closed config, registered in the factory
+
+**Files:**
+- Modify: `apps/paperclip/sandbox.mjs` (add class + registry entry)
+- Test: `tests/sandbox/aca-job.test.mjs` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+const { createSandbox, AcaJobSandbox, PROVIDERS } = await import("../../apps/paperclip/sandbox.mjs");
+
+describe("aca-job registration", () => {
+  test("factory returns AcaJobSandbox for provider='aca-job'", () => {
+    const sb = createSandbox("aca-job", { poolEndpoint: "https://pool.example", transport: async () => ({}) });
+    assert.ok(sb instanceof AcaJobSandbox);
+    assert.equal(sb.provider, "aca-job");
+  });
+  test("throws (fail closed) when poolEndpoint is missing", () => {
+    assert.throws(() => createSandbox("aca-job", {}), /poolEndpoint/);
+  });
+  test("registry now exposes local and aca-job", () => {
+    assert.deepEqual(Object.keys(PROVIDERS).sort(), ["aca-job", "local"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/sandbox/aca-job.test.mjs`
+Expected: FAIL — `AcaJobSandbox` is not exported / `aca-job` not in registry.
+
+- [ ] **Step 3: Write minimal implementation** (in `apps/paperclip/sandbox.mjs`)
+
+```javascript
+class AcaJobSandbox {
+  constructor(config = {}) {
+    this.provider = "aca-job";
+    if (!config.poolEndpoint) {
+      throw new Error("aca-job sandbox requires config.poolEndpoint (the ACA session pool management endpoint)");
+    }
+    this.poolEndpoint = config.poolEndpoint;
+    this.apiVersion = config.apiVersion || "2024-10-02-preview";
+    // Injected transport: (url, {method, headers, body}) => Promise<{status, json()}>
+    // Defaults to global fetch in production; tests inject a fake.
+    this.transport = config.transport || ((url, init) => fetch(url, init));
+    // Injected token provider for managed-identity auth; tests inject a stub.
+    this.getToken = config.getToken || (async () => { throw new Error("aca-job: no token provider configured"); });
+    this.sessionId = config.sessionId || "paperclip";
+  }
+  // exec() added in Task 2.
+}
+```
+
+Then register it:
+
+```javascript
+const PROVIDERS = {
+  local: LocalSandbox,
+  "aca-job": AcaJobSandbox,
+};
+```
+
+And extend the export:
+
+```javascript
+export { createSandbox, LocalSandbox, AcaJobSandbox, PROVIDERS };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test tests/sandbox/aca-job.test.mjs`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Update the existing registry test that asserts local-only**
+
+In `tests/sandbox/sandbox.test.mjs`, change:
+
+```javascript
+test("the registry exposes only local for now", () => {
+  assert.deepEqual(Object.keys(PROVIDERS), ["local"]);
+});
+```
+to:
+```javascript
+test("the registry exposes local and aca-job", () => {
+  assert.deepEqual(Object.keys(PROVIDERS).sort(), ["aca-job", "local"]);
+});
+```
+And remove `aca-job` from the "throws on unknown provider" test (keep `e2b`):
+```javascript
+test("throws (fail closed) on an unknown provider", () => {
+  assert.throws(() => createSandbox("e2b"), /Unknown SANDBOX_PROVIDER/);
+});
+```
+
+- [ ] **Step 6: Run the full sandbox suite + commit**
+
+Run: `node --test tests/sandbox/`
+Expected: PASS (existing 16 minus the moved assertion, plus new aca-job tests).
+
+```bash
+git add apps/paperclip/sandbox.mjs tests/sandbox/
+git commit -m "feat(sandbox): register fail-closed aca-job provider"
+```
+
+---
+
+### Task 2: `AcaJobSandbox.exec()` — delegate to the injected transport, map to the result shape
+
+**Files:**
+- Modify: `apps/paperclip/sandbox.mjs`
+- Test: `tests/sandbox/aca-job.test.mjs`
+
+> Use the response field mapping verified in Task 0 `FINDINGS.md`. The body/endpoint below reflects the documented ACA dynamic-sessions shape; reconcile with FINDINGS before enabling live.
+
+- [ ] **Step 1: Write the failing test** (fake transport, no network)
+
+```javascript
+describe("AcaJobSandbox.exec", () => {
+  function fakeTransport(captured) {
+    return async (url, init) => {
+      captured.url = url; captured.init = init;
+      return { status: 200, json: async () => ({ stdout: "hello\n", stderr: "", exitCode: 0 }) };
+    };
+  }
+  test("posts to the pool execute endpoint and maps the result shape", async () => {
+    const captured = {};
+    const sb = createSandbox("aca-job", {
+      poolEndpoint: "https://pool.example",
+      transport: fakeTransport(captured),
+      getToken: async () => "tok-123",
+    });
+    const res = await sb.exec("echo", ["hello"], { timeoutMs: 5000 });
+    assert.deepEqual(res, { exitCode: 0, signal: null, timedOut: false, stdout: "hello\n", stderr: "" });
+    assert.match(captured.url, /\/code\/execute\?api-version=/);
+    assert.equal(captured.init.headers.Authorization, "Bearer tok-123");
+    assert.match(captured.init.headers["Content-Type"], /application\/json/);
+  });
+  test("never rejects — transport error becomes a result", async () => {
+    const sb = createSandbox("aca-job", {
+      poolEndpoint: "https://pool.example",
+      transport: async () => { throw new Error("network down"); },
+      getToken: async () => "tok",
+    });
+    const res = await sb.exec("echo", ["x"]);
+    assert.equal(res.exitCode, null);
+    assert.match(res.stderr, /network down/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/sandbox/aca-job.test.mjs`
+Expected: FAIL — `exec is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```javascript
+async exec(cmd, args = [], opts = {}) {
+  const { timeoutMs, signal } = opts;
+  const url = `${this.poolEndpoint}/code/execute?api-version=${this.apiVersion}`;
+  const command = [cmd, ...(Array.isArray(args) ? args : [])].join(" ");
+  try {
+    const token = await this.getToken();
+    const init = {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ identifier: this.sessionId, codeInputType: "inline", command }),
+      signal,
+    };
+    const resp = await this.transport(url, init);
+    const data = await resp.json();
+    // Field mapping per Task 0 FINDINGS.md:
+    return {
+      exitCode: typeof data.exitCode === "number" ? data.exitCode : (resp.status === 200 ? 0 : 1),
+      signal: null,
+      timedOut: false,
+      stdout: data.stdout ?? "",
+      stderr: data.stderr ?? "",
+    };
+  } catch (err) {
+    const aborted = signal && signal.aborted;
+    return {
+      exitCode: null, signal: null, timedOut: Boolean(timeoutMs && aborted),
+      stdout: "", stderr: String((err && err.message) || err),
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test tests/sandbox/aca-job.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/paperclip/sandbox.mjs tests/sandbox/aca-job.test.mjs
+git commit -m "feat(sandbox): aca-job exec maps ACA dynamic-sessions to the seam result shape"
+```
+
+---
+
+### Task 3: Guarded wiring into the adapter spawn path (build-time, default `local`)
+
+**Files:**
+- Modify: `apps/paperclip/patch-adapter.mjs`
+- Test: `tests/sandbox/wiring-transform.test.mjs` (new — tests the string transform, offline)
+
+**Approach:** Do NOT change runtime behavior by default. Add a build-time injection in `patch-adapter.mjs` that, only when the upstream `execute.js` spawn call is found, routes it through `createSandbox(process.env.SANDBOX_PROVIDER)` — which returns `LocalSandbox` (today's exact behavior) unless `SANDBOX_PROVIDER=aca-job`. Because the real spawn lives in the vendored adapter, the patch is a guarded string replacement that logs LOUD and no-ops if the anchor isn't found (consistent with the existing `[patch-adapter]` warnings).
+
+- [ ] **Step 1: Write the failing test** for a pure transform function `injectSandboxSeam(src)` exported from a new small module `apps/paperclip/patch-adapter-sandbox.mjs`:
+
+```javascript
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+const { injectSandboxSeam } = await import("../../apps/paperclip/patch-adapter-sandbox.mjs");
+
+describe("injectSandboxSeam", () => {
+  test("returns applied=false and unchanged src when anchor is absent", () => {
+    const r = injectSandboxSeam("no spawn here");
+    assert.equal(r.applied, false);
+    assert.equal(r.src, "no spawn here");
+  });
+  test("is idempotent — second pass does not double-inject", () => {
+    const withAnchor = 'const child = spawn(bin, argv, spawnOpts);';
+    const once = injectSandboxSeam(withAnchor);
+    assert.equal(once.applied, true);
+    const twice = injectSandboxSeam(once.src);
+    assert.equal(twice.applied, false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/sandbox/wiring-transform.test.mjs`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation** (`apps/paperclip/patch-adapter-sandbox.mjs`)
+
+```javascript
+// Pure, unit-tested transform. Anchor MUST be reconciled with the real
+// execute.js spawn line at integration time (Task 4); the anchor string here
+// is the documented default and is verified live in Task 4.
+const ANCHOR = "const child = spawn(bin, argv, spawnOpts);";
+const MARK = "/* AAF sandbox seam */";
+
+export function injectSandboxSeam(src) {
+  if (src.includes(MARK) || !src.includes(ANCHOR)) return { src, applied: false };
+  const replacement =
+    `${MARK} const __sb = (await import('/server-prod/sandbox.mjs')).createSandbox();\n` +
+    `const child = __sb.provider === 'local' ? spawn(bin, argv, spawnOpts) : __sb;`;
+  return { src: src.replace(ANCHOR, replacement), applied: true };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test tests/sandbox/wiring-transform.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Call it from `patch-adapter.mjs`** (after the existing execute.js edits, before `writeFileSync(executePath, execute)`):
+
+```javascript
+import { injectSandboxSeam } from "./patch-adapter-sandbox.mjs";
+// ... after other execute.js transforms:
+const _sb = injectSandboxSeam(execute);
+if (_sb.applied) { execute = _sb.src; console.log("[patch-adapter] Sandbox seam wired (default local)"); }
+else { console.warn("[patch-adapter] WARN: sandbox spawn anchor not found — seam NOT wired (default behavior unchanged)"); }
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/paperclip/patch-adapter-sandbox.mjs apps/paperclip/patch-adapter.mjs tests/sandbox/wiring-transform.test.mjs
+git commit -m "feat(sandbox): guarded build-time wiring of the seam (default local)"
+```
+
+- [ ] **Step 7 (integration, build-time):** During the next image build, confirm the `[patch-adapter] Sandbox seam wired` log appears. If the WARN appears instead, read the real `execute.js` spawn line, update `ANCHOR`, re-run the transform test, rebuild. Do not enable `aca-job` until the wired log is confirmed AND the Task 0 spike passed.
+
+---
+
+### Task 4: Terraform var + docs
+
+**Files:**
+- Modify: `infrastructure/modules/container-apps/variables.tf` (+ `paperclip.tf` env)
+- Modify: `docs/architecture.md` (sandbox section), `ROADMAP.md` (move sandbox from "follow-on" to shipped)
+
+- [ ] **Step 1:** Add a `sandbox_provider` variable (default `"local"`) and a `SANDBOX_PROVIDER` env on the paperclip container app, plus the session-pool endpoint var, all `count`/condition-gated so default deploys are unchanged. Mirror the existing `telegram_enabled`-style gating in `variables.tf`.
+- [ ] **Step 2:** Run `terraform validate` in `infrastructure/environments/dev`. Expected: clean.
+- [ ] **Step 3:** Update docs: the sandbox is now a pluggable provider (`local` default, `aca-job` for isolation); note enablement is operator opt-in after the spike.
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infrastructure/ docs/ ROADMAP.md
+git commit -m "feat(sandbox): sandbox_provider var + docs; mark aca-job shipped (flag-gated)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** aca-job provider (Tasks 1–2 ✓), wiring into spawn path (Task 3 ✓, guarded + build-time-verified), default-unchanged behavior (✓ via `SANDBOX_PROVIDER` default `local`), tests offline (✓ injected transport + pure transform), Terraform/docs (Task 4 ✓). The unproven external API is isolated and spiked first (Task 0 ✓).
+- **Placeholder scan:** the one inherently-unverifiable element (live ACA REST field names + the real execute.js spawn anchor) is dependency-injected and gated behind the Task 0 spike / Task 3 Step 7 integration check, not left as a TODO in shipped code.
+- **Type consistency:** `exec()` returns the seam's `{exitCode, signal, timedOut, stdout, stderr}` shape everywhere; `createSandbox(provider, config)` signature matches the existing factory; `transport(url, init) => {status, json()}` is consistent across Tasks 1–2.
+
+**Risk:** Task 3 (wiring) is the only upstream-coupled, build-time-verified step. If the weekend runs short, Tasks 0–2 + 4 ship the `aca-job` provider as a real, tested, flag-gated capability; Task 3 wiring can follow without blocking the release.

--- a/docs/notes/plans/2026-06-25-observability-pipeline.md
+++ b/docs/notes/plans/2026-06-25-observability-pipeline.md
@@ -1,0 +1,861 @@
+# Observability Pipeline (v1.3.1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish the two items the ROADMAP "Later" section names as "the rest of the observability pipeline", building directly on what v1.3 shipped (`services/model-router/main.py` GenAI-semconv spans behind `OBSERVABILITY_ENABLED`; `infrastructure/modules/monitoring/alerts.tf` v1.2 alert rules + workbook):
+1. A **`gen_ai.usage` cost/token metric** — the spans already set the span *attributes* `gen_ai.usage.input_tokens` / `output_tokens` / `cost_usd`; now ALSO emit aggregatable OpenTelemetry **metrics** (counters) for cost + tokens so they can be charted and alerted, not just traced.
+2. **SLO burn-rate alert rules** — two new Azure Monitor scheduled-query alert rules in the existing monitoring Terraform module that compute the model-router error-budget burn rate (fast-burn + slow-burn), following the exact opt-in/count-gated patterns of the v1.2 alerts.
+
+**Architecture:** The metric rides the SAME OTel provider the spans use. `configure_azure_monitor()` (called once in `_init_tracer`) configures the full OTel SDK — traces *and* metrics — and sets the global meter provider exported to Application Insights. So `opentelemetry.metrics.get_meter("model-router")` returns a meter backed by the already-wired Azure Monitor exporter; we add NO new exporter, connection string, or telemetry stack. A new `observe_genai_metrics()` reuses the existing `genai_semconv_attrs()` mapping for its metric attributes (same tier/system/model dimensions) and is called from the same `observe_genai()` body, so a single flag (`OBSERVABILITY_ENABLED`) and a single fail-open `try/except` govern both span and metric. The SLO alerts are pure HCL added to `alerts.tf`, count-gated on the existing `local.alerts_enabled` (`alert_emails` non-empty), querying the router's existing console-log markers (`call_failed` / `primary_failed` / `fallback_failed` for errors; `routing`/`success`/`messages success` for total volume) — so `terraform validate` stays clean with default (empty) inputs and the deploy footprint is unchanged.
+
+**Tech Stack:** Python 3.12, `opentelemetry-api`/`opentelemetry-sdk` (transitively via `azure-monitor-opentelemetry>=1.6.0`), `opentelemetry.metrics` counters, pytest 8.3.3 (`services/model-router/tests`, the `router` + `monkeypatch` fixtures in `conftest.py`); Terraform 1.9.5, `azurerm_monitor_scheduled_query_rules_alert_v2`, KQL over `ContainerAppConsoleLogs_CL`.
+
+---
+
+### Task 0: Confirm the OTel metrics API surface against the pinned SDK (de-risk before coding)
+
+**Why:** The metric-emission code below uses `opentelemetry.metrics.get_meter(...).create_counter(...).add(value, attributes=...)`. That API is stable in the OpenTelemetry Python SDK that `azure-monitor-opentelemetry>=1.6.0` pulls in, and `configure_azure_monitor()` already sets the global meter provider — but this repo never exercised the metrics path before, so prove the import + call shape once before writing the emitter. This is a read-only verification step (no source changes).
+
+**Files:** none (verification only).
+
+- [ ] **Step 1:** In the router venv (or CI image), confirm the metrics API is importable and the global meter provider is the default no-op until `configure_azure_monitor` runs:
+
+```bash
+cd services/model-router
+pip install -r requirements.txt -r requirements-dev.txt
+python -c "
+from opentelemetry import metrics
+m = metrics.get_meter('probe')
+c = m.create_counter('probe.count', unit='1', description='probe')
+c.add(3, attributes={'k': 'v'})    # no-op meter: must not raise
+print('metrics API OK:', type(c).__name__)
+"
+```
+
+Expected output (the default no-op meter accepts `.add` without an exporter):
+
+```
+metrics API OK: <a Counter or _ProxyCounter type name>
+```
+
+- [ ] **Step 2:** Confirm `configure_azure_monitor` configures metrics (not just traces) — this is what makes the metric DRY with the span. Read the package docstring; do NOT call it (it needs a real connection string):
+
+```bash
+python -c "import azure.monitor.opentelemetry as a; print(a.configure_azure_monitor.__doc__[:600])"
+```
+
+Expected: the docstring mentions configuring distributed tracing **and metrics** (and logging) via OpenTelemetry — confirming one call wires the meter provider the router's `_init_tracer` already invokes.
+
+> If Step 1 raises `ImportError` on `opentelemetry.metrics`, STOP: the pinned `azure-monitor-opentelemetry` is older than expected. The remedy is to add an explicit `opentelemetry-api` pin to `requirements.txt`; reconcile, then resume. If Step 2 shows metrics are NOT configured by `configure_azure_monitor` in this version, the emitter in Task 2 must also create a metric reader/exporter — note it and adjust `_init_meter` accordingly. Both are unlikely on `>=1.6.0` but cheap to verify now.
+
+---
+
+### Task 1: `genai_metric_attrs()` — the pure metric-attribute mapping
+
+**Why first:** Metrics need a *low-cardinality* attribute set (charting/alerting groups by these). The span attrs include per-call values like exact token counts and `agent.run_id` (high cardinality) that must NOT become metric dimensions or they explode the time-series count. So we derive a small, dedicated dimension set first, pure and unit-tested, mirroring how `genai_semconv_attrs()` is a pure mapping.
+
+**Files:**
+- Modify: `services/model-router/main.py`
+- Test: `services/model-router/tests/test_observability.py`
+
+- [ ] **Step 1: Write the failing test** — append this class to `services/model-router/tests/test_observability.py`:
+
+```python
+class TestGenaiMetricAttrs:
+    def test_low_cardinality_dimensions_only(self, router):
+        attrs = router.genai_metric_attrs(
+            tier="gpt4o-mini", model="gpt-4o-mini", run_id="r1",
+        )
+        # Dimensions a chart/alert can group by — and nothing per-call/high-card.
+        assert attrs == {
+            "gen_ai.operation.name": "chat",
+            "gen_ai.system": "az.ai.foundry",
+            "gen_ai.request.model": "gpt-4o-mini",
+            "agent.tier": "gpt4o-mini",
+        }
+        # run_id and raw token/cost numbers must NOT be metric dimensions.
+        assert "agent.run_id" not in attrs
+        assert "gen_ai.usage.input_tokens" not in attrs
+
+    def test_anthropic_system_dimension(self, router):
+        attrs = router.genai_metric_attrs(tier="claude", model="claude-sonnet-4-6")
+        assert attrs["gen_ai.system"] == "anthropic"
+
+    def test_model_falls_back_to_tier_when_blank(self, router):
+        attrs = router.genai_metric_attrs(tier="gpt4o-mini", model="")
+        assert attrs["gen_ai.request.model"] == "gpt4o-mini"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/model-router && pytest -q tests/test_observability.py::TestGenaiMetricAttrs`
+Expected: FAIL — `AttributeError: module 'main' has no attribute 'genai_metric_attrs'`.
+
+- [ ] **Step 3: Write minimal implementation** — in `services/model-router/main.py`, immediately AFTER `genai_semconv_attrs()` (ends at the `return attrs` near line 423), add:
+
+```python
+def genai_metric_attrs(
+    *, tier: str, model: str, run_id: str | None = None,
+) -> dict[str, str]:
+    """Low-cardinality dimension set for the gen_ai.usage METRICS.
+
+    Deliberately a strict subset of genai_semconv_attrs(): per-call values
+    (exact token counts, cost, run_id) are span attributes only — making them
+    metric dimensions would explode the time-series cardinality. run_id is
+    accepted for signature symmetry with observe_genai() but intentionally
+    dropped. No I/O.
+    """
+    return {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.system": _genai_system(tier),
+        "gen_ai.request.model": model or tier,
+        "agent.tier": tier,
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd services/model-router && pytest -q tests/test_observability.py::TestGenaiMetricAttrs`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/model-router/main.py services/model-router/tests/test_observability.py
+git commit -m "feat(router): pure low-cardinality gen_ai metric attribute mapping"
+```
+
+---
+
+### Task 2: `_init_meter()` + module-level instruments — reuse the span's OTel provider
+
+**Why:** The meter must come from the SAME provider `configure_azure_monitor()` set up in `_init_tracer()`, so there's no parallel telemetry stack. `_init_meter()` mirrors `_init_tracer()`: lazy, idempotent, returns `None` when no connection string is set or setup fails. The three counters (cost, input tokens, output tokens) are created once and memoized.
+
+**Files:**
+- Modify: `services/model-router/main.py`
+- Test: `services/model-router/tests/test_observability.py`
+- Modify: `services/model-router/tests/conftest.py` (snapshot the new meter globals so state doesn't leak between tests)
+
+- [ ] **Step 1: Extend the state-isolation fixture FIRST** (so the new globals are restored around every test). In `services/model-router/tests/conftest.py`, inside `_isolate_router_state`, add snapshot lines next to the existing tracer snapshot (after `tracer_initialised_snapshot = main._tracer_initialised`):
+
+```python
+    meter_snapshot = main._meter
+    meter_initialised_snapshot = main._meter_initialised
+    instruments_snapshot = main._instruments
+```
+
+and restore lines next to the existing tracer restore (after `main._tracer_initialised = tracer_initialised_snapshot`):
+
+```python
+    main._meter = meter_snapshot
+    main._meter_initialised = meter_initialised_snapshot
+    main._instruments = instruments_snapshot
+```
+
+- [ ] **Step 2: Write the failing test** — append to `test_observability.py`:
+
+```python
+class TestInitMeter:
+    def test_returns_none_without_connection_string(self, router, monkeypatch):
+        monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+        monkeypatch.setattr(router, "_meter", None)
+        monkeypatch.setattr(router, "_meter_initialised", False)
+        assert router._init_meter() is None
+
+    def test_idempotent_does_not_reconfigure(self, router, monkeypatch):
+        calls = []
+
+        class FakeMeter:
+            def create_counter(self, *a, **k):
+                calls.append(("counter",) + a)
+                return object()
+
+        monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "InstrumentationKey=x")
+        monkeypatch.setattr(router, "_meter", None)
+        monkeypatch.setattr(router, "_meter_initialised", False)
+        monkeypatch.setattr(router, "_instruments", None)
+        # configure_azure_monitor is already called by _init_tracer; the meter
+        # comes from the global provider. Stub the get_meter import boundary.
+        monkeypatch.setattr(router, "_get_otel_meter", lambda name: FakeMeter())
+        m1 = router._init_meter()
+        m2 = router._init_meter()
+        assert m1 is m2  # memoized
+        # three counters created exactly once (not on the second call)
+        assert sum(1 for c in calls if c[0] == "counter") == 3
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd services/model-router && pytest -q tests/test_observability.py::TestInitMeter`
+Expected: FAIL — `AttributeError: module 'main' has no attribute '_init_meter'`.
+
+- [ ] **Step 4: Write minimal implementation** — in `services/model-router/main.py`, immediately AFTER `_init_tracer()` (ends ~line 453, `return _tracer`), add:
+
+```python
+_meter = None
+_meter_initialised = False
+_instruments = None  # dict of created counters, built once
+
+
+def _get_otel_meter(name: str):
+    """Import boundary so tests can stub the global meter provider lookup.
+    Returns a meter from whatever provider configure_azure_monitor() set up."""
+    from opentelemetry import metrics
+    return metrics.get_meter(name)
+
+
+def _init_meter():
+    """Lazily obtain the OTel meter once, from the SAME provider _init_tracer's
+    configure_azure_monitor() set up (it configures traces AND metrics). Returns
+    the meter, or None when no connection string is set or setup fails. Builds
+    the gen_ai.usage instruments once and memoizes them on _instruments."""
+    global _meter, _meter_initialised, _instruments
+    if _meter_initialised:
+        return _meter
+    _meter_initialised = True
+    conn = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING")
+    if not conn:
+        return None
+    try:
+        # Ensure the Azure Monitor SDK is configured (idempotent — _init_tracer
+        # may have already called it; configure_azure_monitor wires metrics too).
+        _init_tracer()
+        meter = _get_otel_meter("model-router")
+        _instruments = {
+            "cost": meter.create_counter(
+                "gen_ai.usage.cost_usd",
+                unit="USD",
+                description="Estimated/billed model spend per call, summed.",
+            ),
+            "input_tokens": meter.create_counter(
+                "gen_ai.usage.input_tokens",
+                unit="{token}",
+                description="Prompt (input) tokens consumed, summed.",
+            ),
+            "output_tokens": meter.create_counter(
+                "gen_ai.usage.output_tokens",
+                unit="{token}",
+                description="Completion (output) tokens produced, summed.",
+            ),
+        }
+        _meter = meter
+    except Exception as e:  # pragma: no cover - requires live OTel SDK
+        log.warning("observability: meter init failed, disabling metrics: %s", e)
+        _meter = None
+        _instruments = None
+    return _meter
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd services/model-router && pytest -q tests/test_observability.py::TestInitMeter`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/model-router/main.py services/model-router/tests/conftest.py services/model-router/tests/test_observability.py
+git commit -m "feat(router): lazy OTel meter + gen_ai.usage counters off the shared provider"
+```
+
+---
+
+### Task 3: `observe_genai_metrics()` — record cost + tokens onto the counters
+
+**Files:**
+- Modify: `services/model-router/main.py`
+- Test: `services/model-router/tests/test_observability.py`
+
+- [ ] **Step 1: Write the failing test** — append to `test_observability.py`:
+
+```python
+class TestObserveGenaiMetrics:
+    def _fake_instruments(self, recorded):
+        class FakeCounter:
+            def __init__(self, key): self.key = key
+            def add(self, amount, attributes=None):
+                recorded.append((self.key, amount, attributes))
+        return {
+            "cost": FakeCounter("cost"),
+            "input_tokens": FakeCounter("input_tokens"),
+            "output_tokens": FakeCounter("output_tokens"),
+        }
+
+    def test_noop_when_no_meter(self, router, monkeypatch):
+        recorded = []
+        monkeypatch.setattr(router, "_init_meter", lambda: None)
+        router.observe_genai_metrics(
+            tier="gpt4o-mini", model="gpt-4o-mini",
+            input_tokens=10, output_tokens=2, cost_usd=0.5,
+        )
+        assert recorded == []  # no meter → nothing recorded
+
+    def test_records_three_counters_with_metric_dims(self, router, monkeypatch):
+        recorded = []
+        monkeypatch.setattr(router, "_init_meter", lambda: object())
+        monkeypatch.setattr(router, "_instruments", self._fake_instruments(recorded))
+        router.observe_genai_metrics(
+            tier="gpt4o-mini", model="gpt-4o-mini",
+            input_tokens=10, output_tokens=2, cost_usd=0.0012345678, run_id="r1",
+        )
+        by_key = {k: (amt, dims) for k, amt, dims in recorded}
+        assert by_key["input_tokens"][0] == 10
+        assert by_key["output_tokens"][0] == 2
+        # cost rounded to 6 dp, same convention as the span attribute
+        assert by_key["cost"][0] == 0.001235
+        # low-cardinality dims only — no run_id leaking into the time series
+        assert by_key["cost"][1] == {
+            "gen_ai.operation.name": "chat",
+            "gen_ai.system": "az.ai.foundry",
+            "gen_ai.request.model": "gpt-4o-mini",
+            "agent.tier": "gpt4o-mini",
+        }
+
+    def test_fail_open_on_counter_error(self, router, monkeypatch):
+        class Boom:
+            def add(self, *a, **k): raise RuntimeError("exporter down")
+        monkeypatch.setattr(router, "_init_meter", lambda: object())
+        monkeypatch.setattr(
+            router, "_instruments",
+            {"cost": Boom(), "input_tokens": Boom(), "output_tokens": Boom()},
+        )
+        # A metrics error must never propagate to the caller.
+        router.observe_genai_metrics(
+            tier="gpt4o-mini", model="gpt-4o-mini",
+            input_tokens=1, output_tokens=1, cost_usd=0.0,
+        )
+
+    def test_negative_values_coerced_to_zero(self, router, monkeypatch):
+        recorded = []
+        monkeypatch.setattr(router, "_init_meter", lambda: object())
+        monkeypatch.setattr(router, "_instruments", self._fake_instruments(recorded))
+        router.observe_genai_metrics(
+            tier="gpt4o-mini", model="m",
+            input_tokens=-5, output_tokens=-1, cost_usd=-3.0,
+        )
+        by_key = {k: amt for k, amt, _ in recorded}
+        # counters are monotonic; never add a negative delta
+        assert by_key["input_tokens"] == 0
+        assert by_key["output_tokens"] == 0
+        assert by_key["cost"] == 0.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/model-router && pytest -q tests/test_observability.py::TestObserveGenaiMetrics`
+Expected: FAIL — `AttributeError: module 'main' has no attribute 'observe_genai_metrics'`.
+
+- [ ] **Step 3: Write minimal implementation** — in `services/model-router/main.py`, immediately AFTER `observe_genai()` (ends ~line 477, the fail-open `except` block), add:
+
+```python
+def observe_genai_metrics(
+    *, tier: str, model: str, input_tokens: int, output_tokens: int,
+    cost_usd: float, run_id: str | None = None,
+) -> None:
+    """Record one model call onto the gen_ai.usage counters (cost, input/output
+    tokens) with low-cardinality dimensions. Flag-gated by the caller
+    (observe_genai); FAIL-OPEN — any metrics error is swallowed so it can never
+    break a model call. Counter deltas are clamped >= 0 (counters are monotonic)."""
+    try:
+        if _init_meter() is None or not _instruments:
+            return
+        dims = genai_metric_attrs(tier=tier, model=model, run_id=run_id)
+        _instruments["input_tokens"].add(max(0, int(input_tokens or 0)), attributes=dims)
+        _instruments["output_tokens"].add(max(0, int(output_tokens or 0)), attributes=dims)
+        _instruments["cost"].add(max(0.0, round(float(cost_usd or 0.0), 6)), attributes=dims)
+    except Exception as e:  # fail-open: never surface telemetry errors
+        log.debug("observe_genai_metrics swallowed: %s", e)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd services/model-router && pytest -q tests/test_observability.py::TestObserveGenaiMetrics`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/model-router/main.py services/model-router/tests/test_observability.py
+git commit -m "feat(router): observe_genai_metrics records cost+tokens onto the counters"
+```
+
+---
+
+### Task 4: Wire the metric into `observe_genai()` — one flag, one fail-open boundary
+
+**Why:** Keep span + metric DRY and co-gated. `observe_genai()` is already called from `record_cost()` on every model call (both the LiteLLM and Anthropic-direct paths — see `_call_model`). Calling `observe_genai_metrics()` from inside the existing `observe_genai()` body means the metric inherits the same `OBSERVABILITY_ENABLED` gate and the same outer fail-open `try/except` — no second call site, no second flag.
+
+**Files:**
+- Modify: `services/model-router/main.py`
+- Test: `services/model-router/tests/test_observability.py`
+
+- [ ] **Step 1: Write the failing test** — append to `test_observability.py`:
+
+```python
+class TestObserveGenaiEmitsBoth:
+    def test_metric_emitted_alongside_span(self, router, monkeypatch):
+        calls = []
+
+        class FakeSpan:
+            def set_attribute(self, k, v): pass
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+
+        class FakeTracer:
+            def start_as_current_span(self, name): return FakeSpan()
+
+        monkeypatch.setattr(router, "OBSERVABILITY_ENABLED", True)
+        monkeypatch.setattr(router, "_init_tracer", lambda: FakeTracer())
+        monkeypatch.setattr(
+            router, "observe_genai_metrics",
+            lambda **kw: calls.append(kw),
+        )
+        router.observe_genai(
+            tier="gpt4o-mini", model="gpt-4o-mini",
+            input_tokens=7, output_tokens=3, cost_usd=0.01, run_id="rX",
+        )
+        assert len(calls) == 1
+        assert calls[0]["input_tokens"] == 7
+        assert calls[0]["cost_usd"] == 0.01
+        assert calls[0]["tier"] == "gpt4o-mini"
+
+    def test_metric_not_emitted_when_flag_off(self, router, monkeypatch):
+        calls = []
+        monkeypatch.setattr(router, "OBSERVABILITY_ENABLED", False)
+        monkeypatch.setattr(router, "observe_genai_metrics", lambda **kw: calls.append(kw))
+        router.observe_genai(
+            tier="gpt4o-mini", model="gpt-4o-mini",
+            input_tokens=1, output_tokens=1, cost_usd=0.0,
+        )
+        assert calls == []  # flag off → neither span nor metric
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/model-router && pytest -q tests/test_observability.py::TestObserveGenaiEmitsBoth`
+Expected: FAIL on `test_metric_emitted_alongside_span` — `assert len(calls) == 1` fails (0 calls) because `observe_genai()` does not yet call `observe_genai_metrics()`. (`test_metric_not_emitted_when_flag_off` already passes.)
+
+- [ ] **Step 3: Write minimal implementation** — in `services/model-router/main.py`, inside `observe_genai()`, in the `try` block AFTER the `with tracer.start_as_current_span(...)` block (after the `span.set_attribute` loop, still inside `try`), add the metric call. The edited body of the `try` becomes:
+
+```python
+        attrs = genai_semconv_attrs(
+            tier=tier, model=model, input_tokens=input_tokens,
+            output_tokens=output_tokens, cost_usd=cost_usd, run_id=run_id,
+        )
+        with tracer.start_as_current_span("gen_ai.chat") as span:
+            for k, v in attrs.items():
+                span.set_attribute(k, v)
+        # Same flag, same fail-open boundary: also emit the aggregatable
+        # gen_ai.usage metrics so cost/tokens can be charted + alerted (v1.3.1).
+        observe_genai_metrics(
+            tier=tier, model=model, input_tokens=input_tokens,
+            output_tokens=output_tokens, cost_usd=cost_usd, run_id=run_id,
+        )
+```
+
+> Note: place the `observe_genai_metrics` call so it runs whether or not the tracer is `None`. Re-check the guard: `observe_genai` currently returns early when `_init_tracer()` is `None`. To emit metrics even when only the meter (not the tracer) is available, move the metric call ABOVE the `if tracer is None: return` guard. Concretely, restructure the `try` so the metric emission is unconditional once the flag is on:
+>
+> ```python
+>     try:
+>         observe_genai_metrics(
+>             tier=tier, model=model, input_tokens=input_tokens,
+>             output_tokens=output_tokens, cost_usd=cost_usd, run_id=run_id,
+>         )
+>         tracer = _init_tracer()
+>         if tracer is None:
+>             return
+>         attrs = genai_semconv_attrs(...)
+>         with tracer.start_as_current_span("gen_ai.chat") as span:
+>             for k, v in attrs.items():
+>                 span.set_attribute(k, v)
+>     except Exception as e:  # fail-open
+>         log.debug("observe_genai swallowed: %s", e)
+> ```
+>
+> This keeps span and metric independently fail-open (each has its own inner guard) while both ride `OBSERVABILITY_ENABLED`. The Task-4 tests above stub `_init_tracer` to a FakeTracer so both orderings pass; this ordering also satisfies the existing `TestObserveGenai::test_noop_when_no_tracer` (still no exception) — re-run that class in Step 4 to confirm.
+
+- [ ] **Step 4: Run the test + the existing observe-genai tests to verify no regression**
+
+Run: `cd services/model-router && pytest -q tests/test_observability.py::TestObserveGenaiEmitsBoth tests/test_observability.py::TestObserveGenai`
+Expected: PASS (2 new + 4 existing = 6 tests). In particular `TestObserveGenai::test_noop_when_no_tracer` and `test_fail_open_on_tracer_error` still pass.
+
+- [ ] **Step 5: Run the FULL router suite to confirm nothing else regressed**
+
+Run: `cd services/model-router && pytest -q tests/`
+Expected: PASS — all existing tests plus the new observability classes. (The CI step is `pytest -q services/model-router/tests`; this is the same suite.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/model-router/main.py services/model-router/tests/test_observability.py
+git commit -m "feat(router): emit gen_ai.usage metrics alongside the span (OBSERVABILITY_ENABLED)"
+```
+
+---
+
+### Task 5: SLO fast-burn alert rule (model-router error budget) in the monitoring module
+
+**Why:** A burn-rate alert fires when the router's error ratio over a short window is high enough to exhaust a meaningful slice of the error budget fast. We follow the v1.2 rules exactly: `azurerm_monitor_scheduled_query_rules_alert_v2`, count-gated on `local.alerts_enabled`, querying `ContainerAppConsoleLogs_CL` for the router's existing error markers vs. its total request markers. No new variables beyond an opt-in SLO target/threshold pair with safe defaults so `terraform validate` stays clean.
+
+**Files:**
+- Modify: `infrastructure/modules/monitoring/variables.tf`
+- Modify: `infrastructure/modules/monitoring/alerts.tf`
+
+- [ ] **Step 1: Add the SLO variables** — append to `infrastructure/modules/monitoring/variables.tf`:
+
+```hcl
+# ─── SLO burn-rate alerts (model-router availability) ────────────────────────
+# Opt-in alongside the other alert rules (they only exist when alert_emails is
+# non-empty). The burn-rate ratio threshold is unitless: errors / total over the
+# rule's window. Defaults page on a sustained high error fraction; tune per SLO.
+
+variable "router_slo_fast_burn_ratio" {
+  description = "Fast-burn threshold: model-router error fraction (errors / total requests) over PT5M that pages immediately. 0.10 = 10% of requests failing burns the error budget ~14x faster than a 99.9% SLO allows."
+  type        = number
+  default     = 0.10
+}
+
+variable "router_slo_slow_burn_ratio" {
+  description = "Slow-burn threshold: model-router error fraction over PT1H that warns on a slower, sustained budget burn. 0.02 = 2% sustained."
+  type        = number
+  default     = 0.02
+}
+
+variable "router_app_name" {
+  description = "Container App name of the model-router (or its host app, since the router runs as a sidecar) used to scope the SLO log queries. Empty matches across all apps on the router's unique log markers (routing / call_failed)."
+  type        = string
+  default     = ""
+}
+```
+
+- [ ] **Step 2: Add the fast-burn rule** — in `infrastructure/modules/monitoring/alerts.tf`, AFTER the `watchdog_run_failure` resource (ends line 169) and BEFORE the `# ─── Observability workbook ───` section (line 171), first extend the `locals` at the top of the file. Append to the existing `locals { ... }` block (lines 18-28) a router scope filter, mirroring `watchdog_app_filter`:
+
+```hcl
+  # Optional scoping to the model-router's host app. Empty → match across all
+  # apps. The router runs as a sidecar, so this is the host Container App name.
+  router_app_filter = (
+    var.router_app_name != ""
+    ? "| where ContainerAppName_s == \"${var.router_app_name}\""
+    : ""
+  )
+```
+
+Then add the rule:
+
+```hcl
+# ─── SLO: model-router fast error-budget burn ────────────────────────────────
+# Burn-rate alert. Over a short PT5M window, compute the router's error fraction
+# (upstream call failures / total routed requests) and page when it exceeds the
+# fast-burn threshold — a high error fraction is burning the availability error
+# budget far faster than the SLO allows. Error markers: call_failed /
+# primary_failed / fallback_failed. Total marker: "routing" (logged once per
+# request in chat_completions) plus "messages tier=" (the /v1/messages path).
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "router_slo_fast_burn" {
+  count                   = local.alerts_enabled ? 1 : 0
+  name                    = "alert-${var.project}-${var.environment}-router-slo-fast-burn"
+  resource_group_name     = var.resource_group_name
+  location                = var.location
+  description             = "Model-router error-budget FAST burn: the upstream error fraction over the last 5 minutes exceeds the fast-burn SLO threshold. An agent-facing path is degraded and the availability budget is draining quickly."
+  display_name            = "Router SLO: fast error-budget burn (${var.environment})"
+  severity                = 1
+  enabled                 = true
+  evaluation_frequency    = "PT5M"
+  window_duration         = "PT5M"
+  scopes                  = [azurerm_log_analytics_workspace.main.id]
+  auto_mitigation_enabled = false
+
+  criteria {
+    query                   = <<-KQL
+      let errors = ContainerAppConsoleLogs_CL
+        ${local.router_app_filter}
+        | where Log_s has_any ("call_failed", "primary_failed", "fallback_failed")
+        | summarize Errors = count();
+      let total = ContainerAppConsoleLogs_CL
+        ${local.router_app_filter}
+        | where Log_s startswith "routing tier=" or Log_s startswith "messages tier="
+        | summarize Total = count();
+      errors
+      | extend Total = toscalar(total)
+      | extend BurnRatio = iff(Total == 0, 0.0, todouble(Errors) / todouble(Total))
+      | where BurnRatio > ${var.router_slo_fast_burn_ratio}
+      | project BurnRatio, Errors, Total
+    KQL
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.alerts[0].id]
+  }
+
+  tags = var.tags
+}
+```
+
+- [ ] **Step 3: Validate** — from the dev environment, run the same command CI runs:
+
+Run:
+```bash
+cd infrastructure/environments/dev
+terraform init -backend=false
+terraform validate
+```
+Expected: `Success! The configuration is valid.` with default (empty) `alert_emails` — the new resource is count-gated to 0 and the new variables have defaults, so nothing changes in the default footprint.
+
+- [ ] **Step 4: fmt** — run the CI fmt gate so the new HCL is canonical:
+
+Run: `terraform fmt -check -recursive infrastructure`
+Expected: no output (exit 0). If it lists files, run `terraform fmt -recursive infrastructure` and re-check.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infrastructure/modules/monitoring/variables.tf infrastructure/modules/monitoring/alerts.tf
+git commit -m "feat(monitoring): model-router fast-burn SLO alert (opt-in, count-gated)"
+```
+
+---
+
+### Task 6: SLO slow-burn alert rule + module output + dev wiring
+
+**Files:**
+- Modify: `infrastructure/modules/monitoring/alerts.tf`
+- Modify: `infrastructure/environments/dev/variables.tf`
+- Modify: `infrastructure/environments/dev/main.tf`
+
+- [ ] **Step 1: Add the slow-burn rule** — in `infrastructure/modules/monitoring/alerts.tf`, AFTER the `router_slo_fast_burn` resource, add the slow-burn twin (longer window, lower threshold, Sev2):
+
+```hcl
+# ─── SLO: model-router slow error-budget burn ────────────────────────────────
+# The slower companion to the fast-burn rule. Over PT1H, a lower but sustained
+# error fraction still erodes the monthly budget — warn (Sev2) before it
+# becomes an outage. Same markers; longer window, lower threshold.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "router_slo_slow_burn" {
+  count                   = local.alerts_enabled ? 1 : 0
+  name                    = "alert-${var.project}-${var.environment}-router-slo-slow-burn"
+  resource_group_name     = var.resource_group_name
+  location                = var.location
+  description             = "Model-router error-budget SLOW burn: a lower but sustained upstream error fraction over the last hour is steadily eroding the availability budget. Investigate before it escalates to a fast burn."
+  display_name            = "Router SLO: slow error-budget burn (${var.environment})"
+  severity                = 2
+  enabled                 = true
+  evaluation_frequency    = var.alert_evaluation_frequency
+  window_duration         = "PT1H"
+  scopes                  = [azurerm_log_analytics_workspace.main.id]
+  auto_mitigation_enabled = false
+
+  criteria {
+    query                   = <<-KQL
+      let errors = ContainerAppConsoleLogs_CL
+        ${local.router_app_filter}
+        | where Log_s has_any ("call_failed", "primary_failed", "fallback_failed")
+        | summarize Errors = count();
+      let total = ContainerAppConsoleLogs_CL
+        ${local.router_app_filter}
+        | where Log_s startswith "routing tier=" or Log_s startswith "messages tier="
+        | summarize Total = count();
+      errors
+      | extend Total = toscalar(total)
+      | extend BurnRatio = iff(Total == 0, 0.0, todouble(Errors) / todouble(Total))
+      | where BurnRatio > ${var.router_slo_slow_burn_ratio}
+      | project BurnRatio, Errors, Total
+    KQL
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.alerts[0].id]
+  }
+
+  tags = var.tags
+}
+```
+
+- [ ] **Step 2: Add both rule ids to the existing `alert_rule_ids` output** — in `infrastructure/modules/monitoring/alerts.tf`, extend the `alert_rule_ids` output (lines 268-275) so the SLO rules are exported too:
+
+```hcl
+output "alert_rule_ids" {
+  description = "Resource ids of the scheduled-query alert rules (empty when disabled)."
+  value = local.alerts_enabled ? [
+    azurerm_monitor_scheduled_query_rules_alert_v2.watchdog_critical[0].id,
+    azurerm_monitor_scheduled_query_rules_alert_v2.secret_expiry[0].id,
+    azurerm_monitor_scheduled_query_rules_alert_v2.watchdog_run_failure[0].id,
+    azurerm_monitor_scheduled_query_rules_alert_v2.router_slo_fast_burn[0].id,
+    azurerm_monitor_scheduled_query_rules_alert_v2.router_slo_slow_burn[0].id,
+  ] : []
+}
+```
+
+- [ ] **Step 3: Thread the new vars through the dev environment.** In `infrastructure/environments/dev/variables.tf`, after the `enable_observability_workbook` variable (line ~242-246), add:
+
+```hcl
+variable "router_app_name" {
+  description = "Container App name hosting the model-router sidecar, used to scope the SLO burn-rate log queries. Empty matches across all apps on the router's log markers."
+  type        = string
+  default     = ""
+}
+
+variable "router_slo_fast_burn_ratio" {
+  description = "Fast-burn SLO threshold: router error fraction over 5m that pages (Sev1). Default 0.10."
+  type        = number
+  default     = 0.10
+}
+
+variable "router_slo_slow_burn_ratio" {
+  description = "Slow-burn SLO threshold: router error fraction over 1h that warns (Sev2). Default 0.02."
+  type        = number
+  default     = 0.02
+}
+```
+
+Then in `infrastructure/environments/dev/main.tf`, inside the `module "monitoring"` block (after `enable_observability_workbook = var.enable_observability_workbook`, line 183), pass them through:
+
+```hcl
+  router_app_name            = var.router_app_name
+  router_slo_fast_burn_ratio = var.router_slo_fast_burn_ratio
+  router_slo_slow_burn_ratio = var.router_slo_slow_burn_ratio
+```
+
+- [ ] **Step 4: Validate + fmt** (the CI gates):
+
+Run:
+```bash
+cd infrastructure/environments/dev
+terraform init -backend=false
+terraform validate
+cd ../../.. && terraform fmt -check -recursive infrastructure
+```
+Expected: `Success! The configuration is valid.` and `fmt -check` exits 0 with no listed files. Defaults keep `alert_emails = []` → both SLO rules count to 0; footprint unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infrastructure/modules/monitoring/alerts.tf infrastructure/environments/dev/variables.tf infrastructure/environments/dev/main.tf
+git commit -m "feat(monitoring): router slow-burn SLO alert + dev wiring + rule-id output"
+```
+
+---
+
+### Task 7: Docs — README, ROADMAP, and the workbook cost tile
+
+**Files:**
+- Modify: `infrastructure/modules/monitoring/README.md`
+- Modify: `infrastructure/modules/monitoring/alerts.tf` (add a cost-metric workbook tile)
+- Modify: `ROADMAP.md`
+
+- [ ] **Step 1: Add a `gen_ai.usage` cost tile to the workbook** — in `infrastructure/modules/monitoring/alerts.tf`, inside `local.workbook_json`'s `items` array, add one more tile after the existing model-router failures tile (the last item, ends line 246). Application Insights surfaces custom OTel metrics in the `customMetrics` table (Log Analytics export), so the tile charts cumulative cost:
+
+```hcl
+      ,
+      {
+        type = 3
+        content = {
+          version      = "KqlItem/1.0"
+          query        = "customMetrics\n| where name == 'gen_ai.usage.cost_usd'\n| summarize CostUSD = sum(valueSum) by bin(timestamp, 1h), tostring(customDimensions['agent.tier'])\n| render timechart"
+          size         = 0
+          title        = "Model spend by tier (per hour, USD)"
+          timeContext  = { durationMs = 604800000 }
+          queryType    = 0
+          resourceType = "microsoft.operationalinsights/workspaces"
+        }
+      }
+```
+
+> Note the leading `,` — it terminates the prior array element. Verify the array stays valid JSON after the edit (Step 3 `terraform validate` will catch a malformed `jsonencode` input). The `customMetrics` table is the App-Insights name for OTel metrics; the `valueSum` column holds the counter's summed value and `customDimensions` carries the `agent.tier` dimension set in Task 1.
+
+- [ ] **Step 2: Update the module README** — in `infrastructure/modules/monitoring/README.md`:
+
+In the "What it creates" table (lines 9-15), change the alert-rules row count and add the SLO row:
+
+```markdown
+| 5× `azurerm_monitor_scheduled_query_rules_alert_v2` | `alert_emails` non-empty | Watchdog critical / secret expiry / watchdog run failure / router SLO fast-burn / router SLO slow-burn. |
+```
+
+In "The log-marker contract" table (lines 27-32), add a row for the request-volume marker the SLO denominator uses:
+
+```markdown
+| Router request (SLO denominator) | `routing tier=…` / `messages tier=…` | `services/model-router/main.py` |
+```
+
+Add a new section after "Alert semantics":
+
+```markdown
+## SLO burn-rate alerts (model-router)
+
+Two rules compute the router's error fraction — upstream failures
+(`call_failed` / `primary_failed` / `fallback_failed`) over total routed
+requests (`routing tier=` / `messages tier=`) — and fire on a high enough
+ratio:
+
+| Rule | Window | Default threshold | Severity |
+|---|---|---|---|
+| `router_slo_fast_burn` | 5 min | `router_slo_fast_burn_ratio` = 0.10 | Sev1 (page) |
+| `router_slo_slow_burn` | 1 h   | `router_slo_slow_burn_ratio` = 0.02 | Sev2 (warn) |
+
+Tune the ratios to your availability target (e.g. a 99.9% SLO over 30 days has
+a small error budget; 10% of requests failing for 5 minutes is a fast burn).
+Scope the queries to the router's host app with `router_app_name`.
+
+## gen_ai.usage cost metric
+
+When `OBSERVABILITY_ENABLED=true` on the model-router, every call also emits
+aggregatable OpenTelemetry counters — `gen_ai.usage.cost_usd`,
+`gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens` — dimensioned by
+`agent.tier`, `gen_ai.request.model`, and `gen_ai.system`. They ride the same
+Application Insights exporter as the spans (no extra config) and surface in the
+`customMetrics` table. The workbook's "Model spend by tier" tile charts them.
+```
+
+- [ ] **Step 3: Validate the workbook JSON change** (catches a broken tile):
+
+Run:
+```bash
+cd infrastructure/environments/dev
+terraform init -backend=false
+terraform validate
+```
+Expected: `Success! The configuration is valid.` (a malformed `jsonencode` argument would fail here).
+
+- [ ] **Step 4: Update ROADMAP** — in `ROADMAP.md`, move the two items out of "Later" (line 77) into the "v1.3 — shipped" section (after line 70). Replace the "Later" sentence's observability clause so it no longer lists the now-shipped items, and add a shipped bullet:
+
+```markdown
+- **Observability pipeline completed (v1.3.1).** The model-router now also emits aggregatable OpenTelemetry **metrics** — `gen_ai.usage.cost_usd` / `input_tokens` / `output_tokens`, dimensioned by tier/model/system — alongside the v1.3 spans, on the same Application Insights exporter and the same `OBSERVABILITY_ENABLED` flag (default off). The monitoring module gains two opt-in **SLO burn-rate alert rules** (fast 5-min / slow 1-h) over the router's error fraction, count-gated on `alert_emails` like the v1.2 rules, plus a "model spend by tier" workbook tile. `terraform validate` clean; metrics + mapping offline-tested.
+```
+
+And trim the "Later" line to:
+
+```markdown
+Multi-tenant implementation (the [`experimental/multi-tenant/`](experimental/multi-tenant/) design). More chat surfaces.
+```
+
+- [ ] **Step 5: fmt + commit**
+
+```bash
+terraform fmt -check -recursive infrastructure
+git add infrastructure/modules/monitoring/ ROADMAP.md
+git commit -m "docs(observability): cost-metric workbook tile, README SLO section, ROADMAP v1.3.1"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:**
+  - *Item 1 — `gen_ai.usage` cost metric:* Task 1 (low-cardinality dimension mapping, pure + tested) → Task 2 (`_init_meter` off the SAME `configure_azure_monitor` provider the spans use, idempotent, tested) → Task 3 (`observe_genai_metrics` records the three counters, fail-open, clamps negatives, tested) → Task 4 (wired into `observe_genai` so it's co-gated by `OBSERVABILITY_ENABLED` and shares the fail-open boundary; existing observe-genai tests re-run for no regression). DRY: no new exporter/connection string/telemetry stack; reuses `_genai_system`, the 6-dp cost rounding convention, and the same call site (`record_cost` → `observe_genai`).
+  - *Item 2 — SLO burn-rate alerts:* Task 5 (fast-burn, Sev1, PT5M, count-gated on `local.alerts_enabled`) + Task 6 (slow-burn, Sev2, PT1H; module output + dev variable/main wiring). Both follow the exact `azurerm_monitor_scheduled_query_rules_alert_v2` shape, opt-in posture (`alert_emails`-gated, defaulted thresholds), and `ContainerAppConsoleLogs_CL` marker contract of the v1.2 rules; build on the v1.2 alert rules + workbook (Task 7 cost tile + README/ROADMAP).
+- **Placeholder scan:** No `add appropriate X` / `similar to Task N` / TODO left in shipped code. Every step has a concrete pytest body or concrete HCL. The two inherently environment-dependent facts — (a) the exact OTel metrics API/provider behavior and (b) the App-Insights `customMetrics`/`valueSum` table shape for the workbook tile — are de-risked by Task 0's read-only probe and by `terraform validate` respectively, not deferred as code TODOs.
+- **Type consistency:** `genai_metric_attrs(*, tier, model, run_id=None) -> dict[str, str]` is a strict subset of `genai_semconv_attrs`'s output keys; `observe_genai_metrics(...)` takes the identical keyword signature as `observe_genai(...)` so the wiring in Task 4 forwards `**kw` cleanly; counter `.add(amount, attributes=dims)` uses int token deltas and a float USD delta, both clamped `>= 0` (monotonic). On the HCL side, the SLO rules reuse the module's existing var types (`number` thresholds, `string` app name) and the `alerts_enabled` count gate; `alert_rule_ids` stays `list(string)`.
+- **Default-off / opt-in preserved:** metric rides `OBSERVABILITY_ENABLED` (unchanged default false) and emits nothing without `APPLICATIONINSIGHTS_CONNECTION_STRING`; both SLO rules are `count = local.alerts_enabled ? 1 : 0` (zero when `alert_emails` is empty) with defaulted thresholds, so `terraform validate` + `fmt -check` pass on the default empty inputs and the deploy footprint is unchanged for a clean fork.

--- a/docs/notes/plans/2026-06-25-slack-bridge.md
+++ b/docs/notes/plans/2026-06-25-slack-bridge.md
@@ -1,0 +1,1104 @@
+# Slack Bridge — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a flag-gated `slack-bridge` service that brings Slack to parity with the existing Discord / Telegram / Microsoft Teams surfaces — a Slack Events API messaging endpoint that turns inbound Slack messages into Orchestrator/PaperClip issues and replies via `chat.postMessage` — plus the Terraform to deploy it behind a `slack_enabled` variable (internal ingress, KV-stored bot token).
+
+**Architecture:** A near-exact structural mirror of `services/teams-bridge/`. A stateless FastAPI app exposes `POST /slack/events`. Slack delivers inbound traffic as HTTP POSTs carrying a `type`: a `url_verification` handshake (echo the `challenge`) or an `event_callback` whose `event.type == "message"`. The reference's Bot Framework JWT validation is replaced by its Slack analog — **signing-secret HMAC-SHA256 verification** of `X-Slack-Signature` over the `v0:<timestamp>:<raw_body>` basestring, with a `X-Slack-Request-Timestamp` replay window. A `message` event becomes a camelCase PaperClip issue (`surface: slack`); the parse / payload helpers are pure and unit-tested offline; the PaperClip POST is injectable (`issue_poster`) so the endpoint is testable without a live API. The endpoint **never returns 5xx** to Slack — Slack retry-storms on non-2xx — so downstream failures are acked with a body flag. Disabled by default (`var.slack_enabled = false`); internal ingress by design; bot token mounted from Key Vault.
+
+**Tech Stack:** Python 3.12, FastAPI, uvicorn, httpx, `hmac`/`hashlib` (stdlib, for signing-secret verification — NO pyjwt; Slack uses HMAC, not JWT). Tests: `pytest` with `fastapi.testclient.TestClient` + `monkeypatch` (mirrors teams-bridge exactly). Terraform: `azurerm` Container App, UAI + AcrPull + KV Secrets User role assignments, internal ingress.
+
+---
+
+## File structure (mirrors `services/teams-bridge/` file-for-file)
+
+```
+services/slack-bridge/
+├── main.py                 # FastAPI app: /health + /slack/events (challenge, HMAC verify, parse, file, reply)
+├── Dockerfile              # python:3.12-slim, non-root appuser, uvicorn on :3978
+├── requirements.txt        # fastapi, uvicorn[standard], httpx   (NO pyjwt — Slack uses HMAC)
+├── requirements-dev.txt    # -r requirements.txt + pytest
+├── README.md               # service docs (endpoints, env, security note)
+└── tests/
+    └── test_bridge.py      # pytest — pure helpers + endpoint contract + HMAC verification, offline
+
+integrations/slack/
+└── README.md               # end-to-end setup (Slack app, signing secret, bot token, enable, expose)
+
+infrastructure/modules/container-apps/
+├── slack_bridge.tf         # NEW — mirrors teams_bridge.tf (UAI, roles, container app, internal ingress)
+└── variables.tf            # MODIFY — add slack_enabled, slack_bridge_image_tag, slack_orchestrator_agent_id
+```
+
+The Slack analog of teams-bridge's pieces:
+
+| teams-bridge | slack-bridge |
+|---|---|
+| `POST /api/messages` (Bot Framework) | `POST /slack/events` (Slack Events API) |
+| Bot Framework JWT (RS256, JWKS) | Signing-secret HMAC-SHA256 (`X-Slack-Signature`) |
+| `parse_activity` (Bot Framework activity) | `parse_event` (Slack event envelope) |
+| Adaptive Card reply | `chat.postMessage` reply |
+| `url_verification` — n/a | `url_verification` challenge handshake (Slack-specific) |
+| `surface: teams` | `surface: slack` |
+| `TEAMS_APP_ID` / JWKS env | `SLACK_SIGNING_SECRET` / `SLACK_BOT_TOKEN` env |
+
+---
+
+### Task 1: Scaffold the service skeleton (FastAPI app, `/health`, deps, Dockerfile)
+
+**Files:**
+- Create: `services/slack-bridge/main.py`
+- Create: `services/slack-bridge/requirements.txt`
+- Create: `services/slack-bridge/requirements-dev.txt`
+- Create: `services/slack-bridge/Dockerfile`
+- Create: `services/slack-bridge/tests/test_bridge.py`
+
+- [ ] **Step 1: Write the failing test** (`services/slack-bridge/tests/test_bridge.py`)
+
+```python
+"""Offline tests for the Slack bridge — pure helpers + the endpoint contract.
+
+No network: the PaperClip POST is swapped via the injectable `issue_poster`,
+and the Slack reply is swapped via `reply_poster`.
+Run: pip install -r requirements-dev.txt && pytest
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import main  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+client = TestClient(main.app)
+
+
+def test_health():
+    r = client.get("/health")
+    assert r.status_code == 200 and r.json()["surface"] == "slack"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/slack-bridge && python -m pytest -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'main'`.
+
+- [ ] **Step 3: Write `requirements.txt`** (note: NO pyjwt — Slack uses HMAC, which is stdlib)
+
+```
+fastapi>=0.110
+uvicorn[standard]>=0.29
+httpx>=0.27
+```
+
+- [ ] **Step 4: Write `requirements-dev.txt`**
+
+```
+-r requirements.txt
+pytest>=8.0
+```
+
+- [ ] **Step 5: Write the minimal `main.py`** (app + `/health` only; handlers land in Tasks 2–5)
+
+```python
+"""Slack bridge (AzureAgentForge) — Slack chat surface.
+
+A minimal Slack Events API messaging endpoint that bridges Slack to the agent
+platform, at parity with the Discord plugin, the Telegram gateway, and the
+Teams bridge: an inbound Slack message becomes a PaperClip issue routed to the
+Orchestrator, and the agent's reply returns to the channel via chat.postMessage.
+Disabled by default; enable with the `slack_enabled` Terraform variable.
+
+The parse / payload helpers are pure and unit-tested offline. The PaperClip POST
+is injectable (`issue_poster`) and the Slack reply is injectable (`reply_poster`)
+so the endpoint is testable without a live API, and the endpoint NEVER returns
+5xx to Slack (that triggers an aggressive retry storm) — failures are acked with
+a body flag.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Callable, Optional
+
+import httpx
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, PlainTextResponse
+
+PAPERCLIP_API_URL = os.getenv("PAPERCLIP_API_URL", "http://paperclip:3000")
+PAPERCLIP_COMPANY_ID = os.getenv("PAPERCLIP_COMPANY_ID", "")
+PAPERCLIP_API_KEY = os.getenv("PAPERCLIP_API_KEY", "")
+ORCHESTRATOR_AGENT_ID = os.getenv("ORCHESTRATOR_AGENT_ID", "")
+
+app = FastAPI(title="slack-bridge", version="1.0.0")
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok", "surface": "slack"}
+```
+
+- [ ] **Step 6: Write the `Dockerfile`** (mirrors teams-bridge — `python:3.12-slim`, non-root, uvicorn on :3978)
+
+```dockerfile
+# Slack bridge — Slack chat surface (Slack Events API messaging endpoint).
+# Disabled by default; deployed only when the `slack_enabled` Terraform variable
+# is true. Bridges inbound Slack messages to PaperClip issues and replies via
+# chat.postMessage. Stateless FastAPI app behind ACA internal ingress.
+
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+
+RUN useradd --uid 1001 --create-home appuser
+COPY --chown=appuser:appuser main.py /app/main.py
+USER appuser
+
+# Same conventional messaging port as the Teams bridge for a uniform ingress shape.
+EXPOSE 3978
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "3978"]
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `cd services/slack-bridge && pip install -r requirements-dev.txt && python -m pytest -q`
+Expected: PASS (1 test).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add services/slack-bridge/
+git commit -m "feat(slack-bridge): scaffold FastAPI service skeleton + /health"
+```
+
+---
+
+### Task 2: `parse_event` — pull the routable bits from a Slack event envelope
+
+**Files:**
+- Modify: `services/slack-bridge/main.py`
+- Modify: `services/slack-bridge/tests/test_bridge.py`
+
+Slack `event_callback` envelopes wrap the inner event in `event`. We route only
+`message` events with non-empty text, and we **drop bot/self messages** (any
+envelope carrying `bot_id`, or `subtype` set — `bot_message`, `message_changed`,
+etc.) so the bridge never loops on its own `chat.postMessage` replies.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# ── parse_event ──────────────────────────────────────────────────────────────
+
+def test_parse_event_extracts_fields():
+    body = {
+        "type": "event_callback",
+        "team_id": "T123",
+        "event": {
+            "type": "message",
+            "text": "  deploy the staging stack  ",
+            "user": "U99",
+            "channel": "C42",
+            "ts": "1700000000.000100",
+        },
+    }
+    parsed = main.parse_event(body)
+    assert parsed == {
+        "text": "deploy the staging stack",
+        "user": "U99",
+        "channel": "C42",
+        "ts": "1700000000.000100",
+        "team_id": "T123",
+    }
+
+
+def test_parse_event_ignores_non_message_and_empty():
+    assert main.parse_event({"type": "event_callback", "event": {"type": "reaction_added"}}) is None
+    assert main.parse_event({"type": "event_callback", "event": {"type": "message", "text": "   "}}) is None
+    assert main.parse_event({"type": "url_verification", "challenge": "x"}) is None
+    assert main.parse_event("not a dict") is None
+    assert main.parse_event({}) is None
+
+
+def test_parse_event_drops_bot_and_subtyped_messages():
+    # Never re-ingest our own chat.postMessage replies, edits, or joins.
+    assert main.parse_event({"type": "event_callback",
+                             "event": {"type": "message", "text": "hi", "bot_id": "B1"}}) is None
+    assert main.parse_event({"type": "event_callback",
+                             "event": {"type": "message", "text": "hi", "subtype": "message_changed"}}) is None
+
+
+def test_parse_event_falls_back_to_default_user():
+    p = main.parse_event({"type": "event_callback",
+                          "event": {"type": "message", "text": "hi", "channel": "C1", "ts": "1.1"}})
+    assert p["user"] == "slack-user"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/slack-bridge && python -m pytest -q -k parse_event`
+Expected: FAIL — `AttributeError: module 'main' has no attribute 'parse_event'`.
+
+- [ ] **Step 3: Write the implementation** (add to `main.py`)
+
+```python
+def parse_event(body: Any) -> Optional[dict]:
+    """Pull the routable bits from a Slack Events API envelope. Returns None for
+    anything that isn't a non-empty user `message` (reactions, joins, the
+    url_verification handshake, …), and for bot/self or subtyped messages, so
+    those are silently acked and ignored (and we never loop on our own replies)."""
+    if not isinstance(body, dict) or body.get("type") != "event_callback":
+        return None
+    event = body.get("event") or {}
+    if event.get("type") != "message":
+        return None
+    # Drop our own bot replies and edits/joins/etc. to avoid feedback loops.
+    if event.get("bot_id") or event.get("subtype"):
+        return None
+    text = (event.get("text") or "").strip()
+    if not text:
+        return None
+    return {
+        "text": text,
+        "user": event.get("user") or "slack-user",
+        "channel": event.get("channel") or "",
+        "ts": event.get("ts") or "",
+        "team_id": body.get("team_id") or "",
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd services/slack-bridge && python -m pytest -q -k parse_event`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/slack-bridge/main.py services/slack-bridge/tests/test_bridge.py
+git commit -m "feat(slack-bridge): parse_event extracts routable message fields, drops bot/self"
+```
+
+---
+
+### Task 3: `build_issue_payload` — the camelCase PaperClip issue an inbound Slack message creates
+
+**Files:**
+- Modify: `services/slack-bridge/main.py`
+- Modify: `services/slack-bridge/tests/test_bridge.py`
+
+camelCase matters — the PaperClip API's validation drops snake_case fields (same
+constraint as teams-bridge).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# ── build_issue_payload ──────────────────────────────────────────────────────
+
+def test_build_issue_payload_is_camelcase_and_tagged():
+    parsed = {"text": "x" * 200, "user": "U7", "channel": "C9", "ts": "1.2", "team_id": "T1"}
+    p = main.build_issue_payload(parsed, "co-1", agent_id="agent-9")
+    assert p["companyId"] == "co-1"            # camelCase, not company_id
+    assert p["assigneeId"] == "agent-9"
+    assert p["status"] == "todo"
+    assert len(p["title"]) == 120              # truncated
+    assert p["metadata"] == {"surface": "slack", "channel": "C9", "ts": "1.2"}
+    assert "via Slack — U7" in p["description"]
+
+
+def test_build_issue_payload_omits_assignee_when_unset():
+    p = main.build_issue_payload(
+        {"text": "t", "user": "u", "channel": "", "ts": "", "team_id": ""}, "co")
+    assert "assigneeId" not in p
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/slack-bridge && python -m pytest -q -k build_issue_payload`
+Expected: FAIL — no `build_issue_payload`.
+
+- [ ] **Step 3: Write the implementation** (add to `main.py`)
+
+```python
+def build_issue_payload(parsed: dict, company_id: str, agent_id: str = "") -> dict:
+    """The camelCase PaperClip issue an inbound Slack message creates (camelCase
+    matters — the API's validation drops snake_case fields)."""
+    payload: dict = {
+        "title": parsed["text"][:120],
+        "description": (
+            f"{parsed['text']}\n\n"
+            f"_via Slack — {parsed['user']} "
+            f"(channel `{parsed['channel']}`)_"
+        ),
+        "status": "todo",
+        "companyId": company_id,
+        "metadata": {"surface": "slack", "channel": parsed["channel"], "ts": parsed["ts"]},
+    }
+    if agent_id:
+        payload["assigneeId"] = agent_id
+    return payload
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd services/slack-bridge && python -m pytest -q -k build_issue_payload`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/slack-bridge/main.py services/slack-bridge/tests/test_bridge.py
+git commit -m "feat(slack-bridge): build_issue_payload (camelCase, surface=slack)"
+```
+
+---
+
+### Task 4: Signing-secret HMAC verification (the Slack analog of Bot Framework JWT)
+
+**Files:**
+- Modify: `services/slack-bridge/main.py`
+- Modify: `services/slack-bridge/tests/test_bridge.py`
+
+Slack signs every request: `X-Slack-Signature = "v0=" + HMAC_SHA256(signing_secret,
+"v0:" + X-Slack-Request-Timestamp + ":" + raw_body)`. We verify the signature
+with a **constant-time compare** and reject stale timestamps (replay window,
+default 300s). Enforced when `SLACK_SIGNING_SECRET` is set; with it unset the
+endpoint is unauthenticated (local/dev only) and logs a warning.
+`SLACK_AUTH_DISABLED=1` is an explicit local escape — mirrors teams-bridge's
+`authenticate()` contract exactly, including the warning and the env escape.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# ── Slack signing-secret HMAC verification ───────────────────────────────────
+
+import hashlib  # noqa: E402
+import hmac  # noqa: E402
+import time  # noqa: E402
+
+import pytest  # noqa: E402
+
+_SECRET = "8f742231b10e8888abcd99yyyzzz85a5"
+
+
+def _sign(secret: str, ts: str, body: bytes) -> str:
+    base = b"v0:" + ts.encode() + b":" + body
+    digest = hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+    return "v0=" + digest
+
+
+def test_verify_signature_accepts_valid():
+    ts = str(int(time.time()))
+    body = b'{"type":"event_callback"}'
+    sig = _sign(_SECRET, ts, body)
+    assert main.verify_signature(_SECRET, ts, body, sig) is True
+
+
+def test_verify_signature_rejects_tampered_body():
+    ts = str(int(time.time()))
+    sig = _sign(_SECRET, ts, b'{"type":"event_callback"}')
+    assert main.verify_signature(_SECRET, ts, b'{"type":"evil"}', sig) is False
+
+
+def test_verify_signature_rejects_wrong_secret():
+    ts = str(int(time.time()))
+    body = b"x"
+    sig = _sign("the-real-secret", ts, body)
+    assert main.verify_signature(_SECRET, ts, body, sig) is False
+
+
+def test_verify_signature_rejects_stale_timestamp():
+    ts = str(int(time.time()) - 1000)  # 1000s old, beyond the 300s window
+    body = b"x"
+    sig = _sign(_SECRET, ts, body)
+    assert main.verify_signature(_SECRET, ts, body, sig) is False
+
+
+def test_verify_signature_rejects_malformed_header():
+    ts = str(int(time.time()))
+    assert main.verify_signature(_SECRET, ts, b"x", "") is False
+    assert main.verify_signature(_SECRET, ts, b"x", "garbage") is False
+
+
+def test_authenticate_noop_when_unconfigured(monkeypatch):
+    monkeypatch.setattr(main, "SLACK_SIGNING_SECRET", "")
+    monkeypatch.setattr(main, "SLACK_AUTH_DISABLED", False)
+    main.authenticate("ts", b"body", "")  # warns, does not raise
+
+
+def test_authenticate_raises_when_required_and_bad(monkeypatch):
+    monkeypatch.setattr(main, "SLACK_SIGNING_SECRET", _SECRET)
+    monkeypatch.setattr(main, "SLACK_AUTH_DISABLED", False)
+    with pytest.raises(main.AuthError):
+        main.authenticate(str(int(time.time())), b"body", "v0=deadbeef")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/slack-bridge && python -m pytest -q -k "signature or authenticate"`
+Expected: FAIL — no `verify_signature` / `authenticate` / `AuthError`.
+
+- [ ] **Step 3: Write the implementation** (add to `main.py`, near the top imports add `hashlib`, `hmac`, `time`)
+
+```python
+import hashlib
+import hmac
+import time
+
+# ── Slack signing-secret verification ────────────────────────────────────────
+# Inbound Slack traffic carries an `X-Slack-Signature` HMAC-SHA256 over
+# "v0:<X-Slack-Request-Timestamp>:<raw_body>" keyed by the app's signing secret.
+# Verify it before acting on the event: constant-time digest compare + a replay
+# window on the timestamp. Enforced when SLACK_SIGNING_SECRET is set; with it
+# unset the endpoint is unauthenticated (local/dev only) and logs a warning.
+# SLACK_AUTH_DISABLED=1 is an explicit local escape.
+SLACK_SIGNING_SECRET = os.getenv("SLACK_SIGNING_SECRET", "")
+SLACK_AUTH_DISABLED = os.getenv("SLACK_AUTH_DISABLED", "").lower() in ("1", "true", "yes")
+SLACK_REPLAY_WINDOW_SECONDS = int(os.getenv("SLACK_REPLAY_WINDOW_SECONDS", "300"))
+
+
+class AuthError(Exception):
+    """Raised when an inbound request fails Slack signing-secret verification."""
+
+
+def verify_signature(secret: str, timestamp: str, raw_body: bytes, signature: str,
+                     *, window: int = SLACK_REPLAY_WINDOW_SECONDS,
+                     now: Optional[float] = None) -> bool:
+    """Validate a Slack request signature. Pure (no network). Checks the HMAC-SHA256
+    digest with a constant-time compare and rejects stale timestamps (replay
+    window). Returns True only on a fully valid, fresh signature."""
+    if not secret or not signature.startswith("v0="):
+        return False
+    try:
+        ts = int(timestamp)
+    except (TypeError, ValueError):
+        return False
+    current = int(now if now is not None else time.time())
+    if abs(current - ts) > window:
+        return False
+    base = b"v0:" + timestamp.encode() + b":" + raw_body
+    expected = "v0=" + hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature)
+
+
+def authenticate(timestamp: str, raw_body: bytes, signature: str) -> None:
+    """Enforce Slack signing-secret auth on an inbound request when configured.
+    No-op (with a warning) when SLACK_SIGNING_SECRET is unset, or when
+    SLACK_AUTH_DISABLED. Raises AuthError on a bad/stale signature."""
+    if SLACK_AUTH_DISABLED:
+        return
+    if not SLACK_SIGNING_SECRET:
+        print("[slack-bridge] WARNING: SLACK_SIGNING_SECRET unset — /slack/events is "
+              "UNAUTHENTICATED. Set SLACK_SIGNING_SECRET (the Slack app's signing "
+              "secret) before exposing this endpoint.")
+        return
+    if not verify_signature(SLACK_SIGNING_SECRET, timestamp, raw_body, signature):
+        raise AuthError("invalid or stale Slack signature")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd services/slack-bridge && python -m pytest -q -k "signature or authenticate"`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/slack-bridge/main.py services/slack-bridge/tests/test_bridge.py
+git commit -m "feat(slack-bridge): signing-secret HMAC verification + replay window"
+```
+
+---
+
+### Task 5: The `/slack/events` endpoint — challenge handshake, verify, file, reply
+
+**Files:**
+- Modify: `services/slack-bridge/main.py`
+- Modify: `services/slack-bridge/tests/test_bridge.py`
+
+The endpoint must, in order: (1) answer the `url_verification` challenge **before**
+auth (Slack sends it during app setup; it's signed, but answering the plaintext
+challenge is the documented handshake) — actually we verify the signature first
+since it's present on every request, then branch; (2) verify the HMAC; (3) parse;
+(4) file the PaperClip issue via the injectable `issue_poster`; (5) reply via the
+injectable `reply_poster` (`chat.postMessage`); (6) **never 5xx** — Slack
+retry-storms on non-2xx, so downstream failures ack `200 {"queued": false}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# ── reply (chat.postMessage) ─────────────────────────────────────────────────
+
+def test_build_reply_payload():
+    p = main.build_reply_payload("C42", "done ✅")
+    assert p == {"channel": "C42", "text": "done ✅"}
+
+
+# ── endpoint contract ────────────────────────────────────────────────────────
+
+def _post(body: bytes, *, signed=True, ts=None):
+    import json as _json
+    ts = ts or str(int(time.time()))
+    headers = {"Content-Type": "application/json"}
+    if signed:
+        headers["X-Slack-Request-Timestamp"] = ts
+        headers["X-Slack-Signature"] = _sign(_SECRET, ts, body)
+    return client.post("/slack/events", content=body, headers=headers)
+
+
+def test_url_verification_echoes_challenge(monkeypatch):
+    monkeypatch.setattr(main, "SLACK_SIGNING_SECRET", _SECRET)
+    monkeypatch.setattr(main, "SLACK_AUTH_DISABLED", False)
+    body = b'{"type":"url_verification","challenge":"abc123"}'
+    r = _post(body)
+    assert r.status_code == 200 and r.json() == {"challenge": "abc123"}
+
+
+def test_message_creates_issue_and_replies(monkeypatch):
+    monkeypatch.setattr(main, "SLACK_SIGNING_SECRET", _SECRET)
+    monkeypatch.setattr(main, "SLACK_AUTH_DISABLED", False)
+    seen, replied = {}, {}
+    monkeypatch.setattr(main, "issue_poster", lambda payload: seen.update(payload) or 201)
+    monkeypatch.setattr(main, "reply_poster", lambda channel, text: replied.update({"channel": channel, "text": text}) or 200)
+    body = b'{"type":"event_callback","team_id":"T1","event":{"type":"message","text":"run the audit","user":"U7","channel":"C42","ts":"1.1"}}'
+    r = _post(body)
+    assert r.status_code == 200 and r.json()["queued"] is True
+    assert seen["title"] == "run the audit"
+    assert replied["channel"] == "C42"
+
+
+def test_non_message_event_is_ignored_with_200(monkeypatch):
+    monkeypatch.setattr(main, "SLACK_SIGNING_SECRET", _SECRET)
+    monkeypatch.setattr(main, "SLACK_AUTH_DISABLED", False)
+    monkeypatch.setattr(main, "issue_poster", lambda p: (_ for _ in ()).throw(AssertionError("should not post")))
+    body = b'{"type":"event_callback","event":{"type":"reaction_added"}}'
+    r = _post(body)
+    assert r.status_code == 200 and r.json()["ignored"] is True
+
+
+def test_bad_signature_returns_401(monkeypatch):
+    monkeypatch.setattr(main, "SLACK_SIGNING_SECRET", _SECRET)
+    monkeypatch.setattr(main, "SLACK_AUTH_DISABLED", False)
+    body = b'{"type":"event_callback","event":{"type":"message","text":"hi","channel":"C","ts":"1"}}'
+    ts = str(int(time.time()))
+    r = client.post("/slack/events", content=body, headers={
+        "X-Slack-Request-Timestamp": ts, "X-Slack-Signature": "v0=deadbeef"})
+    assert r.status_code == 401
+
+
+def test_poster_failure_never_5xxes_slack(monkeypatch):
+    monkeypatch.setattr(main, "SLACK_SIGNING_SECRET", _SECRET)
+    monkeypatch.setattr(main, "SLACK_AUTH_DISABLED", False)
+    def boom(_):
+        raise RuntimeError("paperclip down")
+    monkeypatch.setattr(main, "issue_poster", boom)
+    monkeypatch.setattr(main, "reply_poster", lambda c, t: 200)
+    body = b'{"type":"event_callback","event":{"type":"message","text":"hi","channel":"C","ts":"1"}}'
+    r = _post(body)
+    assert r.status_code == 200 and r.json()["queued"] is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/slack-bridge && python -m pytest -q`
+Expected: FAIL — no `build_reply_payload` / `reply_poster` / `/slack/events`.
+
+- [ ] **Step 3: Write the implementation** (add to `main.py`)
+
+```python
+def build_reply_payload(channel: str, text: str) -> dict:
+    """The chat.postMessage body the bridge posts back to the Slack channel."""
+    return {"channel": channel, "text": text}
+
+
+def _post_issue(payload: dict) -> int:
+    """Default issue poster — POST to the PaperClip API. Returns the status code."""
+    headers = {"Content-Type": "application/json"}
+    if PAPERCLIP_API_KEY:
+        headers["Authorization"] = f"Bearer {PAPERCLIP_API_KEY}"
+    resp = httpx.post(
+        f"{PAPERCLIP_API_URL}/api/issues", json=payload, headers=headers, timeout=10.0
+    )
+    return resp.status_code
+
+
+def _post_reply(channel: str, text: str) -> int:
+    """Default Slack reply — POST chat.postMessage with the bot token. Status code."""
+    headers = {
+        "Content-Type": "application/json; charset=utf-8",
+        "Authorization": f"Bearer {SLACK_BOT_TOKEN}",
+    }
+    resp = httpx.post(
+        f"{SLACK_API_URL}/chat.postMessage",
+        json=build_reply_payload(channel, text), headers=headers, timeout=10.0,
+    )
+    return resp.status_code
+
+
+# Injectable for tests; production uses the real posters.
+issue_poster: Callable[[dict], int] = _post_issue
+reply_poster: Callable[[str, str], int] = _post_reply
+
+
+@app.post("/slack/events")
+async def slack_events(request: Request) -> Any:
+    raw = await request.body()
+    timestamp = request.headers.get("x-slack-request-timestamp", "")
+    signature = request.headers.get("x-slack-signature", "")
+    # Verify the signing-secret HMAC first (401, not 5xx — Slack retry-storms on 5xx).
+    try:
+        authenticate(timestamp, raw, signature)
+    except AuthError:
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+    body = await request.json()
+    # Slack app-setup handshake: echo the plaintext challenge.
+    if isinstance(body, dict) and body.get("type") == "url_verification":
+        return JSONResponse({"challenge": body.get("challenge", "")}, status_code=200)
+    parsed = parse_event(body)
+    if parsed is None:
+        return JSONResponse({"ignored": True}, status_code=200)
+    payload = build_issue_payload(parsed, PAPERCLIP_COMPANY_ID, ORCHESTRATOR_AGENT_ID)
+    try:
+        code = issue_poster(payload)
+    except Exception:  # noqa: BLE001 — never 5xx to Slack; it retry-storms
+        return JSONResponse({"queued": False, "error": "bridge_post_failed"}, status_code=200)
+    queued = 200 <= code < 300
+    # Best-effort ack back into the channel; a reply failure must not 5xx either.
+    try:
+        reply_poster(parsed["channel"], "Got it — filed for the Orchestrator. 🛠️" if queued
+                     else "Couldn't file that just now; please retry.")
+    except Exception:  # noqa: BLE001
+        pass
+    return JSONResponse({"queued": queued, "issueStatus": code}, status_code=200)
+```
+
+Also add the two Slack config constants near the other env reads at the top of `main.py`:
+
+```python
+SLACK_BOT_TOKEN = os.getenv("SLACK_BOT_TOKEN", "")
+SLACK_API_URL = os.getenv("SLACK_API_URL", "https://slack.com/api")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd services/slack-bridge && python -m pytest -q`
+Expected: PASS (full suite: 1 health + 4 parse + 2 payload + 7 auth + 1 reply + 5 endpoint = 20 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/slack-bridge/main.py services/slack-bridge/tests/test_bridge.py
+git commit -m "feat(slack-bridge): /slack/events — challenge, HMAC, file issue, reply"
+```
+
+---
+
+### Task 6: Service README + integration docs
+
+**Files:**
+- Create: `services/slack-bridge/README.md`
+- Create: `integrations/slack/README.md`
+
+- [ ] **Step 1: Write `services/slack-bridge/README.md`**
+
+````markdown
+# Slack bridge
+
+A small FastAPI service that bridges **Slack** to the agent platform, at parity
+with the [Discord plugin](../../integrations/discord/), the
+[Telegram gateway](../../integrations/telegram/), and the
+[Teams bridge](../teams-bridge/): an inbound Slack message becomes a PaperClip
+issue routed to the Orchestrator, and the agent's reply returns to the channel
+via `chat.postMessage`.
+
+Disabled by default. Enable with the `slack_enabled` Terraform variable. See
+[`integrations/slack/`](../../integrations/slack/) for the end-to-end setup.
+
+## Endpoints
+
+| Method | Path             | Purpose                                                                 |
+|--------|------------------|-------------------------------------------------------------------------|
+| `GET`  | `/health`        | Liveness.                                                               |
+| `POST` | `/slack/events`  | Slack Events API endpoint. Answers the `url_verification` challenge; a `message` event becomes a PaperClip issue; non-`message`/bot/subtyped events are acked and ignored. |
+
+The endpoint **never returns 5xx** to Slack (that triggers an aggressive retry
+storm) — a downstream failure is acked with `{"queued": false}`.
+
+## Configuration (env)
+
+| Variable | Purpose |
+|---|---|
+| `PAPERCLIP_API_URL` | PaperClip base URL (default `http://paperclip:3000`). |
+| `PAPERCLIP_COMPANY_ID` | Company the inbound issue is filed under. |
+| `PAPERCLIP_API_KEY` | Bearer token for the PaperClip API (mounted from Key Vault). |
+| `ORCHESTRATOR_AGENT_ID` | Optional — route Slack messages straight to one agent. |
+| `SLACK_SIGNING_SECRET` | Slack app signing secret — HMAC-verifies inbound requests (mounted from Key Vault). |
+| `SLACK_BOT_TOKEN` | Bot token (`xoxb-…`) for `chat.postMessage` replies (mounted from Key Vault). |
+| `SLACK_REPLAY_WINDOW_SECONDS` | Replay window for the request timestamp (default `300`). |
+
+## Security — read before enabling
+
+The container's ingress is **internal** by design, so flipping `slack_enabled`
+never publishes an unauthenticated event-ingest endpoint on its own. To take it
+live you must:
+
+1. **Expose `/slack/events`** to Slack through the platform's Cloudflare tunnel
+   (the same path PaperClip uses for public ingress).
+2. **Set `SLACK_SIGNING_SECRET`** so the bridge HMAC-verifies the
+   `X-Slack-Signature` on every request. With it unset the endpoint logs a
+   warning and trusts the body — local/dev only.
+
+## Tests
+
+```bash
+pip install -r requirements-dev.txt
+pytest            # 20 offline tests — pure helpers, HMAC verification, the endpoint contract, no network
+```
+````
+
+- [ ] **Step 2: Write `integrations/slack/README.md`** (mirrors `integrations/teams/README.md` structure: Overview, Prerequisites, Setup steps, How it routes, Verify)
+
+```markdown
+# Slack Integration
+
+## Overview
+
+The Slack integration lets users talk to the agent platform from a Slack
+channel. Messages flow from Slack → the **slack-bridge** service
+([`services/slack-bridge`](../../services/slack-bridge/)) → a PaperClip issue →
+the Orchestrator; the agent's reply returns to the channel via
+`chat.postMessage`. It is at parity with the Discord, Telegram, and Teams
+surfaces. **Disabled by default** — opt in via the `slack_enabled` Terraform
+variable.
+
+## Prerequisites
+
+- A Slack workspace where you can create and install a Slack app.
+- An Azure Key Vault provisioned by the platform.
+- Azure CLI authenticated to the target subscription.
+
+## Setup
+
+### 1. Create a Slack app
+
+1. At <https://api.slack.com/apps> create an app (from scratch).
+2. **OAuth & Permissions** → add bot scopes `chat:write` and `channels:history`
+   (and `groups:history` for private channels), then **Install to Workspace**
+   and copy the **Bot User OAuth Token** (`xoxb-…`).
+3. **Basic Information** → copy the **Signing Secret**.
+4. **Event Subscriptions** → enable, set the **Request URL** to your public
+   bridge URL `https://<your-public-host>/slack/events` (Slack sends the
+   `url_verification` challenge here), and subscribe to the bot event
+   `message.channels` (and `message.groups` for private channels).
+
+### 2. Store the credentials in Key Vault
+
+```bash
+az keyvault secret set --vault-name <your-key-vault-name> \
+  --name slack-bot-token --value "<xoxb-...>"
+az keyvault secret set --vault-name <your-key-vault-name> \
+  --name slack-signing-secret --value "<signing-secret>"
+```
+
+### 3. Enable the surface
+
+```hcl
+# dev.auto.tfvars (or your environment's tfvars)
+slack_enabled               = true
+slack_orchestrator_agent_id = ""   # optional — route Slack messages to one agent
+```
+
+```bash
+terraform plan   # adds ca-slack-bridge-<env> (internal ingress)
+terraform apply
+```
+
+### 4. Expose the events endpoint (required, not automatic)
+
+The bridge ingress is **internal**. Route `/slack/events` to Slack through the
+platform's Cloudflare tunnel (the same pattern PaperClip uses), and make sure
+`SLACK_SIGNING_SECRET` is set so the bridge HMAC-verifies every request — see the
+[service README security note](../../services/slack-bridge/README.md#security--read-before-enabling).
+Enabling the variable alone never exposes an unauthenticated ingest endpoint.
+
+## How it routes
+
+| Slack event | Bridge behavior |
+|---|---|
+| `url_verification` | Echoes the `challenge` (app-setup handshake). |
+| `message` (non-empty text, not bot/self/subtyped) | Files a PaperClip issue (`surface: slack`, the channel + ts in metadata) for the Orchestrator and acks into the channel. |
+| reactions, joins, bot/self, subtyped, empty text | Acked with `200` and ignored. |
+| Downstream PaperClip failure | Acked with `200 {"queued": false}` — never 5xx, which would make Slack retry-storm. |
+
+## Verify
+
+```bash
+cd services/slack-bridge && pip install -r requirements-dev.txt && pytest
+```
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add services/slack-bridge/README.md integrations/slack/README.md
+git commit -m "docs(slack-bridge): service + integration README"
+```
+
+---
+
+### Task 7: Terraform — `slack_bridge.tf` + the `slack_enabled` variable (default-off)
+
+**Files:**
+- Create: `infrastructure/modules/container-apps/slack_bridge.tf`
+- Modify: `infrastructure/modules/container-apps/variables.tf`
+
+Mirrors `teams_bridge.tf` exactly: a user-assigned identity, AcrPull +
+KV-Secrets-User role assignments, an internal-ingress Container App, all
+`count`-gated on `var.slack_enabled`. Adds the two Slack KV secrets
+(`slack-signing-secret`, `slack-bot-token`) alongside the shared
+`paperclip-automation-jwt-secret`.
+
+- [ ] **Step 1: Add the variables** to `infrastructure/modules/container-apps/variables.tf` (place after the `teams_orchestrator_agent_id` block to keep the chat-surface vars together):
+
+```hcl
+variable "slack_enabled" {
+  type        = bool
+  description = "Enable the Slack chat surface (services/slack-bridge Slack Events API endpoint). Internal ingress — expose via the Cloudflare tunnel + set SLACK_SIGNING_SECRET before go-live."
+  default     = false
+}
+
+variable "slack_bridge_image_tag" {
+  type        = string
+  description = "Image tag for the slack-bridge container."
+  default     = "latest"
+}
+
+variable "slack_orchestrator_agent_id" {
+  type        = string
+  description = "Optional agent id to route inbound Slack messages to (the Orchestrator). Empty → PaperClip default routing."
+  default     = ""
+}
+```
+
+- [ ] **Step 2: Write `infrastructure/modules/container-apps/slack_bridge.tf`**
+
+```hcl
+# Slack bridge — Slack chat surface (services/slack-bridge).
+#
+# A Slack Events API messaging endpoint that turns inbound Slack messages into
+# PaperClip issues for the Orchestrator and replies via chat.postMessage — at
+# parity with the Discord plugin, the Telegram gateway, and the Teams bridge.
+# Gated OFF by default (var.slack_enabled = false); when enabled it's a small
+# stateless FastAPI app.
+#
+# SECURITY: ingress is INTERNAL by design. Expose /slack/events to Slack through
+# the platform's Cloudflare tunnel (the same pattern PaperClip uses for public
+# ingress), and set SLACK_SIGNING_SECRET so the bridge HMAC-verifies every
+# request before going live (called out in services/slack-bridge/README.md).
+# Keeping it internal means enabling the variable never exposes an
+# unauthenticated event-ingest endpoint on its own.
+
+resource "azurerm_user_assigned_identity" "slack_bridge" {
+  count               = var.slack_enabled ? 1 : 0
+  name                = "id-slack-bridge-${var.environment}"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  tags                = var.tags
+}
+
+resource "azurerm_role_assignment" "slack_bridge_acr_pull" {
+  count                = var.slack_enabled ? 1 : 0
+  scope                = var.container_registry_id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_user_assigned_identity.slack_bridge[0].principal_id
+}
+
+resource "azurerm_role_assignment" "slack_bridge_kv_reader" {
+  count                = var.slack_enabled ? 1 : 0
+  scope                = var.key_vault_id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_user_assigned_identity.slack_bridge[0].principal_id
+}
+
+resource "azurerm_container_app" "slack_bridge" {
+  count                        = var.slack_enabled ? 1 : 0
+  name                         = "ca-slack-bridge-${var.environment}"
+  container_app_environment_id = local.container_app_environment_id
+  resource_group_name          = var.resource_group_name
+  revision_mode                = "Single"
+  workload_profile_name        = "Consumption"
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.slack_bridge[0].id]
+  }
+
+  registry {
+    server   = var.container_registry_login_server
+    identity = azurerm_user_assigned_identity.slack_bridge[0].id
+  }
+
+  # The bridge attaches this as the bearer token when creating PaperClip issues.
+  secret {
+    name                = "paperclip-automation-jwt-secret"
+    key_vault_secret_id = "${var.key_vault_uri}secrets/paperclip-automation-jwt-secret"
+    identity            = azurerm_user_assigned_identity.slack_bridge[0].id
+  }
+
+  # Slack app signing secret — HMAC-verifies inbound /slack/events requests.
+  secret {
+    name                = "slack-signing-secret"
+    key_vault_secret_id = "${var.key_vault_uri}secrets/slack-signing-secret"
+    identity            = azurerm_user_assigned_identity.slack_bridge[0].id
+  }
+
+  # Bot token (xoxb-…) for chat.postMessage replies.
+  secret {
+    name                = "slack-bot-token"
+    key_vault_secret_id = "${var.key_vault_uri}secrets/slack-bot-token"
+    identity            = azurerm_user_assigned_identity.slack_bridge[0].id
+  }
+
+  template {
+    min_replicas = 1
+    max_replicas = 1
+
+    container {
+      name   = "slack-bridge"
+      image  = "${var.container_registry_login_server}/slack-bridge:${var.slack_bridge_image_tag}"
+      cpu    = 0.25
+      memory = "0.5Gi"
+
+      env {
+        name  = "PAPERCLIP_API_URL"
+        value = "http://ca-paperclip-${var.environment}"
+      }
+      env {
+        name  = "PAPERCLIP_COMPANY_ID"
+        value = var.paperclip_company_id
+      }
+      env {
+        name        = "PAPERCLIP_API_KEY"
+        secret_name = "paperclip-automation-jwt-secret"
+      }
+      env {
+        name        = "SLACK_SIGNING_SECRET"
+        secret_name = "slack-signing-secret"
+      }
+      env {
+        name        = "SLACK_BOT_TOKEN"
+        secret_name = "slack-bot-token"
+      }
+      env {
+        # Optional: route Slack messages straight to a specific agent (the
+        # Orchestrator). Empty → PaperClip's default routing applies.
+        name  = "ORCHESTRATOR_AGENT_ID"
+        value = var.slack_orchestrator_agent_id
+      }
+      env {
+        name  = "APPLICATIONINSIGHTS_CONNECTION_STRING"
+        value = var.app_insights_connection_string
+      }
+    }
+  }
+
+  ingress {
+    external_enabled = false
+    target_port      = 3978
+    transport        = "http"
+
+    traffic_weight {
+      percentage      = 100
+      latest_revision = true
+    }
+  }
+
+  tags = var.tags
+
+  depends_on = [
+    azurerm_role_assignment.slack_bridge_acr_pull,
+    azurerm_role_assignment.slack_bridge_kv_reader,
+  ]
+}
+```
+
+- [ ] **Step 3: Validate Terraform with the flag off (default)**
+
+Run:
+```bash
+cd infrastructure/environments/dev && terraform init -backend=false && terraform validate
+```
+Expected: `Success! The configuration is valid.` — with `slack_enabled` defaulting to `false`, the four `slack_bridge.*` resources have `count = 0` and contribute nothing to the plan, so validation stays clean.
+
+- [ ] **Step 4: Sanity-check the flag-on shape (optional, no apply)**
+
+Run:
+```bash
+cd infrastructure/environments/dev && terraform validate
+# then confirm the gate is wired (count expression present):
+grep -n "var.slack_enabled" ../../modules/container-apps/slack_bridge.tf
+```
+Expected: `validate` clean; the `grep` shows `count = var.slack_enabled ? 1 : 0` on each of the four resources. Do NOT run `terraform plan -var slack_enabled=true` against the live backend.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infrastructure/modules/container-apps/slack_bridge.tf infrastructure/modules/container-apps/variables.tf
+git commit -m "feat(slack-bridge): slack_enabled var + container app (internal ingress, default off)"
+```
+
+---
+
+### Task 8: Full suite + final wiring check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full service test suite**
+
+Run: `cd services/slack-bridge && pip install -r requirements-dev.txt && python -m pytest -q`
+Expected: `20 passed`.
+
+- [ ] **Step 2: Confirm the Dockerfile builds the dependency layer** (no network calls in tests; this just proves the image is buildable)
+
+Run: `cd services/slack-bridge && docker build -t slack-bridge:plancheck .`
+Expected: image builds; `main.py` copied as `appuser`; CMD is `uvicorn main:app … --port 3978`.
+
+- [ ] **Step 3: Re-validate Terraform with the flag off**
+
+Run: `cd infrastructure/environments/dev && terraform validate`
+Expected: `Success! The configuration is valid.`
+
+- [ ] **Step 4: Commit (if any doc tweaks were needed)** — otherwise nothing to commit.
+
+---
+
+## Self-Review
+
+- **Spec coverage:**
+  - New flag-gated `slack-bridge` service mirroring teams-bridge file-for-file — ✓ (`main.py`, `Dockerfile`, `requirements*.txt`, `README.md`, `tests/test_bridge.py`; Tasks 1–6).
+  - Slack Events API inbound: `url_verification` challenge handshake — ✓ (Task 5, returns `{"challenge": …}`); `event_callback` / `event.type == "message"` → issue — ✓ (Tasks 2, 3, 5).
+  - Replies via `chat.postMessage` — ✓ (`build_reply_payload` + `reply_poster`, Task 5).
+  - Signature verification: `X-Slack-Signature` + `X-Slack-Request-Timestamp` HMAC-SHA256 over `v0:<ts>:<body>`, constant-time compare, replay window — ✓ (Task 4), wired as the real auth step in the endpoint — ✓ (Task 5). This is the deliberate Slack analog of teams-bridge's Bot Framework JWT (NO pyjwt; HMAC is stdlib).
+  - Terraform `slack_bridge.tf` mirroring `teams_bridge.tf` + `slack_enabled` (default `false`), internal ingress, KV-stored bot token + signing secret — ✓ (Task 7).
+  - Default-off + `terraform validate` clean with the flag off — ✓ (Task 7 Step 3, Task 8 Step 3): the four resources are `count = var.slack_enabled ? 1 : 0`.
+- **Placeholder scan:** No `TODO`/`…`/"similar to teams-bridge"/"add validation" left in shipped artifacts — every handler, test body, Dockerfile, and HCL block is written out in full. The one operator-owned hardening step (exposing the endpoint through Cloudflare + ensuring `SLACK_SIGNING_SECRET` is set) is documented, not stubbed, and mirrors how teams-bridge documents its go-live step.
+- **Type consistency:**
+  - `parse_event(body) -> Optional[dict]` returns the fixed shape `{text, user, channel, ts, team_id}` consumed by `build_issue_payload` everywhere.
+  - `issue_poster: Callable[[dict], int]` and `reply_poster: Callable[[str, str], int]` signatures match their default `_post_issue` / `_post_reply` and every `monkeypatch.setattr` in the tests.
+  - `verify_signature(secret, timestamp, raw_body, signature, *, window, now) -> bool` and `authenticate(timestamp, raw_body, signature) -> None (raises AuthError)` are consistent across Task 4 and the endpoint in Task 5.
+  - Test runner is `pytest` with `fastapi.testclient.TestClient` + `monkeypatch` — identical to `services/teams-bridge/tests/test_bridge.py`. Container port `3978`, `python:3.12-slim`, non-root `appuser` — identical to teams-bridge.
+- **Deliberate divergences from teams-bridge (all intentional, all Slack-correct):**
+  - `requirements.txt` drops `pyjwt[crypto]` — Slack auth is HMAC (stdlib `hmac`/`hashlib`), not JWT.
+  - Endpoint path is `/slack/events` (not `/api/messages`) and adds the `url_verification` branch.
+  - Reply is `chat.postMessage` JSON (not an Adaptive Card).
+  - `parse_event` additionally drops `bot_id`/`subtype` messages to prevent the bridge looping on its own replies — no teams-bridge equivalent is needed because Bot Framework doesn't echo bot activities the same way.
+
+**Risk:** The only externally-coupled behaviors (`_post_issue` PaperClip POST and `_post_reply` chat.postMessage) are dependency-injected and never exercised by the offline suite, exactly as in teams-bridge; their live correctness is verified by the operator during go-live (Task 6 integration README), not in CI. Everything testable — parsing, payload shaping, HMAC verification, challenge handshake, the never-5xx contract — is covered offline.

--- a/docs/notes/plans/2026-06-26-entra-migration-remediation-plan.md
+++ b/docs/notes/plans/2026-06-26-entra-migration-remediation-plan.md
@@ -1,0 +1,223 @@
+# AAF — Entra Identity Migration & Vulnerability Remediation Plan
+
+**Date:** 2026-06-26 · **Window:** 2 days · **Status:** Plan — not executed.
+**Scope decisions (confirmed):** Hermes Python fixes via **build-time override** in AAF's Dockerfile (no submodule edit); Node criticals fixed **defense-in-depth in a Hermes fork** even though AAF doesn't ship them; Entra identity covers **both layers** (services → managed identity / workload identity, agent personas → Entra Agent ID); target **dev + prod**.
+
+> **Command safety legend:** 🟢 safe/idempotent (read-only or re-runnable, no destructive effect) · 🟠 **requires explicit approval** before running (mutates live Azure/GitHub/prod or is hard to reverse). Every 🟠 step names its blast radius.
+
+---
+
+## 1. Objective & success criteria
+
+**Goal 1 — Entra identity migration. Done when:**
+- Every AAF Container App authenticates to Azure resources (ACR, Key Vault, PostgreSQL, AI Foundry) via **managed identity / workload identity** — no password/key in the connection path. PostgreSQL `password_auth_enabled` can be set `false` in dev with all services still healthy.
+- Each of the **14 agent personas** has a governed **Entra Agent ID** with a named human sponsor and an entry in a central inventory; lifecycle (create/disable) is documented and reproducible.
+- Static third-party keys exist **only in Key Vault** (referenced by MI) and are **removed from GitHub Actions secrets**; the `seed` job no longer carries them.
+- The **two-app OIDC least-privilege split is preserved and actually wired into `deploy.yml`**; the `deploy-destroy` gate still fires only on destructive plans.
+
+**Goal 2 — Vulnerability remediation. Done when:**
+- All **11 Python** packages in the findings doc are at fix versions in the **built AAF image** (verified in-image), via build-time override; base image is Python ≥3.13 where required.
+- All **Node** advisories (`undici`, `ws`, `protobufjs` high; `baileys` critical) are resolved in the Hermes fork; AAF documents + CI-asserts that it never builds the Node surface.
+- **Container OS layer** is scanned (Trivy) for every AAF base image and findings are triaged/remediated.
+- A **recurring scan is gated in CI** (Dependabot + OSV/Trivy source scan + Trivy image scan) so this can't silently regress.
+- **Re-scan is clean** (or every residual is an accepted, documented risk).
+
+**Definition of done for the window:** both goals complete on **dev**; **prod** cutover staged with its gate (see §6 realism note — prod password-auth-disable and the shared-Foundry-key rotation are scheduled but soak-gated).
+
+---
+
+## 2. Current-state inventory (as found in the repo)
+
+### 2.1 Identities
+- **CI/CD OIDC (designed two-app split, partially landed):**
+  - `github-aaf-deploy` — Contributor @ sub + Storage Blob Data Contributor @ state RG. Intended for **apply only**. Repo var `AZURE_CLIENT_ID`.
+  - `github-aaf-deploy-plan` — Reader @ sub + Storage Blob Data Contributor @ state RG. Intended for **build/seed/plan/smoke**. Repo var `AZURE_CLIENT_ID_PLAN`.
+  - **Drift:** `provision.sh` creates both apps, but the repo's `.github/workflows/deploy.yml` still sets `ARM_CLIENT_ID` / every `azure/login` to `vars.AZURE_CLIENT_ID` for **all** jobs. The per-job split is **not yet wired** (Task A1).
+  - OIDC IDs are repo **Variables**, not Secrets (setting them as Secrets breaks `azure/login`).
+- **Runtime (already MI-based — strong starting point):** all 7 Container Apps have a UAMI (`hermes, honcho, paperclip, memory_governor, teams_bridge, cloudflared, apps`). Each has **AcrPull** (image pull via MI) and **Key Vault Secrets User** (secret refs via MI). **Hermes already has `Cognitive Services OpenAI User`** (Foundry via MI). Secrets are KV-referenced with `identity = <uai>.id`.
+- **PostgreSQL Flexible Server:** `active_directory_auth_enabled = true` **and** `password_auth_enabled = true` — **Entra auth is already on**; services still connect via password connection strings.
+- **Agent personas (Entra Agent ID inventory, 14):** orchestrator, planner, researcher, coder, qa, business, psychology, cost-guardian, security, strategy, coach, infrastructure, generalist, curator (`agents/profiles/*.yaml`).
+
+### 2.2 Static secrets in CI (the `seed` job env → KV)
+`AI_FOUNDRY_API_KEY, OPENAI_API_KEY, CLAUDE_API_KEY, BRAVE_SEARCH_API_KEY, TELEGRAM_BOT_TOKEN, DISCORD_BOT_TOKEN, CF_TUNNEL_TOKEN, POSTGRES_CONNECTION_STRING, PAPERCLIP_DB_URL`. All already land in Key Vault and are consumed by MI; the gap is the **CI-held copy** and the **password-based DB strings**.
+
+### 2.3 Vulnerable dependencies (per findings doc, target `NousResearch/hermes-agent@a4091e4`)
+- **`apps/hermes/src` is a git submodule** → `github.com/NousResearch/hermes-agent.git`, pinned `a91a57f` (`v2026.5.16`). Dep changes **cannot be committed in the AAF parent repo**.
+- **AAF builds Hermes Python-only:** `services/agent-runtime/Dockerfile` = `python:3.12-slim`, `pip install ".[messaging,honcho,cron]"`. **No `npm`, no `website/`, no `scripts/whatsapp-bridge/`** in the image → the Node criticals are **not in AAF's shipped artifact**.
+- **Python (11, all fixes available):** aiohttp 3.13.4→**3.14.1**, starlette 1.0.1→**1.3.1**, tornado 6.5.5→**6.5.7**, python-multipart 0.0.27→**0.0.31**, cryptography 46.0.7→**48.0.1**, pynacl 1.5.0→**1.6.2**, pydantic-settings 2.13.1→**2.14.2**, msgpack 1.1.2→**1.2.1**, cbor2 5.8.0→**5.9.0**, pygments 2.19.2→**2.20.0**, pytest 9.0.2→**9.0.3** (dev). Priority cluster: **aiohttp/starlette/tornado/python-multipart** (request path / DoS).
+- **Node (upstream Hermes only):** `website/` — undici (high), ws (high) + 31 mod/low (`npm audit fix` compatible). `scripts/whatsapp-bridge/` — **baileys (CRITICAL, no non-breaking fix)**, protobufjs (high), ws (high).
+- **Base images (OS layer, unscanned):** `python:3.12-slim` (agent-runtime, memory-governor, model-router, teams-bridge, watchdog), `python:3.13-slim-bookworm` + `uv:0.9.24` (honcho), `node:${NODE_VERSION}` + `python:3.13-slim` (paperclip). Upstream Hermes image (unused by AAF): `uv:0.11.6-python3.13-trixie` + `debian:13.4`.
+- **Interpreter note:** AAF's agent-runtime is **3.12**; several Python fixes target ≥3.13 → bump that base to `python:3.13-slim` (Task B1).
+
+---
+
+## 3. Scope & decisions
+
+### 3.1 The `baileys` decision (surfaced explicitly)
+`baileys` (CRITICAL) lives in `scripts/whatsapp-bridge/`, which **AAF never builds or ships** (Python-only image). **AAF runtime risk from baileys today: none.** Per the confirmed decision we still remediate **defense-in-depth in the Hermes fork** (upgrade to the patched `baileys` major + retest the bridge) **and** assert in AAF CI that the Node surface is never built. We do **not** add the WhatsApp bridge to AAF. If a future AAF feature needs WhatsApp, the breaking `baileys` major must be validated first.
+
+### 3.2 Per-secret classification
+
+| Secret | Nature | Target | Action |
+|---|---|---|---|
+| `AI_FOUNDRY_API_KEY` | Azure AI Foundry (Azure OpenAI) | **Managed identity** | Extend `Cognitive Services OpenAI User` to router/governor/honcho (Hermes done); drop key from KV+CI after MI verified |
+| `OPENAI_API_KEY` (honcho) | Verify endpoint | **MI if Azure OpenAI; else Key Vault** | If Azure → MI as above; if api.openai.com → KV only + remove CI copy |
+| `CLAUDE_API_KEY` | Third-party (Anthropic) | **Key Vault** | Already KV; **remove CI copy** (seed out-of-band) |
+| `BRAVE_SEARCH_API_KEY` | Third-party | **Key Vault** | Already KV; **remove CI copy** |
+| `TELEGRAM_BOT_TOKEN` | Third-party | **Key Vault** | Already KV; **remove CI copy** |
+| `DISCORD_BOT_TOKEN` | Third-party | **Key Vault** | Already KV; **remove CI copy** |
+| `CF_TUNNEL_TOKEN` | Third-party (Cloudflare) | **Key Vault** | Already KV (cloudflared MI); **remove CI copy** |
+| `POSTGRES_CONNECTION_STRING` | Azure PostgreSQL | **Managed identity** | Migrate honcho/governor to Entra token auth (AAD already enabled); remove KV secret + CI copy after cutover |
+| `PAPERCLIP_DB_URL` | Azure PostgreSQL | **Managed identity** | Migrate paperclip to Entra token auth; remove after cutover |
+| *(Storage account key — Azure Files SMB mount)* | Azure Storage | **Stays static** | Azure Files SMB mount can't use MI; mitigate via rotation + scope; document residual |
+
+**Principle:** a third-party API key cannot "become" a managed identity — its migration is **Key Vault + MI reference + remove from CI**. Only Azure-resource auth (PostgreSQL, Foundry, ACR, KV) converts to MI.
+
+---
+
+## 4. Workstream A — Identity migration
+
+> Each task: **Steps · Validation · Rollback · Risk.** Default target **dev**; prod repeats gated (§5).
+
+### A1 — Land the two-app OIDC split into `deploy.yml`
+- **Steps:** 🟢 Confirm both apps + `vars.AZURE_CLIENT_ID_PLAN` exist (`provision.sh` already creates them; re-run `./provision.sh` is idempotent). 🟢 Edit `deploy.yml`: remove the top-level `ARM_CLIENT_ID`; set it per-job — `build/seed/plan/smoke` → `vars.AZURE_CLIENT_ID_PLAN`, `apply` → `vars.AZURE_CLIENT_ID`; point each `azure/login` `client-id` at the matching var. 🟠 Merge to `main` (the workflow is `workflow_dispatch`-only, so it won't fire on the PR).
+- **Validation:** 🟢 `terraform validate`/yaml lint; 🟠 dispatch a **non-destructive** dev run — plan/seed/smoke succeed under the plan identity, apply under the privileged one; confirm no job uses Contributor pre-gate.
+- **Rollback:** revert the `deploy.yml` commit (single file); apps unchanged.
+- **Risk:** Low. Main failure mode = plan identity missing a narrow data role (grant the specific scoped role, never Contributor).
+
+### A2 — Remove third-party keys from CI; seed Key Vault out-of-band
+- **Steps:** 🟠 One-time seed of KV from a trusted admin shell (not CI): `scripts/seed-keyvault.sh -v <vault>` with the keys in the local env / `secrets.env` (idempotent). 🟢 Edit `deploy.yml` `seed` job to stop referencing the third-party `secrets.*` (keep the job for internal/generated secrets only, or gate it off once KV is populated). 🟠 `gh secret delete` the migrated third-party secrets from the repo.
+- **Validation:** 🟢 `az keyvault secret show` each name resolves; 🟠 dev redeploy → apps start, KV refs resolve via MI; 🟢 `gh secret list` shows the keys gone.
+- **Rollback:** re-add the secret via `gh secret set` and re-run seed.
+- **Risk:** Medium — deleting a CI secret before KV holds the value breaks seed. **Order matters:** seed KV → verify → then delete CI secret.
+
+### A3 — PostgreSQL: password connection strings → Entra (MI) auth
+- **Steps:** 🟢 AAD auth already enabled. 🟠 Set an **Entra admin** on the server (`azurerm_postgresql_flexible_server_active_directory_administrator` or `az postgres flexible-server ad-admin create`). 🟠 For each app UAMI (honcho, paperclip, memory_governor) create a DB role mapped to the MI and `GRANT` least-privilege on its DB. **Build-time/app override** so each service connects with an Entra **access token** (AAD `https://ossrdbms-aad.database.windows.net` token via `DefaultAzureCredential`) instead of the password DSN — honcho & paperclip are submodules → apply via the same override mechanism as B1 (no submodule edit). 🟠 Flip those apps to MI auth (drop the `postgres-connection-string` / `paperclip-db-url` env, add `PGHOST/PGUSER=<uami-name>` + token sidecar/refresh).
+- **Validation:** 🟠 each app reads/writes its DB under MI; 🟢 `SELECT` as the MI role works, password DSN no longer referenced; once soaked, 🟠 set `password_auth_enabled = false` (dev) and confirm health.
+- **Rollback:** re-enable password auth + restore the KV DSN env (kept until soak passes).
+- **Risk:** **High** — token lifetime/refresh, role grants, and submodule app-code changes. Keep password auth as the fallback until a clean soak. This is the most failure-prone task; do it on dev with the DSN still seeded.
+
+### A4 — Extend Foundry managed-identity auth (drop the Foundry key path)
+- **Steps:** 🟢 Hermes already uses `Cognitive Services OpenAI User`. 🟠 Add the same role assignment for model-router / memory-governor / honcho UAMIs; 🟠 switch those services' Azure-OpenAI calls to `DefaultAzureCredential` token auth (override). Verify whether `OPENAI_API_KEY` is Azure or api.openai.com (per §3.2) — MI only applies to Azure.
+- **Validation:** 🟠 a chat/embedding call succeeds with the key removed; 🟢 confirm role assignment via `az role assignment list`.
+- **Rollback:** restore the KV key env (kept until verified).
+- **Risk:** Medium — only Azure OpenAI endpoints qualify; api.openai.com stays a KV key.
+
+### A5 — Entra Agent ID for the 14 agent personas
+- **Steps:** 🟠 Register an **Entra Agent ID** per persona (orchestrator … curator) using the GA (Apr 2026) flow; assign a **named human sponsor** per agent; record in a central inventory (new `agents/ENTRA-AGENT-INVENTORY.md` + the agent-id in each `agents/profiles/<name>.yaml`). 🟠 Wire the agent's Entra identity into its runtime auth where it makes outbound governed calls (least-privilege; no standing secrets). 🟢 Document lifecycle (create/disable/rotate sponsor).
+- **Validation:** 🟢 inventory lists 14 agents, each with id + sponsor; 🟠 a test agent authenticates via its Entra Agent ID; disable flow revokes access.
+- **Rollback:** disable the Agent IDs; personas fall back to the service UAMI path (no runtime dependency added until verified).
+- **Risk:** **High/uncertain** — newest capability, tooling maturity unknown. **Most likely deferral candidate** if the GA flow is fiddly (see §5).
+
+---
+
+## 5. Workstream B — Vulnerability remediation
+
+### B1 — Python deps: build-time override + base bump (the in-scope fix)
+- **Steps:** 🟢 Add `services/agent-runtime/constraints.txt` pinning the 11 fix versions; 🟢 change the Dockerfile base `python:3.12-slim` → `python:3.13-slim`; 🟢 change `pip install ".[messaging,honcho,cron]"` → `pip install -c constraints.txt ".[messaging,honcho,cron]"` (constraints win over transitive resolution; no submodule edit). 🟢 Also bump `apps/hermes/src` `pyproject.toml`/`uv.lock` **in the Hermes fork** (B4) for lockfile parity + dev.
+- **Validation:** 🟢 `docker build` the image; 🟢 `pip list` / `pip freeze` in-image shows all 11 at fix versions; 🟢 run Hermes' Python tests in the builder stage; 🟠 dev deploy + smoke.
+- **Rollback:** revert constraints + base (one Dockerfile); image rebuilds to prior state.
+- **Risk:** Medium — 3.12→3.13 base + cryptography/pynacl native wheels; the constraints approach is idempotent and reversible.
+
+### B2 — Container OS-layer scan (Trivy) + remediate
+- **Steps:** 🟢 `trivy image` each built AAF image (agent-runtime, honcho, paperclip, model-router, memory-governor, watchdog, teams-bridge); 🟢 triage OS-package CVEs; 🟢 remediate via base-image bump / `apt-get upgrade` pin in the relevant Dockerfile.
+- **Validation:** 🟢 re-`trivy image` → no unaccepted HIGH/CRITICAL; 🟢 rebuild + tests pass.
+- **Rollback:** revert the Dockerfile base/pin.
+- **Risk:** Low–Medium — base bumps can shift transitive system libs; rebuild + smoke covers it.
+
+### B3 — Node defense-in-depth (Hermes fork) + AAF not-built assertion
+- **Steps:** 🟠 In the **Hermes fork** (B4): `cd website && npm audit fix` (undici, ws + the 31); `cd scripts/whatsapp-bridge && npm audit fix` (protobufjs, ws) + **`baileys` major upgrade** (breaking — retest the bridge). 🟢 In **AAF**: add a CI assertion that `services/agent-runtime/Dockerfile` contains no `npm`/`website`/`whatsapp-bridge` build step (fail the build if it ever does).
+- **Validation:** 🟢 `npm audit` clean in both Node trees (fork); 🟢 AAF CI guard passes on current Dockerfile and fails on an injected `npm install`.
+- **Rollback:** fork branch is independent; AAF guard is one CI step to revert.
+- **Risk:** Medium — `baileys` major is breaking; isolated to the fork, zero AAF runtime impact.
+
+### B4 — Hermes fork (carrier for B1 lock parity + B3)
+- **Steps:** 🟠 Fork `NousResearch/hermes-agent` → your org; branch `aaf-sec-bumps`; apply Python (`pyproject.toml`/`uv.lock`) + Node fixes; keep AAF's submodule **URL/pin unchanged for runtime** (AAF runtime fix is the build-time override, B1) — the fork carries parity + the Node defense-in-depth + a clean upstream-PR basis.
+- **Validation:** 🟢 fork CI / `uv sync` + tests green.
+- **Rollback:** n/a (additive fork).
+- **Risk:** Low — does not touch AAF runtime.
+
+### B5 — Recurring scanning gated in CI
+- **Steps:** 🟢 Enable **Dependabot** alerts + security updates on the AAF repo; 🟢 add an **OSV-Scanner** (or Trivy fs) job on source; 🟢 add a **Trivy image scan** on the `build` job's output, gated like other checks; 🟢 (optional) Black Duck Detect step for license/BDSA.
+- **Validation:** 🟢 a deliberately-pinned-old dep fails the gate.
+- **Rollback:** remove the workflow steps.
+- **Risk:** Low.
+
+---
+
+## 6. Day-by-day schedule
+
+> Front-loads CRITICAL/HIGH. Identity work that touches running apps (A3/A4) follows the vuln fixes so the image is already patched when redeployed. Prod repeats dev, gated.
+
+**Day 1 — Vulnerability remediation + identity groundwork (low-blast-radius first)**
+- **Block 1 (AM): Python + base + image scan** — B1 (constraints + 3.13 base + rebuild + in-image verify), B2 (Trivy scan of all images), B4 (fork created). 🟠 only at dev deploy. *Highest-severity in-scope items first.*
+- **Block 2 (AM/Mid): Node defense-in-depth** — B3 (fork `npm audit fix` + `baileys` major + retest; AAF not-built CI guard). B5 (Dependabot + OSV/Trivy CI gates).
+- **Block 3 (PM): OIDC split + CI-secret removal** — A1 (wire two-app split into `deploy.yml`), A2 (seed KV out-of-band → verify → delete CI third-party secrets). **Order:** seed+verify *before* any `gh secret delete`.
+- **End-of-Day-1 gate:** 🟠 one dev `workflow_dispatch` (non-destructive) — patched images deploy under the split identities; smoke green; re-scan source/images clean.
+
+**Day 2 — Resource-auth MI migration + agent identity + prod staging**
+- **Block 4 (AM): Postgres → Entra MI (dev)** — A3 (Entra admin, MI DB roles, token-auth override for honcho/paperclip/governor) with password auth still on as fallback. *Most failure-prone; do it with the DSN still seeded.*
+- **Block 5 (Mid): Foundry MI extension** — A4 (role assignments + token auth for router/governor/honcho; drop Foundry key where Azure).
+- **Block 6 (PM): Entra Agent ID** — A5 (register 14 personas, sponsors, inventory). *Timeboxed; deferral candidate (§ realism).*
+- **Block 7 (PM): Prod cutover (gated)** — 🟠 repeat A1–A4 + B1/B2 deploy on prod via the `deploy-destroy`-gated pipeline. **Shared AI-Foundry-key rotation needs an operator-prod maintenance window** — coordinate; do not rotate mid-day unscheduled.
+- **End-of-Day-2 gate:** dev fully on MI (password auth off after soak); prod patched + identity-split live; full re-scan clean; exit checklist signed.
+
+**Approval gates in the schedule:** every dev/prod `apply` (the existing `deploy-destroy` gate, destructive-only); `gh secret delete` (A2); `password_auth_enabled=false` (A3); Entra admin + MI DB roles (A3); prod cutover block (A7); Foundry key rotation (prod window).
+
+### Realism — what fits, what defers
+Two full goals across **dev + prod**, with **both Entra layers**, **Postgres MI**, and **defense-in-depth Node**, is **more than 2 clean days** if anything resists. Honest prioritization:
+- **Will fit (commit to these):** all vuln remediation (B1–B5) on dev + dev image rebuild; the OIDC split (A1) + CI-secret removal (A2); Foundry MI extension (A4); the Hermes fork.
+- **At risk / likely partial:** **A3 Postgres→MI** (token-auth app changes across two submodule services + soak before disabling password auth) and **A5 Entra Agent ID** (newest GA tooling). Recommend: land A3 on dev with password auth **kept on** (don't disable in-window); pilot **A5 on 2–3 personas**, roll the remaining 11 as a fast-follow.
+- **Defer out of the window (recommended):** **prod password-auth-disable** and **prod Foundry-key rotation** — both need a scheduled maintenance window + a dev soak first. Stage prod's identity-split + patched images in-window; finish prod's MI cutover in the next window. **Rationale:** prod data-plane auth changes without a soak are the highest-regret action here.
+
+---
+
+## 7. Risk register & rollback summary
+
+| # | Risk | Likelihood | Impact | Mitigation / Rollback |
+|---|---|---|---|---|
+| R1 | Postgres MI token/refresh or role grant wrong → apps can't reach DB | Med | High | Keep `password_auth_enabled=true` + KV DSN until soak; A3 rollback = restore DSN env |
+| R2 | Deleting a CI secret before KV holds it → seed/deploy breaks | Med | High | Strict order: seed→verify→delete; rollback = `gh secret set` |
+| R3 | 3.12→3.13 base or constraint pin breaks a native dep | Med | Med | In-image tests in builder stage; revert one Dockerfile |
+| R4 | `baileys` major breaks the WhatsApp bridge | Med | Low (AAF) | Isolated to fork; AAF doesn't ship it |
+| R5 | Plan identity missing a narrow data role after split | Med | Low | Grant the specific scoped role (AcrPush/KV Officer), never Contributor; rollback = revert deploy.yml |
+| R6 | Entra Agent ID GA flow immature → time sink | Med | Med | Timebox; pilot 2–3 personas; defer remainder; personas keep service-UAMI path |
+| R7 | Prod cutover without soak → outage | Low | High | Defer prod data-plane disable to a window; stage only |
+| R8 | Shared Foundry key rotation hits operator prod | Med | Med | Coordinate maintenance window; two-key rotation (add new, swap, retire old) |
+| R9 | Storage-account key can't go MI (Azure Files SMB) | — | Low | Accept residual; rotate + scope; document |
+
+**Global rollback:** all changes land via PR + the saved-plan `apply`; every step keeps its prior credential path (KV DSN, CI secret, password auth, Foundry key) **until the MI path is verified**, so any single task reverts independently without a coordinated rollback.
+
+---
+
+## 8. Exit checklist — every finding mapped to a task + re-scan
+
+| Finding (from `Hermes_SCA_Scan_Findings.md`) | Remediation task | Verify |
+|---|---|---|
+| aiohttp 3.13.4→3.14.1 | B1 (override) + B4 (fork lock) | `pip freeze` in-image |
+| starlette 1.0.1→1.3.1 | B1 + B4 | in-image |
+| tornado 6.5.5→6.5.7 | B1 + B4 | in-image |
+| python-multipart 0.0.27→0.0.31 | B1 + B4 | in-image |
+| cryptography 46.0.7→48.0.1 | B1 + B4 | in-image |
+| pynacl 1.5.0→1.6.2 | B1 + B4 | in-image |
+| pydantic-settings 2.13.1→2.14.2 | B1 + B4 | in-image |
+| msgpack 1.1.2→1.2.1 | B1 + B4 | in-image |
+| cbor2 5.8.0→5.9.0 | B1 + B4 | in-image |
+| pygments 2.19.2→2.20.0 | B1 + B4 | in-image |
+| pytest 9.0.2→9.0.3 (dev) | B4 (fork dev dep) | fork CI |
+| website: undici (high) | B3 (fork audit fix) | `npm audit` |
+| website: ws (high) + 31 mod/low | B3 | `npm audit` |
+| whatsapp-bridge: **baileys (CRITICAL)** | B3 (fork major upgrade) + §3.1 not-built | `npm audit` + AAF CI guard |
+| whatsapp-bridge: protobufjs (high) | B3 | `npm audit` |
+| whatsapp-bridge: ws (high) | B3 | `npm audit` |
+| Container OS layer (debian/node/uv/slim bases) | B2 (Trivy all images) | `trivy image` clean |
+| Point-in-time / recurring | B5 (Dependabot + OSV + Trivy gates) | gate fails on stale dep |
+
+**Final verification:** 🟢 re-run the SCA (OSV/Trivy fs) on source + `trivy image` on every built image + `npm audit` on the fork → clean or accepted-and-documented; confirm dev apps healthy on MI; confirm `gh secret list` no longer holds migrated third-party keys; confirm `deploy.yml` uses the split identities and the `deploy-destroy` gate still guards destructive plans.
+
+---
+
+## 9. Open items for the operator
+- Confirm `OPENAI_API_KEY` endpoint (Azure OpenAI → MI, or api.openai.com → KV-only).
+- Confirm the operator-prod maintenance window for the shared AI-Foundry-key rotation.
+- Confirm Entra Agent ID tenant prerequisites (the GA flow may need a specific Entra role/license) before A5.

--- a/docs/notes/specs/2026-06-25-voice-live-web-app-design.md
+++ b/docs/notes/specs/2026-06-25-voice-live-web-app-design.md
@@ -1,0 +1,197 @@
+# Design — Real-time voice web app (Microsoft Voice Live + Azure Speech)
+
+**Date:** 2026-06-25
+**Status:** Design only — *not* scheduled for build. Drafted as the announced
+direction for first-class voice; the implementation is a follow-on milestone.
+**Target:** AzureAgentForge as a flag-gated **template feature**
+(`voice_enabled`), with the operator's own platform as the reference deployment.
+
+---
+
+## 1. Summary
+
+A browser-based, low-latency **conversational voice surface**: you open a web
+page, talk to your agents, and hear them answer — every hop staying inside one
+Azure region/VNet so the round-trip is short. Microsoft **Voice Live** (BYOM
+mode) is the ear (speech → text); **Azure AI Speech** neural TTS is the mouth
+(text → speech); the agent stack (Hermes / model-router / PaperClip memory) is
+the brain. PaperClip stays in the loop for **audit and replay**, but off the
+hot path so it never adds conversational latency.
+
+This eliminates the latency and turn-taking limits of a chat-app bridge
+(Telegram/Discord) by owning the transport end to end.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Push-to-talk (or VAD-gated) **half-duplex** voice conversation in a browser.
+- Single agent persona per session, backed by the real agent stack.
+- All inference and speech processing stays in-region/in-VNet for low latency.
+- Durable, human-readable **transcript per session** + PaperClip issue for audit.
+- Ship as a **sanitized, generic AAF template** any operator can enable.
+
+**Non-goals (this milestone)**
+- Full-duplex barge-in / interrupt-mid-sentence. (Half-duplex turn-taking only.)
+- **Multiple agents speaking** in one session. (Single persona; multi-agent
+  voice is a separate, larger initiative.)
+- Voice Live's *own* model generating responses (we use BYOM — Voice Live does
+  STT only; the agent stack is the brain).
+- Mobile-native apps. (Responsive web only.)
+
+## 3. What exists today (grounding)
+
+- **Voice Live BYOM STT is proven.** A spike (2026-05-31, `gpt-realtime-mini`,
+  api-version `2026-01-01-preview`) confirmed: open a session, stream PCM16
+  24 kHz, suppress the model (`modalities:["text"]`, `turn_detection:null`, no
+  `response.create`), and receive a clean transcript via
+  `conversation.item.input_audio_transcription.completed` at **~841 ms** for a
+  4.2 s utterance. This is the canonical STT path.
+- **A provider abstraction already exists** (`paperclip-plugin-discord`,
+  `feat/voice-provider-abstraction`, ~1,136 LOC): an `AzureVoiceLiveProvider`
+  (STT), a Deepgram fallback, Opus→PCM resampling, and dual transcript sinks.
+  The provider/event model is reusable; the Discord transport is not.
+- **Hermes has no synchronous "message → reply" endpoint.** Its web server is
+  management/dashboard routes plus a pty bridge to the TUI; the agent loop runs
+  through the async **gateway** pipeline. A synchronous dispatch seam is
+  net-new code (see §6).
+- **The model-router is a synchronous, in-VNet LLM gateway** (OpenAI-compatible)
+  — the fastest existing brain, but without tools/memory/persona on its own.
+- **TTS (voice out) is unbuilt.** The STT spike explicitly deferred it. This
+  design selects **Azure AI Speech neural TTS** (GA, same region) for output.
+- An **auth-proxy** already fronts the platform's services — reuse it for the
+  web app's auth rather than inventing a new scheme.
+
+## 4. Architecture
+
+```
+ Browser (React, App Service, behind Cloudflare tunnel + auth-proxy)
+   │  mic capture (PCM16) over WSS
+   ▼
+ voice-relay  (new backend service — holds ALL keys; the trust boundary)
+   ├─ proxies/streams audio → Voice Live (BYOM STT) ──► transcript
+   ├─ dispatches transcript → agent brain (§6) ──────► reply text
+   ├─ reply text → Azure Speech neural TTS ──────────► audio
+   │                                  (streamed back to the browser to play)
+   └─ on session end: write transcript .md → Blob;  file/append PaperClip issue
+```
+
+**Components (each independently testable):**
+
+1. **`voice-web`** — React SPA. Mic capture, WSS to the relay, playback,
+   push-to-talk / VAD UI, session lifecycle. Holds **no secrets**.
+2. **`voice-relay`** — the only component with credentials. Token-broker +
+   audio/dispatch orchestrator. FastAPI, mirrors the `teams-bridge` service
+   shape (own Container App, flag-gated). This is the security boundary (§5).
+3. **STT adapter** — Voice Live BYOM client (port the proven
+   `AzureVoiceLiveProvider` event model; drop the Discord transport).
+4. **Brain dispatch** — pluggable seam (§6): `router` (fast MVP) or `hermes`
+   (full agent). Chosen by config so the surface doesn't change when the brain
+   is upgraded.
+5. **TTS adapter** — Azure AI Speech neural TTS, streamed.
+6. **Transcript/audit writer** — markdown → Blob + PaperClip issue (§7).
+
+## 5. Security — the relay is non-negotiable
+
+The browser must **never** hold the Voice Live or Speech keys. The `voice-relay`
+holds them (from Key Vault, fetched at startup) and either proxies the Voice
+Live WebSocket or mints **short-lived tokens**. The SPA authenticates through
+the existing **auth-proxy**; the relay authorizes every session before opening
+any upstream connection. Audio is content-redacted in logs; transcripts are
+treated as user content and stored only in the operator's Blob + PaperClip.
+
+## 6. Brain dispatch (the load-bearing decision)
+
+Because Hermes exposes no synchronous reply endpoint, the brain is a **pluggable
+seam** with two implementations:
+
+- **`router` (MVP / fast path).** Relay calls the model-router
+  (`/v1/chat/completions`) with a single-agent system prompt. Lowest latency,
+  uses only existing infrastructure, no tools/memory. Good enough to prove the
+  loop and demo the conversational feel.
+- **`hermes` (full vision).** A **new synchronous dispatch endpoint** added to
+  Hermes's gateway (in AAF: a build-time `patch-*.mjs`, the established
+  mechanism for Hermes changes) that runs one agent turn with tools + Honcho
+  memory + persona and returns the reply text. Higher value, real new code in an
+  upstream-vendored component — the milestone's main engineering risk.
+
+The relay treats both behind one interface; swapping `router`→`hermes` changes
+config, not the web app.
+
+## 7. Transcript & audit (off the hot path)
+
+Each session produces a **markdown transcript** (frontmatter + turn-by-turn) the
+relay writes to **Blob storage** at session end. PaperClip audit is then either:
+
+- **Direct (recommended):** the relay files/updates **one PaperClip issue per
+  session** at session end — synchronous with the session, no extra moving
+  parts; or
+- **Backfill (original vision):** a separate **ACA scheduled Job** (every 5 min)
+  scans Blob for new transcripts and backfills PaperClip issues — decouples
+  audit from the live path at the cost of one more deployable.
+
+Default to **direct**; keep the Blob markdown as the durable artifact (it also
+dovetails with the v1.3 Obsidian memory interface — transcripts can live in the
+vault). The markdown→issue mapping is identical either way, so we can add the
+cron later without reworking the writer.
+
+## 8. AAF template & sanitization
+
+Shipped generic and flag-gated (`voice_enabled`, default false):
+- No hardcoded guild/channel/webhook IDs, agent UUIDs, tenant names, or
+  Cloudflare specifics — all config/Terraform variables.
+- Terraform: the App Service (or Container App) for `voice-web`, the
+  `voice-relay` Container App, the Azure Speech + Voice Live resources, KV
+  secrets, and ingress wiring — all `count`-gated on `voice_enabled`.
+- Reference deployment (operator's platform) documented separately; the public
+  template carries only generic defaults.
+
+## 9. Phasing
+
+1. **Spike (½ day):** browser→relay→Voice Live STT round-trip + Azure Speech
+   TTS playback, one real agent turn via `router`. Confirms latency + the relay
+   token model end to end.
+2. **MVP slice:** `voice-web` + `voice-relay` + `router` brain + direct
+   PaperClip issue + Blob transcript. Dev only.
+3. **Full vision:** `hermes` dispatch endpoint (tools/memory/persona),
+   optional cron backfill, sanitized AAF template, then production.
+
+## 10. Latency budget (half-duplex turn)
+
+| Stage | Est. |
+|---|---|
+| Capture → relay (end-of-utterance) | ~100–200 ms |
+| Voice Live STT (commit → transcript) | ~0.8 s (measured) |
+| Agent reply (`router`; `hermes` higher) | ~1–3 s |
+| Azure Speech TTS (first audio) | ~0.3–0.7 s |
+| **Perceived round-trip** | **~2.5–5 s/turn** |
+
+Voice-assistant feel (turn-taking), **not** interrupt-mid-sentence full duplex.
+Set this expectation in the UI (clear "speaking / listening / thinking" states).
+
+## 11. Testing
+
+- STT adapter: event-model unit tests against recorded Voice Live event logs.
+- Relay: auth/authorization, token brokering, no-key-leak assertions, session
+  lifecycle, error/reconnect.
+- TTS adapter: synthesis + streaming offline tests.
+- Transcript writer: markdown render + PaperClip mapping (offline).
+- E2E: scripted audio → transcript → reply → audio, latency assertion.
+
+## 12. Risks & open questions
+
+- **Hermes dispatch endpoint** is the biggest unknown — scope/stability of a
+  new synchronous seam in the gateway. Mitigated by shipping `router` first.
+- **Voice Live session stability** over long/real sessions (spike ran seconds):
+  reconnect/keepalive strategy TBD.
+- **Real mic audio** (vs synthetic) may affect STT quality/latency.
+- **Managed-identity auth** to Voice Live (spike used API key) — verify the WS
+  upgrade auth pattern under MI.
+- **Cost**: per-minute Voice Live + Speech spend; add a budget alert.
+- **Barge-in**: deferred; would require full-duplex streaming + VAD arbitration.
+
+## 13. References
+
+- STT spike findings: `voice-live-byom/FINDINGS.md` (reference platform).
+- Provider abstraction: `paperclip-plugin-discord` `feat/voice-provider-abstraction`.
+- v1.3 Obsidian memory interface (transcript-as-vault synergy).
+- `teams-bridge` (service shape to mirror for `voice-relay`).

--- a/docs/notes/specs/2026-06-26-multi-tenant-design.md
+++ b/docs/notes/specs/2026-06-26-multi-tenant-design.md
@@ -1,0 +1,129 @@
+# Design — Multi-tenant AzureAgentForge
+
+**Date:** 2026-06-26
+**Status:** Design spec. Supersedes the memory-plane assumptions in
+[`experimental/multi-tenant/ARCHITECTURE.md`](../../../experimental/multi-tenant/ARCHITECTURE.md)
+(kept as the authoritative reference for the SQL/HCL detail). Implementation is
+**phased** — this is the umbrella design; each phase gets its own plan.
+**Target:** AzureAgentForge as a flag-gated capability (`multi_tenant_enabled`),
+sanitized for the public template.
+
+---
+
+## 1. Summary
+
+Turn AAF from a single-tenant stack into a platform that runs many isolated
+tenants on **one shared deployment** (one Postgres, one Container Apps
+Environment, one Key Vault), with hard isolation enforced **at the database
+layer** by PostgreSQL Row-Level Security. A tenant is identified by a `tenant_id`
+that rides every request (resolved from subdomain or JWT), is set as
+`app.tenant_id` on every DB connection, and is enforced by RLS policies that
+default-deny. A small **control plane** (`aaf_core` registry + provisioning API)
+and a per-tenant **Terraform module** make onboarding a tenant a bounded,
+repeatable operation.
+
+The reference design in `ARCHITECTURE.md` already specifies the SQL, RLS
+policies, router budget code, Terraform `modules/tenant`, onboarding flow, and
+security model in detail. **This spec does not restate them** — it (a) locks the
+decisions, (b) **reconciles the design with the code that actually shipped**, (c)
+closes the governed-memory gap the reference doc predates, and (d) defines
+component boundaries, phasing, testing, and done-criteria.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Hard tenant isolation at the data layer (RLS, default-deny), un-bypassable from app code.
+- One shared infrastructure footprint; per-tenant marginal cost near zero in shared mode.
+- Per-tenant budget tracking and per-tenant agent memory.
+- Bounded onboarding: registry row + Terraform module + secret seed + DNS.
+- Ship sanitized and flag-gated; single-tenant remains the default and is unaffected.
+
+**Non-goals (this milestone)**
+- Database-per-tenant or schema-per-tenant-via-separate-schemas (RLS on shared `public` is the decision; see §4.1).
+- A billing/metering product (budget tracking exists; invoicing does not).
+- The experimental mem0 / Azure AI Search per-tenant memory backend (superseded; see §4.3).
+- Self-service signup UI (onboarding is operator/admin-driven via the control-plane API).
+
+## 3. What exists today (grounding)
+
+- **Reference design** — `experimental/multi-tenant/ARCHITECTURE.md`: complete, authoritative for detail.
+- **Control plane (~built, not deployed)** — `experimental/multi-tenant/control-plane/`: a FastAPI provisioning API + `aaf_core` registry schema (`tenants`, `users`, `channels`, …). **Keep** — this is the tenant control plane. It currently provisions an Azure AI Search index per tenant (`vector_index_name`); that step is dropped (see §4.3).
+- **memory-store (~built, not deployed)** — `experimental/multi-tenant/memory-store/`: a standalone pgvector memory service for the mem0/AI-Search model. **Supersede** — the shipped stack uses Honcho + the memory-governor instead.
+- **Shipped single-tenant services** — `services/{paperclip,hermes(agent-runtime),model-router,honcho,memory-governor,watchdog,teams-bridge}` on one VNet + Postgres Flexible Server + Key Vault. These are the real integration surface.
+- **Drift to reconcile:** the reference doc names predate the template — `ca-orchestrator`→`paperclip`, the `platform-*` KV prefix vs the current `seed-keyvault.sh` names, `app.example.com` as a literal. The spec uses generic, current names; concrete hostnames/prefixes are variables.
+
+## 4. Key decisions (locked here)
+
+### 4.1 Isolation: RLS on shared `public` schema
+Adopt the reference recommendation. One Postgres instance, shared `honcho`/`paperclip` databases, a `tenant_id` column on every tenant table, RLS policies keyed on `current_setting('app.tenant_id')`, app roles (`honcho_app`, `paperclip_app`, `governor_app`) that are subject to RLS while the `postgres` admin bypasses it. Rationale and the rejected alternatives are in `ARCHITECTURE.md` §1.
+
+### 4.2 Tenant context propagation
+`tenant_id` is resolved at the edge (Paperclip from subdomain `*.<base-domain>`; agents from the inbound channel) and carried as: a JWT claim through the app, an `X-Tenant-ID` header to the model-router, and `SET LOCAL app.tenant_id` on every DB transaction (the SQLAlchemy `checkout` / Drizzle `withTenant` patterns in `ARCHITECTURE.md` §2.3). A request with no resolvable tenant is **rejected**, never defaulted.
+
+### 4.3 Memory tenancy on the shipped stack (the reconciliation)
+Multi-tenant memory is **Honcho + memory-governor**, isolated by `tenant_id` + RLS on their Postgres tables — *not* the experimental mem0/Azure-AI-Search/`memory-store` path, which is retired. Concretely this **adds scope the reference doc omits**:
+- Honcho tables get `tenant_id` + RLS (reference §2.1 covers this).
+- **memory-governor** tables (`session_memory`, `documents` annotations, `durable_facts`, `agent_events`, and the `feature_flags`/registry it reads) get `tenant_id` + RLS, and `/admit` + `/plan-retrieval` set `app.tenant_id` per call. Admission authority and retrieval planes become tenant-scoped.
+- **watchdog** detectors and the lessons they write (`durable_fact` per agent) are tenant-scoped, so one tenant's failure signatures never leak into another's agents.
+
+This is the single largest delta from `ARCHITECTURE.md` and the main source of new implementation work.
+
+### 4.4 Hermes mode
+Default **Option A** (one shared Hermes; tenant resolved per-inbound-channel; tenant-scoped Honcho `app_id` and `/opt/data/{slug}/`). **Option B** (dedicated Hermes container app per tenant) is a per-tenant Terraform flag (`enable_dedicated_hermes`) for tenants needing their own Telegram bot / isolated network path. Both behind `modules/tenant` (reference §3, §8).
+
+### 4.5 Ingress
+Wildcard Cloudflare tunnel (`*.<base-domain>` → the shared Paperclip ingress); Paperclip resolves the tenant from the subdomain (reference §6). Base domain is a variable, not a literal.
+
+## 5. Components (each independently testable)
+
+1. **Control plane** (`aaf_core` registry + provisioning API) — owns tenant lifecycle: create/list/suspend a tenant, its users/channels/api-keys/features. Source of truth for "what tenants exist."
+2. **Data-layer tenancy** — migrations adding `tenant_id` + indexes + RLS policies + app roles across honcho / paperclip / governor schemas; the per-connection `SET app.tenant_id` middleware in each service.
+3. **Router budget** — per-tenant `tenant→tier→spend` tracking, DB-backed (`budget_spend`, `tenant_budget_limits`), gated by `X-Tenant-ID` (reference §4). Falls back to flat single-tenant behavior when the header is absent.
+4. **Hermes scoping** — tenant→`HONCHO_APP_ID` mapping + tenant-scoped file-share paths + `X-Tenant-ID` to the router sidecar.
+5. **Paperclip resolver** — subdomain→tenant middleware; `company_id`/`tenant_id` in Better-Auth JWT; `SET app.tenant_id` on all connections.
+6. **Terraform `modules/tenant`** — per-tenant managed identity + RBAC (KV scoped to `…-{slug}-*`), file share, optional dedicated Hermes; driven by a `tenants` map (reference §8).
+7. **Onboarding** — the bounded sequence (registry row → tfvars entry → apply → secret seed → DNS → verify) (reference §9), with the control-plane API as the entry point.
+
+Each maps to a phase in §7 and can be built/tested without the others present (behind the flag).
+
+## 6. Security (the core of the feature)
+
+RLS is the isolation mechanism; everything else is defense in depth. The spec adopts `ARCHITECTURE.md` §11 wholesale and extends it:
+- **Default-deny:** every tenant table has RLS enabled; a connection without `app.tenant_id` sees zero rows.
+- **App-role vs admin:** services connect as `*_app` roles (RLS-subject); migrations/ops use the admin (RLS-bypass) explicitly.
+- **Governor/watchdog** included in the RLS perimeter (§4.3) — the reference doc's table list is extended to the governed-memory tables.
+- **Audit:** the `audit_log` table + triggers (reference §11.2) capture tenant-scoped mutations.
+- **Verification is a test artifact, not a checklist:** the cross-tenant pen-test queries (reference §11.4) become automated isolation tests (§8) that must pass in CI before the flag can be enabled in any environment.
+
+## 7. Phasing (umbrella → per-phase plans)
+
+The reference §12 four-phase plan is sound; adopt it with the governor work folded in. Each phase is a separate implementation plan and ships behind the flag.
+
+- **Phase 1 — Data-layer foundation.** `tenants` registry; `tenant_id` + indexes + RLS + app roles across honcho **and the governor tables**; per-connection `SET app.tenant_id` middleware in Honcho + governor. Existing single-tenant behavior preserved (seed `operator`, backfill, default-deny only after backfill). **This is the first plan to write.**
+- **Phase 2 — Router + Hermes.** Per-tenant budget (DB-backed) behind `X-Tenant-ID`; Hermes tenant→`HONCHO_APP_ID` + file-share scoping; `modules/tenant` (structured, `operator`-only, no behavior change).
+- **Phase 3 — Paperclip + ingress + onboarding.** Subdomain resolver + JWT `tenant_id` + `SET app.tenant_id`; wildcard Cloudflare; control-plane API wired to drive provisioning; `audit_log`.
+- **Phase 4 — Second tenant + validation.** Onboard a test tenant end-to-end; run the automated isolation/budget/memory tests; load test; runbooks; production cutover.
+
+## 8. Testing
+
+- **RLS isolation (automated, gates the flag):** as `*_app` role, set tenant A, assert zero rows for tenant B; reset context, assert zero rows (default-deny). One test per tenant table, including the governor tables.
+- **Budget isolation:** tenant A over-budget does not throttle tenant B; spend persists across a simulated router restart.
+- **Memory isolation:** governor `/admit` + `/plan-retrieval` and Honcho recall return only the calling tenant's data; a watchdog lesson written for tenant A is never injected into tenant B's agents.
+- **Regression:** the full single-tenant suite passes with RLS active and the flag **off** (proves zero-impact default).
+- **Migration safety:** Phase-1 migration is idempotent and reversible (drop policies / revert role) on a seeded single-tenant DB.
+
+## 9. Risks & open questions
+
+- **Honcho upstream `tenant_id`** — Honcho is vendored; adding `tenant_id` + RLS may need a maintained patch/fork (reference risk register). Confirm against the vendored Honcho schema before Phase 1.
+- **Governor tenancy complexity** — the governed-memory layer (admission authority, four-plane retrieval, contradiction sweeps, the watchdog loop) is the hardest surface to make tenant-correct; it is also flag-gated-off today, so Phase 1 can land its RLS without the governor being live.
+- **Connection limits** — B1ms (~50 conns) bounds tenant count under per-connection `SET`; monitor, plan the B2ms bump (reference risk register).
+- **Drift reconciliation** — the per-connection middleware must be added to each *current* service's actual DB layer; verify the SQLAlchemy/Drizzle integration points still match the reference patterns.
+- **Open:** does Paperclip's shipped `company` model still map 1:1 to a tenant, or has it diverged? Confirm before Phase 3.
+- **Open:** retire `memory-store/` outright, or keep it as a documented alternative? (Default: mark superseded, leave in `experimental/`.)
+
+## 10. References
+
+- Authoritative detail: `experimental/multi-tenant/ARCHITECTURE.md` (§1 isolation, §2 data layer + middleware, §4 router budget, §6 Cloudflare, §8 Terraform module, §9 onboarding, §11 security, §12 migration).
+- Control plane: `experimental/multi-tenant/control-plane/` (`aaf_core` registry + provisioning API).
+- Superseded: `experimental/multi-tenant/memory-store/` (mem0/AI-Search memory model).
+- Shipped memory architecture this builds on: `docs/design/memory-system.md`, `services/memory-governor/`, `services/watchdog/`.


### PR DESCRIPTION
## Summary
- Extracts unmerged design/planning docs from 4 stale local branches before they're deleted
- multi-tenant-design spec, voice-live web-app spec, ACA sandbox / observability / slack-bridge plans, Entra migration + vuln remediation plan
- Migration plan sanitized: private platform name genericized to "the operator platform" / "operator-prod" for the public template

## Test plan
- [x] Scanned all 6 docs for internal identifiers/secrets before commit
- [x] Verified `docs/notes/` placement matches existing convention (`docs/notes/specs/`, `docs/notes/plans/`)
- Docs-only change, no code/build impact