### PR TITLE
docs(release): v1.8.0 — deploy-path repair after the v1.7 hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="#platform-status"><img src="https://img.shields.io/badge/status-running%20on%20Azure-brightgreen" alt="Status"></a>
-  <a href="ROADMAP.md"><img src="https://img.shields.io/badge/release-v1.7-blue" alt="Release v1.7"></a>
+  <a href="ROADMAP.md"><img src="https://img.shields.io/badge/release-v1.8-blue" alt="Release v1.8"></a>
   <a href="#license"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <a href="#quickstart"><img src="https://img.shields.io/badge/IaC-Terraform-623CE4" alt="Terraform"></a>
   <a href="#why-azureagentforge"><img src="https://img.shields.io/badge/cloud-Azure-0078D4" alt="Azure"></a>
@@ -167,6 +167,18 @@ The part most demos skip is what happens when a request is dangerous. Ask the or
 </p>
 
 ---
+
+## The v1.8 release
+
+v1.8 is a repair release, not a feature one. v1.7 hardened the platform's security posture; applying that hardening to a real subscription then broke the paths that install and update it. Every item is a defect found by running the thing, plus a guard so it fails loudly next time. No new features, no new flags, no migrations — if your environment is deployed and healthy, v1.8 changes what happens the next time you build an image, seed a vault, or deploy from scratch. Full detail in [`docs/releases/v1.8.0.md`](docs/releases/v1.8.0.md).
+
+**Fresh deploys work again.** The `Deny`-by-default Key Vault and storage firewalls from v1.7 blocked the deploy that creates the platform. Azure Container Apps is not a Key Vault trusted service, so the app subnet now carries service endpoints and is allowlisted alongside the runner's IP; storage rejects `/32`, so single addresses go in bare; and PostgreSQL 15 names its throttling parameter differently than the module assumed.
+
+**The paperclip image builds again.** The build script pinned its own copy of the vendored PaperClip version, which stopped matching the Dockerfile after the upstream bump — so every build silently cloned the wrong upstream and then failed on a workspace package that version doesn't contain. Both values now come from one place.
+
+**A misconfigured database URL fails at seed time instead of six days later.** Postgres reports a wrong *username* as `password authentication failed`, which points at the wrong secret. In the reference deployment that cost a six-day outage. `seed-keyvault.sh` now checks each DSN's user against the server's administrator login — including values kept from an earlier run, which is how the drift actually happened.
+
+**Dependencies.** `services/honcho` moves to Python 3.14, reversing the v1.7 revert now that the smoke suite passes on it. The equivalent `services/paperclip` bump stays open — its smoke job still fails.
 
 ## The v1.7 milestone
 
@@ -519,6 +531,7 @@ Start with the row that matches what you're trying to do; each doc opens with it
 | [`docs/design/memory-system.md`](docs/design/memory-system.md) | Governed-memory architecture (four planes, six classes, trust model, self-improvement loop); shipped flag-gated off; code under [`services/memory-governor/`](services/memory-governor/) + [`services/watchdog/`](services/watchdog/) |
 | [`docs/deploy-pipeline.md`](docs/deploy-pipeline.md) | Reference GitHub Actions deploy pipeline with a destroy-aware approval gate (OIDC, no stored secrets) |
 | [`docs/obsidian-memory-interface.md`](docs/obsidian-memory-interface.md) | Two-way memory ↔ Obsidian vault CLI: export governed memory, curate in Obsidian, sync edits back |
