### PR TITLE
fix(ci): stop gitleaks flagging Slack's docs placeholder in design notes

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -20,3 +20,14 @@ paths = ['''(.*)?\.example$''', '''README\.md''']
 [[allowlists]]
 description = "static demo/sample UI fixtures — feature-flag & capability keys are not secrets"
 paths = ['''demos/.*\.html$''', '''installer/static/.*\.html$''']
+
+# Design notes under docs/notes/ quote test fixtures verbatim. The Slack
+# signing-secret placeholder below is Slack's own published documentation
+# example (note the literal "yyyzzz" filler), not a credential. Scoped with
+# condition = "AND" so docs/notes/ is NOT blanket-exempt — only this known
+# placeholder string is allowed, and only inside those notes.
+[[allowlists]]
+description = "Slack docs placeholder signing secret quoted in design notes"
+condition = "AND"
+paths = ['''docs/notes/.*\.md$''']
+regexes = ['''8f742231b10e8888abcd99yyyzzz[0-9a-z]{4,}''']


### PR DESCRIPTION
## Problem

`secret-scan` has failed on `main` since `e77d2fd` (the design-notes import), so CI has been red for `e77d2fd`, `db901a2`, `6057a27`, and `c1002e4`.

Single finding: `generic-api-key` at `docs/notes/plans/2026-06-25-slack-bridge.md:389`.

## Why it is a false positive

The flagged value is the `_SECRET` constant of a pytest fixture quoted verbatim inside the design notes. It is Slack's own published documentation placeholder — `8f742231b10e8888abcd99yyyzzz…`, with the literal `yyyzzz` filler. Not a credential, nothing to rotate.

## Fix

One `[[allowlists]]` entry using `condition = "AND"`, so `docs/notes/` is **not** blanket-exempt — only that known placeholder string is allowed, and only inside those notes. Any other secret-shaped value in the same tree still fails the scan.

## Verification

Run locally with gitleaks 8.30.1, the version CI pins:

- `gitleaks git . --config .gitleaks.toml` → `no leaks found` (was `leaks found: 1`)
- Remaining `gitleaks dir` hits in a local worktree come only from populated `apps/*/src` submodules and gitignored `*.tfstate*`; CI checks out with `submodules: false`, so its `dir` scan was already clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)