### PR TITLE
Fix fresh deploys: ACA-through-KV-firewall subnet endpoints, PG15 parameter rename

### DIFF
--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -46,10 +46,13 @@ module "keyvault" {
   public_network_access_enabled = var.key_vault_public_network_access_enabled
   network_default_action        = var.key_vault_network_default_action
   allowed_ip_ranges             = var.key_vault_allowed_ip_ranges
-  # aaf-0013: allowlist the app subnet through the default-Deny firewall. Empty
-  # by default (operator-gated) — set key_vault_allowed_subnet_ids, or rely on
-  # the private endpoint (hardened profile) / an allowed_ip_ranges egress entry.
-  allowed_subnet_ids = var.key_vault_allowed_subnet_ids
+  # aaf-0013: allowlist subnets through the default-Deny firewall. The app
+  # subnet is ALWAYS included (2026-07-15 deploy incident): Container Apps is
+  # not a Key Vault trusted service, so with the firewall at Deny every app's
+  # managed-identity secret fetch fails at revision provisioning unless its
+  # subnet is allowed. The subnet carries the Microsoft.KeyVault service
+  # endpoint (modules/network). Add more via key_vault_allowed_subnet_ids.
+  allowed_subnet_ids = concat([module.network.app_subnet_id], var.key_vault_allowed_subnet_ids)
 
   # List the principals that should have Key Vault Secrets Officer.
   # Replace with your own Azure AD object IDs before deploying.
@@ -114,8 +117,10 @@ module "container_apps" {
   # relies on the AzureServices/Logging/Metrics bypass; same operator-gated
   # pattern as the Key Vault allowlists above. See variables.tf and
   # modules/container-apps/storage.tf.
-  storage_allowed_ip_ranges  = var.storage_allowed_ip_ranges
-  storage_allowed_subnet_ids = var.storage_allowed_subnet_ids
+  storage_allowed_ip_ranges = var.storage_allowed_ip_ranges
+  # App subnet always allowed — same ACA-not-a-trusted-service rationale as the
+  # Key Vault allowlist above (file-share mounts fetch through the data plane).
+  storage_allowed_subnet_ids = concat([module.network.app_subnet_id], var.storage_allowed_subnet_ids)
 
   # PostgreSQL credentials for Honcho
   postgres_admin_username = var.postgres_admin_username

--- a/infrastructure/modules/network/main.tf
+++ b/infrastructure/modules/network/main.tf
@@ -35,6 +35,15 @@ resource "azurerm_subnet" "app" {
   virtual_network_name = local.vnet_name
   address_prefixes     = var.subnet_app_address_prefixes
 
+  # aaf-0013/0014 follow-on (2026-07-15 deploy): with the Key Vault / storage
+  # firewalls at default-Deny, Container Apps' managed identities can't fetch
+  # secrets — ACA is NOT a Key Vault trusted service, so the AzureServices
+  # bypass never applies and revision provisioning fails with "unable to fetch
+  # secret ... using Managed identity". Service endpoints let the app subnet be
+  # allowlisted via key_vault_allowed_subnet_ids / storage_allowed_subnet_ids
+  # (subnet rules REQUIRE the matching endpoint on the subnet).
+  service_endpoints = ["Microsoft.KeyVault", "Microsoft.Storage"]
+
   delegation {
     name = "container-apps"
     service_delegation {

--- a/infrastructure/modules/postgres/main.tf
+++ b/infrastructure/modules/postgres/main.tf
@@ -69,7 +69,11 @@ resource "azurerm_postgresql_flexible_server_configuration" "log_connections" {
 }
 
 resource "azurerm_postgresql_flexible_server_configuration" "connection_throttling" {
-  name      = "connection_throttling" # AZU-0021: throttle repeated failed auth
+  # AZU-0021: throttle repeated failed auth. On Flexible Server / PG15 the
+  # parameter is `connection_throttle.enable` — the bare `connection_throttling`
+  # name is Single Server-era and the API rejects it with ParameterNotExists
+  # (bit the 2026-07-15 deploy).
+  name      = "connection_throttle.enable"
   server_id = azurerm_postgresql_flexible_server.main.id
   value     = "on"
 }


### PR DESCRIPTION
Found by running the first fresh deploy since the aaf-0013/0014 default-Deny firewall hardening. Three fixes:

1. **App subnet service endpoints** (`Microsoft.KeyVault`, `Microsoft.Storage`) — ACA is not a KV trusted service; with Deny firewalls, every container app failed revision provisioning on managed-identity secret fetch.
2. **App subnet always in both allowlists** (env main.tf concat) — not operator-optional: no app can boot on a fresh deploy without it.
3. **PG15 rename**: `connection_throttling` → `connection_throttle.enable` (ParameterNotExists on Flexible Server PG15).

Deploy verified live end-to-end: all three apps Succeeded/Running, router registered the Foundry grok tier, `budget_enforce mode=warn` active.

Runner notes: build+push images before full apply; paperclip needs `PAPERCLIP_VERSION=v2026.707.0` (patch-adapter targets the 707 workspace layout); hermes' `secfix-0fbac31` pin needs an `az acr import` retag from the fresh build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)