### PR TITLE
feat(seed): fail loudly when a Postgres DSN's user is not the server admin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
           shellcheck --severity=error scripts/*.sh
       - name: agent-loop canary self-check (offline)
         run: bash scripts/smoke-canary.sh --self-check
+      - name: keyvault seed DSN guard self-check (offline)
+        run: bash scripts/seed-keyvault.sh --self-check
 
   node-tests:
     runs-on: ubuntu-latest

--- a/scripts/seed-keyvault.sh
+++ b/scripts/seed-keyvault.sh
@@ -58,6 +58,24 @@ paperclip-db-url"
 # other readers) to treat PLACEHOLDER_VALUE as empty.
 PLACEHOLDER_VALUE="__unset__"
 
+# The externals that are Postgres DSNs. Their userinfo must match the server's
+# administrator_login — see check_dsn_username below for why that is worth a
+# hard failure here.
+DSN_SECRETS="postgres-connection-string paperclip-db-url"
+
+# Expected Postgres administrator_login. Read from POSTGRES_ADMIN_USERNAME, else
+# from the Terraform variable's default so the two cannot drift silently. Note
+# the deploy pipeline threads its own value (deploy.yml passes
+# -var="postgres_admin_username=${{ vars.POSTGRES_ADMIN_USERNAME || 'dbadmin' }}"),
+# so set the env var here to match whatever that repo variable says if it is not
+# the default.
+tf_admin_username_default() {
+  sed -n '/variable "postgres_admin_username"/,/^}/p' \
+    "$(dirname "$0")/../infrastructure/environments/dev/variables.tf" 2>/dev/null \
+    | sed -n 's/.*default *= *"\(.*\)".*/\1/p' | head -1
+}
+PG_ADMIN_USERNAME="${POSTGRES_ADMIN_USERNAME:-$(tf_admin_username_default)}"
+
 die() { echo "error: $*" >&2; exit 2; }
 
 usage() {
@@ -68,6 +86,11 @@ Usage: scripts/seed-keyvault.sh --vault NAME [options]
       --force        Overwrite secrets that already exist.
   -n, --dry-run      Print what would happen; never call `az keyvault secret set`.
   -l, --list         Print the secret inventory (generate vs external) and exit.
+      --postgres-admin-username NAME
+                     Expected Postgres administrator_login for the DSN guard.
+                     Default: $POSTGRES_ADMIN_USERNAME, else the Terraform
+                     variable default. Empty string disables the check.
+      --self-check   Offline self-test of the DSN guard; no vault, no network.
   -h, --help         This help.
 
 External secrets are read from env vars (claude-api-key -> CLAUDE_API_KEY):
@@ -94,6 +117,42 @@ secret_exists() {
   az keyvault secret show --vault-name "$VAULT" --name "$1" >/dev/null 2>&1
 }
 
+secret_value() {
+  az keyvault secret show --vault-name "$VAULT" --name "$1" \
+    --query value -o tsv 2>/dev/null
+}
+
+# Extract the userinfo name from a postgres DSN: scheme://USER:password@host/db
+# Prints nothing for a value that is not a DSN (e.g. the placeholder). Never
+# prints the password — callers echo only the username.
+dsn_username() {
+  printf '%s' "$1" | sed -n 's#^[a-zA-Z+]*://\([^:/@]*\):[^@]*@.*#\1#p'
+}
+
+# Guard: a DSN whose user disagrees with the server's administrator_login gets
+# FATAL "password authentication failed for user ..." at container start, which
+# reads as a password problem and sends you hunting the wrong secret. That cost
+# a six-day dev outage (2026-07-15 → 07-21): the environment was rebuilt with
+# the sanitized default `dbadmin` while both DSNs still carried the pre-v1.4
+# `vaultadmin`, inherited from the platform this repo was extracted from.
+#
+# administrator_login is immutable — changing it forces Postgres replacement —
+# so the DSN is what has to match, and mismatches are worth catching here rather
+# than in container logs days later.
+check_dsn_username() {
+  # check_dsn_username NAME VALUE
+  [ -n "$PG_ADMIN_USERNAME" ] || return 0
+  [ "$2" = "$PLACEHOLDER_VALUE" ] && return 0
+  actual="$(dsn_username "$2")"
+  [ -n "$actual" ] || return 0
+  [ "$actual" = "$PG_ADMIN_USERNAME" ] && return 0
+  die "$1 connects as user '$actual' but the Postgres administrator_login is \
+'$PG_ADMIN_USERNAME'. Every app using this DSN will fail with \
+\"password authentication failed for user \\\"$actual\\\"\" — which is a USERNAME \
+mismatch, not a password one. Fix the DSN (or pass \
+--postgres-admin-username to match a server that really does use '$actual')."
+}
+
 set_secret() {
   # set_secret NAME VALUE
   if [ "$DRY_RUN" -eq 1 ]; then
@@ -102,6 +161,46 @@ set_secret() {
   fi
   az keyvault secret set --vault-name "$VAULT" --name "$1" --value "$2" \
     --output none && echo "    set: $1"
+}
+
+# Offline self-test of the DSN guard: no vault, no az, no network. Runs in CI
+# next to the other scripts checks.
+self_check() {
+  fails=0
+  t() {
+    # t DESCRIPTION EXPECT_USER DSN EXPECT_RESULT(ok|fail)
+    PG_ADMIN_USERNAME="$2"
+    if ( check_dsn_username "self-check" "$3" ) >/dev/null 2>&1; then
+      got=ok
+    else
+      got=fail
+    fi
+    if [ "$got" = "$4" ]; then
+      echo "  PASS  $1"
+    else
+      echo "  FAIL  $1 (wanted $4, got $got)"; fails=$((fails + 1))
+    fi
+  }
+
+  echo "seed-keyvault: self-check (offline)…"
+  t "matching user passes" dbadmin \
+    "postgresql+psycopg://dbadmin:pw@host.postgres.database.azure.com:5432/honcho" ok
+  t "mismatched user fails (the 2026-07-15 outage)" dbadmin \
+    "postgresql+psycopg://vaultadmin:pw@host.postgres.database.azure.com:5432/honcho" fail
+  t "plain postgresql scheme parses" dbadmin \
+    "postgresql://vaultadmin:pw@host:5432/postgres" fail
+  t "placeholder is skipped" dbadmin "$PLACEHOLDER_VALUE" ok
+  t "non-DSN value is skipped" dbadmin "not-a-dsn" ok
+  t "empty expectation disables the check" "" \
+    "postgresql://whoever:pw@host:5432/db" ok
+  t "password containing an @ does not confuse the parser" dbadmin \
+    "postgresql://dbadmin:p@ss@host:5432/db" ok
+
+  if [ "$fails" -eq 0 ]; then
+    echo "seed-keyvault: self-check PASS"
+  else
+    echo "seed-keyvault: self-check FAIL ($fails)"; exit 1
+  fi
 }
 
 print_inventory() {
@@ -117,6 +216,8 @@ while [ $# -gt 0 ]; do
     --force) FORCE=1; shift ;;
     -n|--dry-run) DRY_RUN=1; shift ;;
     -l|--list) print_inventory; exit 0 ;;
+    --postgres-admin-username) PG_ADMIN_USERNAME="${2:-}"; shift 2 ;;
+    --self-check) self_check; exit 0 ;;
     -h|--help) usage; exit 0 ;;
     *) die "unknown argument: $1 (try --help)" ;;
   esac
