### PR TITLE
fix(build): read the paperclip upstream pin from the Dockerfile, not a stale copy

### DIFF
--- a/scripts/build-and-push.sh
+++ b/scripts/build-and-push.sh
@@ -32,12 +32,26 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 ALL_SERVICES="model-router memory-governor watchdog teams-bridge agent-runtime honcho paperclip"
 SELF_CONTAINED="model-router memory-governor watchdog teams-bridge"
 
-# Default build-args for the paperclip upstream pin (match the Dockerfile ARGs).
+# Build-args for the paperclip upstream pin. These are READ FROM THE DOCKERFILE
+# ARG defaults rather than duplicated here: hardcoded copies drifted once (the
+# v2026.707.0 bump landed in the Dockerfile only), and because --build-arg wins
+# over the ARG default, the stale copy silently built the OLD upstream. That
+# clone predates packages/adapters/hermes, so patch-adapter.mjs then aborted the
+# build looking for @paperclipai/hermes-paperclip-adapter.
+#
 # EXPECTED_SHA guards against git-tag drift: the build fails if the cloned tag
 # resolves to a different commit. Resolve with:
 #   git ls-remote https://github.com/paperclipai/paperclip refs/tags/<tag>
-PAPERCLIP_VERSION="${PAPERCLIP_VERSION:-v2026.517.0}"
-PAPERCLIP_EXPECTED_SHA="${PAPERCLIP_EXPECTED_SHA:-3e6610fb938d04638fa578a1fc0d119b434fa2e4}"
+paperclip_arg_default() {
+  sed -n "s/^ARG $1=\\(.*\\)\$/\\1/p" "$REPO_ROOT/services/paperclip/Dockerfile" | head -1
+}
+PAPERCLIP_VERSION="${PAPERCLIP_VERSION:-$(paperclip_arg_default PAPERCLIP_VERSION)}"
+PAPERCLIP_EXPECTED_SHA="${PAPERCLIP_EXPECTED_SHA:-$(paperclip_arg_default PAPERCLIP_EXPECTED_SHA)}"
+[ -n "$PAPERCLIP_VERSION" ] && [ -n "$PAPERCLIP_EXPECTED_SHA" ] || {
+  echo "ERROR: could not read PAPERCLIP_VERSION / PAPERCLIP_EXPECTED_SHA from" \
+       "services/paperclip/Dockerfile — pass them as env vars, or restore the ARG lines." >&2
+  exit 1
+}
 
 REGISTRY=""
 TAG=""


### PR DESCRIPTION
## Problem

The `paperclip` image has not been buildable since `5d25f4b` bumped the vendored PaperClip to `v2026.707.0`. That commit updated `services/paperclip/Dockerfile`'s ARG defaults; `scripts/build-and-push.sh` kept its own hardcoded copies at `v2026.517.0` / `3e6610fb`. Since `--build-arg` wins over an `ARG` default, every `az acr build` cloned the **old** upstream.

`v2026.517.0` predates `packages/adapters/hermes`, so `@paperclipai/hermes-paperclip-adapter` was absent from the tree, never landed in the `pnpm deploy --prod` bundle, and the build died at:

```
[patch-adapter] FATAL: workspace adapter @paperclipai/hermes-paperclip-adapter not found —
the vendored PaperClip (v2026.707.x) loads it at runtime; without this patch agent runs bypass the router
```

The `FATAL` is correct — it was telling the truth about a wrong-version clone.

## Fix

Read both values from the Dockerfile `ARG` defaults (env vars still override). The two can no longer drift, and the script fails loudly if the ARG lines disappear.

## Verification

- `--dry-run` now emits `--build-arg PAPERCLIP_VERSION=v2026.707.0` plus the matching SHA.
- Real build of `paperclip:4540494` against `aafregistry` succeeded, log shows `Copied src for @paperclipai/hermes-paperclip-adapter from /app/packages/adapters/hermes` then `[patch-adapter] All patches applied successfully`.
- All seven service images now exist at tag `4540494`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)