+| [`docs/releases/v1.8.0.md`](docs/releases/v1.8.0.md) | v1.8.0 release notes: deploy-path repair after the v1.7 firewall hardening, the DSN username guard, dependency bumps, upgrade notes |
 | [`docs/releases/v1.7.0.md`](docs/releases/v1.7.0.md) | Full grouped v1.7.0 release notes: platform features, security, examples & samples, docs & dependencies, upgrade notes |
 | [`docs/design/vendored-config-schema-guard.md`](docs/design/vendored-config-schema-guard.md) | Why config drift into a vendored app fails silently, the `validate-vendored-config` CI job that closes it, and the per-app validation strategy (Honcho, Hermes, PaperClip) |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -113,6 +113,20 @@ Turning the flag-gated differentiators real and closing day-2 operational gaps. 
 - **Observability + cost governance.** The model-router emits `gen_ai.usage` metrics (aggregatable token + cost counters by model/tier) alongside the v1.3 spans, threads a `correlation_id` onto the span, and attributes spend per caller (agent/tenant) with an optional per-caller daily cap and a `daily_cost_rollup`. The monitoring module gains an SLO-burn alert on sustained model-router upstream failures/fallbacks and a GenAI cost-per-day workbook tile. All flag-gated and fail-open; 194 offline router tests.
 - **Human-in-the-loop action approval.** A provider-pluggable action-approval seam ([`apps/paperclip/approval.mjs`](apps/paperclip/approval.mjs)) extends the v1.1 destroy-aware *infra* gate to runtime *actions* (an outbound message, a destructive tool call). Only kinds in `APPROVAL_REQUIRED_KINDS` are gated (default empty → inert); a gated action with no approver **fails closed**; a `webhook` provider delegates the decision to an external approver and fails closed on any error. Ships **unwired** (mirrors the sandbox seam); 15 offline tests.
 