@@ -147,11 +248,17 @@ for s in $EXTERNAL; do
     # Provided — set it, overwriting any prior value. This is what makes the
     # two-pass flow work: a placeholder seeded on pass 1 is replaced by the real
     # value (e.g. the connection strings from `terraform output`) on pass 2.
+    case " $DSN_SECRETS " in *" $s "*) check_dsn_username "$s" "$val" ;; esac
     set_secret "$s" "$val"; provided=$((provided + 1)); continue
   fi
   if [ "$DRY_RUN" -eq 0 ] && secret_exists "$s"; then
     # Already present (real value set earlier or out-of-band) — never clobber it
-    # with an empty placeholder.
+    # with an empty placeholder. Still check a DSN kept this way: the outage the
+    # guard exists for came from exactly this path, a stale vault value nobody
+    # was re-seeding.
+    case " $DSN_SECRETS " in
+      *" $s "*) check_dsn_username "$s" "$(secret_value "$s")" ;;
+    esac
     echo "    keep: $s (exists)"; kept=$((kept + 1)); continue
   fi
   # Unset and absent — seed a non-empty placeholder ($PLACEHOLDER_VALUE). Every


### PR DESCRIPTION
## Why

A DSN whose userinfo disagrees with the server's `administrator_login` fails at container start with:

```
FATAL: password authentication failed for user "vaultadmin"
```

The message names the password, so it points at the wrong secret. The real defect is the **username**.

This cost a six-day dev outage, 2026-07-15 → 07-21. The environment was rebuilt using the sanitized default `dbadmin`, while `postgres-connection-string` and `paperclip-db-url` still carried the pre-v1.4 `vaultadmin` inherited from the platform this repo was extracted from. `ca-paperclip-dev` and `ca-honcho-dev` were down the whole time; Log Analytics shows the failure starting 2026-07-15 09:50 and running continuously until the secrets were corrected.

Both DSNs are `external` secrets — operator-supplied, never generated by this script — so nothing in the repo could catch the drift.

## What

`seed-keyvault.sh` now validates the userinfo of both DSN secrets against the expected `administrator_login`:

- Source of truth: `POSTGRES_ADMIN_USERNAME`, else the Terraform variable's own `default`, parsed from `variables.tf` so the two cannot drift.
- Checks values **kept** from a previous run, not only newly provided ones — a stale vault value nobody re-seeds is exactly how this happened.
- Skips the `__unset__` placeholder and any non-DSN value.
- `--postgres-admin-username NAME` overrides; empty disables.

`administrator_login` is immutable (changing it forces Postgres replacement), so the DSN is always the side that must move — the error message says so.

## Verification

New `--self-check` runs offline (no vault, no `az`, no network) and is wired into the CI `scripts` job beside the canary self-check:

```
  PASS  matching user passes
  PASS  mismatched user fails (the 2026-07-15 outage)
  PASS  plain postgresql scheme parses
  PASS  placeholder is skipped
  PASS  non-DSN value is skipped
  PASS  empty expectation disables the check
  PASS  password containing an @ does not confuse the parser
```

Also confirmed against the real failure shape — `POSTGRES_CONNECTION_STRING=postgresql+psycopg://vaultadmin:…` now aborts the run with an actionable message instead of seeding a DSN that breaks every consumer. `shellcheck --severity=error` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)