+## v1.8: shipped
+
+*Why it matters: v1.7's security hardening broke the paths that install and update the platform. v1.8 fixes them, and adds guards so the same class of breakage announces itself instead of hiding.*
+
+A repair release. No new features, no new flags, no migrations — it changes what happens the next time you build an image, seed a vault, or deploy from scratch.
+
+- **Fresh deploys work again after the `Deny`-by-default firewalls** ([#122](https://github.com/mrobinson2/AzureAgentForge/pull/122)). A clean-subscription apply died mid-Pass-2 with `ForbiddenByFirewall` on the Key Vault data sources and a 403 on file-share reads, after plan-time reads had already succeeded — so it failed with billable resources standing. Azure Container Apps is **not** a Key Vault trusted service, so an IP allowlist alone never covers in-VNet callers: the app subnet now carries `Microsoft.KeyVault`/`Microsoft.Storage` service endpoints and is concatenated into both allowlists. Storage `ip_rules` rejects `/32`, so single addresses go in as bare IPs. PostgreSQL 15 names the throttling parameter `connection_throttle.enable`.
+- **The paperclip image is buildable again** ([#128](https://github.com/mrobinson2/AzureAgentForge/pull/128)). `scripts/build-and-push.sh` hardcoded its own `PAPERCLIP_VERSION`/`PAPERCLIP_EXPECTED_SHA`, which stopped matching the Dockerfile ARGs at the `v2026.707.0` bump. Because `--build-arg` beats an `ARG` default, every build cloned the old upstream — which predates `packages/adapters/hermes`, so `patch-adapter.mjs` aborted looking for a workspace package that version does not ship. Both values are now read from the Dockerfile.
+- **DSN username guard** ([#129](https://github.com/mrobinson2/AzureAgentForge/pull/129)). Postgres answers a username mismatch with `FATAL: password authentication failed for user "..."` — the message names the password and sends you to the wrong secret. That cost the reference deployment a six-day outage (2026-07-15 → 07-21) when a rebuild used the sanitized default admin login while both DSN secrets still carried the pre-v1.4 one. `seed-keyvault.sh` now validates `postgres-connection-string` and `paperclip-db-url` against the expected `administrator_login` (from `POSTGRES_ADMIN_USERNAME`, else the Terraform variable's own default), including values *kept* from an earlier run — the path the drift actually took. Offline `--self-check` runs it in CI.
+- **CI green again** ([#127](https://github.com/mrobinson2/AzureAgentForge/pull/127), [#130](https://github.com/mrobinson2/AzureAgentForge/pull/130)). Two gitleaks false positives in `docs/notes/` — Slack's published placeholder signing secret and a demo feature-flag key — allowlisted with `condition = "AND"` so only those literals are exempt, and only there. #130 also files the v1.7 release plan under `docs/notes/plans/` instead of leaving it untracked at the repo root.
+- **Dependencies.** `services/honcho` → `python:3.14-slim-bookworm` ([#125](https://github.com/mrobinson2/AzureAgentForge/pull/125)), reversing the v1.7 revert of #98 now that `local-stack-smoke` passes on 3.14; `astral-sh/uv` 0.11.29 ([#126](https://github.com/mrobinson2/AzureAgentForge/pull/126)); `actions/setup-node` 7 ([#123](https://github.com/mrobinson2/AzureAgentForge/pull/123)). The `services/paperclip` 3.14 bump ([#124](https://github.com/mrobinson2/AzureAgentForge/pull/124)) stays open — its smoke job still fails.
+
+Full grouped release notes: [`docs/releases/v1.8.0.md`](docs/releases/v1.8.0.md).
+
 ## v1.7: shipped
 
 *Why it matters: the memory system stays useful under real load instead of silently timing out, you get a daily digest of what needs your attention, and roughly 27 security findings across the codebase got fixed in one pass.*
@@ -146,11 +160,13 @@ Six merges, one theme: turn a way this platform — or an app it vendors — cou
 
 Full grouped release notes: [`docs/releases/v1.7.0.md`](docs/releases/v1.7.0.md).
 
-## Post-1.7 horizon
+## Post-1.8 horizon
 
-*In plain terms: tag the release, catch the agent runtime up to the latest upstream version, and close a few loose ends the last few releases created.*
+*In plain terms: catch the agent runtime up to the latest upstream version, and close a few loose ends the last few releases created.*
 
-The near-term direction after the v1.7 milestone, before the longer "Later" list below:
+The near-term direction after the v1.8 release, before the longer "Later" list below:
+
+- **Get `services/paperclip` onto Python 3.14** ([#124](https://github.com/mrobinson2/AzureAgentForge/pull/124)), which needs the smoke failure diagnosed rather than the bump merged on green-looking checks.
 
 - **Bump the vendored Hermes submodule to v0.18.1.** Previously blocked by the config/auth incidents the v1.7 reliability-hardening vendored-defaults and canary items fix; unblocked now.
 - **Identity map + peer re-consolidation sweep.** An alias table at admission plus a background sweep that detects and merges unexpected peers — the production backstop the canonical-peer design ([`docs/design/memory-system.md` §18](docs/design/memory-system.md#18-identity-the-canonical-user-peer)) names as a separate enhancement.

--- a/docs/releases/v1.8.0.md
+++ b/docs/releases/v1.8.0.md
@@ -1,0 +1,135 @@
+# v1.8.0 — release notes
+
+> **Technical reference for contributors.** For the operational overview, start at [README](../../README.md) or [Architecture](../architecture.md).
+
+v1.8 is a repair release. v1.7 hardened the platform's security posture and shipped
+the reliability-hardening batch; applying that hardening to a real subscription then
+broke the paths that install and update the platform. Every item below is a defect
+found by running the thing, plus the guards that make each defect fail loudly the
+next time instead of silently.
+
+Nothing here adds a runtime feature or a flag. No migrations. The deploy footprint
+is unchanged. If your environment is already deployed and healthy, v1.8 changes
+what happens the *next* time you build an image, seed a vault, or deploy from
+scratch.
+
+The v1.7 tag was cut on 2026-07-11, before the reliability-hardening merges
+(#112–#117) reached `main`. Those merges are described in the v1.7 milestone docs
+and are contained in this tag; see [`v1.7.0.md`](v1.7.0.md) for their detail. This
+document covers only what is new since that documentation.
+
+---
+
+## Deploy-path repair
+
+1. **Fresh deploys work again after the `Deny`-by-default firewalls**
+   ([#122](https://github.com/mrobinson2/AzureAgentForge/pull/122)). The
+   aaf-0013/aaf-0014 remediation flipped Key Vault and the storage account to
+   `Deny` plus allowlist. A clean-subscription deploy then died partway through
+   Pass 2 with `ForbiddenByFirewall` on the Key Vault secret data sources and a
+   403 on the file-share reads — after plan-time reads had already succeeded, so
+   the failure landed mid-apply with billable resources standing. Three fixes:
+   the app subnet carries `Microsoft.KeyVault` and `Microsoft.Storage` service
+   endpoints and is concatenated into both allowlists (Azure Container Apps is
+   **not** a Key Vault trusted service, so an IP allowlist alone never covers
+   in-VNet callers); storage `ip_rules` rejects `/32`, so single addresses go in
+   as bare IPs; and PostgreSQL 15 Flexible Server names the throttling parameter
+   `connection_throttle.enable`, not `connection_throttling`.
+
+2. **The paperclip image is buildable again**
+   ([#128](https://github.com/mrobinson2/AzureAgentForge/pull/128)).
+   `scripts/build-and-push.sh` carried its own hardcoded copies of
+   `PAPERCLIP_VERSION` / `PAPERCLIP_EXPECTED_SHA`. When the vendored PaperClip
+   was bumped to `v2026.707.0` the Dockerfile ARGs moved and the script's copies
+   did not, and because `--build-arg` beats an `ARG` default, every `az acr build`
+   silently cloned the *old* upstream. That upstream predates
+   `packages/adapters/hermes`, so the workspace package
+   `@paperclipai/hermes-paperclip-adapter` did not exist, never landed in the
+   `pnpm deploy --prod` bundle, and `patch-adapter.mjs` aborted the build:
+
+   ```
+   [patch-adapter] FATAL: workspace adapter @paperclipai/hermes-paperclip-adapter not found
+   ```
+
+   The `FATAL` was correct — it was reporting a wrong-version clone. Both values
+   are now read from the Dockerfile ARG defaults, so the two cannot drift, and the
+   script fails loudly if those ARG lines disappear.
+
+3. **CI is green again** ([#127](https://github.com/mrobinson2/AzureAgentForge/pull/127),
+   [#130](https://github.com/mrobinson2/AzureAgentForge/pull/130)). `secret-scan`
+   had failed on `main` since the design-notes import. Two false positives, both
+   in `docs/notes/`: Slack's own published placeholder signing secret (the one
+   with the literal `yyyzzz` filler) quoted in a pytest fixture, and a demo
+   SMS feature-flag name written as a quoted `key:` assignment, which the
+   `generic-api-key` rule reads as a secret. Both allowlisted with
+   `condition = "AND"` so only those literals are exempt, and only inside
+   `docs/notes/` — every other secret-shaped value in those notes still fails the
+   scan. #130 also files the v1.7 merge-and-release plan under `docs/notes/plans/`,
+   where it had been sitting untracked at the repo root, outside git history and
+   one `git add -A` from an unreviewed commit.
+
+## Drift guards
+
+4. **A DSN whose user is not the server admin now fails at seed time**
+   ([#129](https://github.com/mrobinson2/AzureAgentForge/pull/129)). Postgres
+   answers a username mismatch with `FATAL: password authentication failed for
+   user "..."`. The message names the password, so it sends you auditing the
+   wrong secret. In the reference deployment this cost a six-day outage
+   (2026-07-15 → 07-21): the environment was rebuilt using the sanitized default
+   admin login while both DSN secrets still carried the pre-v1.4 login inherited
+   from the platform this repo was extracted from. Both container apps were down
+   the entire time and the failure read as a password problem throughout.
+
+   `postgres-connection-string` and `paperclip-db-url` are `external` secrets —
+   operator-supplied, never generated — so nothing in the repo could catch the
+   drift. `seed-keyvault.sh` now validates their userinfo against the expected
+   `administrator_login`, taken from `POSTGRES_ADMIN_USERNAME` or, failing that,
+   parsed from the Terraform variable's own `default` so the two cannot diverge.
+   It checks values *kept* from an earlier run, not only newly provided ones — a
+   stale vault value nobody re-seeds is exactly how this happened.
+   `administrator_login` is immutable (changing it forces server replacement), so
+   the DSN is always the side that must move, and the error message says so.
+   `--postgres-admin-username` overrides for a server that genuinely uses a
+   different login; an empty value disables the check. A new offline
+   `--self-check` covers the parser's cases (including a password containing an
+   `@`) and runs in the CI `scripts` job.
+
+   Two related notes for operators, learned the same week:
+
+   - Pinning a value in one deploy path and not the other is drift waiting to
+     happen. The admin login was pinned for the CI path via a repo variable while
+     the local `terraform.tfvars` path kept the default, and the two disagreed the
+     moment someone deployed locally.
+   - Azure Container Apps resolves Key Vault secret references **per revision** and
+     caches them. Correcting a secret requires a new revision; `az containerapp
+     revision restart` keeps serving the cached value.
+
+## Dependencies
+
+5. **`services/honcho` moves to `python:3.14-slim-bookworm`**
+   ([#125](https://github.com/mrobinson2/AzureAgentForge/pull/125)). This
+   reverses the correction recorded in
+   [`v1.7.0.md`](v1.7.0.md) item 14, where the same bump (#98) was reverted in
+   #108 because the smoke suite failed on 3.14. The suite now passes on it —
+   including `local-stack-smoke`, which builds and runs the service rather than
+   only type-checking it — so the bump stands. The `services/paperclip` 3.14 bump
+   ([#124](https://github.com/mrobinson2/AzureAgentForge/pull/124)) is **not** in
+   this release: its smoke job still fails, and it stays open until it doesn't.
+
+6. **Routine bumps.** `astral-sh/uv` 0.11.28 → 0.11.29 in `services/honcho`
+   ([#126](https://github.com/mrobinson2/AzureAgentForge/pull/126)) and
+   `actions/setup-node` 6 → 7 ([#123](https://github.com/mrobinson2/AzureAgentForge/pull/123)).
+
+---
+
+## Upgrading
+
+No migrations, no new flags, no configuration changes.
+
+If you deploy from a clean subscription, #122 is the fix you need — earlier tags
+cannot complete a fresh apply against the hardened firewalls. If you build images,
+rebuild `paperclip` on this tag; any image built between the PaperClip 707 bump and
+#128 either failed or came from the wrong upstream. If you seed a Key Vault, expect
+`seed-keyvault.sh` to now reject a DSN whose user disagrees with your Postgres
+`administrator_login` — that check is the point, and the fix is the DSN, not the
+guard.


### PR DESCRIPTION
## What this release is

A repair release, not a feature one. v1.7 hardened the security posture; applying that hardening to a real subscription broke the paths that install and update the platform. v1.8 collects the repairs, plus the guards that make the same class of breakage fail loudly next time.

No new features, no new flags, no migrations. For an already-deployed healthy environment, v1.8 changes what happens the *next* time you build an image, seed a vault, or deploy from scratch.

## Contents

- `docs/releases/v1.8.0.md` — grouped notes: deploy-path repair (#122, #128, #127, #130), the DSN username guard (#129) and the six-day outage that motivated it, dependency bumps (#123, #125, #126), and upgrade notes.
- `README.md` — a "The v1.8 release" section above the v1.7 milestone, the release badge, and a docs-table row.
- `ROADMAP.md` — a "v1.8: shipped" section; the horizon section becomes post-1.8 and picks up the still-open `services/paperclip` Python 3.14 bump.

## Scope note

The v1.7 tag was cut 2026-07-11, before the reliability-hardening merges (#112–#117) reached `main`. Those are described in the v1.7 milestone docs and are contained in this tag, so `v1.8.0.md` covers only what is new since that documentation — otherwise the same work would be enumerated twice.

`services/paperclip` Python 3.14 (#124) is deliberately excluded and named as excluded: its smoke job still fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)