### PR TITLE
fix(identity): resolve each agent's own slug, and stop defaulting to a system peer

### DIFF
--- a/apps/hermes/overrides/skills/playbooks/honcho-memory/scripts/pc-memory.sh
+++ b/apps/hermes/overrides/skills/playbooks/honcho-memory/scripts/pc-memory.sh
@@ -38,7 +38,14 @@ set -e
 BASE="${GOVERNOR_BASE_URL:-http://ca-memory-governor-dev}"
 KEY="${GOVERNOR_API_KEY:-}"
 WORKSPACE="${GOVERNOR_WORKSPACE:-${HONCHO_APP_ID:-hermes-dev}}"
-AGENT="${PAPERCLIP_AGENT_SLUG:-${GOVERNOR_AGENT_SLUG:-operator}}"
+# Agent identity. The fallback is deliberately an UNPRIVILEGED, obviously-wrong
+# slug, not "operator": the governor maps "operator" to the SYSTEM memory
+# profile (write: every class), so defaulting there silently handed any agent
+# whose slug failed to resolve full write authority — the opposite of the
+# per-agent profile enforcement this identity is for. An unknown slug falls to
+# SPECIALIST (profiles.profile_for), which is least-privilege, and the peer name
+# says plainly that identity resolution failed.
+AGENT="${PAPERCLIP_AGENT_SLUG:-${GOVERNOR_AGENT_SLUG:-unknown-agent}}"
 # A5: canonical user peer. `record` sends `observed` EXPLICITLY instead of
 # leaning on the governor's server-side default — an omitted field is how
 # writes fragment across peers when any component's default drifts. The same

--- a/apps/paperclip/patch-adapter.mjs
+++ b/apps/paperclip/patch-adapter.mjs
@@ -95,6 +95,41 @@ if (!execute.includes("if (ctx.runId)")) {
   }
 }
 
+// ── Fix 2b: agent identity — inject PAPERCLIP_AGENT_SLUG ────────────────────
+// Upstream's buildPaperclipEnv gives the spawned Hermes PAPERCLIP_AGENT_ID (a
+// UUID) and PAPERCLIP_COMPANY_ID — but no slug. The memory helpers key identity
+// off PAPERCLIP_AGENT_SLUG, so without this every agent's writes collapse onto
+// one peer: memory cannot be attributed per agent, and the governor's per-agent
+// memoryProfile is enforced against the wrong identity.
+//
+// Derived from the agent's display name using the SAME convention the rest of
+// the platform already uses (services/watchdog/roster.py's name→slug map and
+// governor/profiles.py's keys): camel-case boundaries become hyphens, then
+// lowercase — "Researcher" → "researcher", "CostGuardian" → "cost-guardian",
+// "QA" → "qa" (an all-caps run has no boundary to split).
+const AGENT_SLUG_INJECTION =
+  "if (ctx.agent?.name) env.PAPERCLIP_AGENT_SLUG = String(ctx.agent.name)" +
+  ".replace(/([a-z0-9])([A-Z])/g, '$1-$2').trim().toLowerCase()" +
+  ".replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');\n    ";
+
+if (!execute.includes("env.PAPERCLIP_AGENT_SLUG")) {
+  if (execute.includes("if (ctx.runId)")) {
+    execute = execute.replace("if (ctx.runId)", AGENT_SLUG_INJECTION + "if (ctx.runId)");
+    console.log("[patch-adapter] Injected PAPERCLIP_AGENT_SLUG (per-agent memory identity)");
+  } else {
+    // Fail loud: silently shipping without this returns the platform to one
+    // shared memory peer, which is exactly the failure mode we are closing.
+    console.error(
+      "[patch-adapter] FATAL: 'if (ctx.runId)' anchor not found — PAPERCLIP_AGENT_SLUG " +
+      "NOT injected. Every agent would write memory under the same fallback peer and " +
+      "be profiled as the wrong identity. Re-inspect execute.ts and update this patch."
+    );
+    process.exit(1);
+  }
+} else {
+  console.log("[patch-adapter] PAPERCLIP_AGENT_SLUG already present (cached layer) — no-op");
+}
+
 // AzureAgentForge cost-envelope — forward the per-run id + budget ceiling to the
 // spawned Hermes (ROUTER_RUN_ID = ctx.runId; ROUTER_BUDGET_ENVELOPE_USD from the
 // container env). patch-hermes-cost-envelope.mjs then relays them into the

--- a/tests/paperclip/agent-slug-injection.test.mjs
+++ b/tests/paperclip/agent-slug-injection.test.mjs
@@ -1,0 +1,96 @@
+/**
+ * Agent identity — PAPERCLIP_AGENT_SLUG injection.
+ *
+ * Upstream's buildPaperclipEnv hands the spawned Hermes PAPERCLIP_AGENT_ID (a
+ * UUID) and PAPERCLIP_COMPANY_ID, but no slug. The memory helpers key identity
+ * off PAPERCLIP_AGENT_SLUG, so without the injection every agent's writes
+ * collapse onto one fallback peer — memory cannot be attributed per agent, and
+ * the governor enforces the per-agent memoryProfile against the wrong identity.
+ *
+ * The slug must match the platform's existing convention exactly, because three
+ * places have to agree on it: services/watchdog/roster.py's name→slug map,
+ * governor/profiles.py's profile keys, and this injection. These tests pin the
+ * injected expression against that map, so drift in either direction fails.
+ *
+ * Offline: reads the patch source, evaluates only the injected expression.
+ */
+
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const PATCH_SRC = readFileSync(
+  new URL("../../apps/paperclip/patch-adapter.mjs", import.meta.url),
+  "utf-8",
+);
+
+/** Pull the injected slug expression out of the patch and make it callable. */
+function slugifyFromPatch(name) {
+  const m = PATCH_SRC.match(
+    /const AGENT_SLUG_INJECTION =\s*([\s\S]*?);\n\nif \(!execute\.includes/,
+  );
+  assert.ok(m, "AGENT_SLUG_INJECTION not found — did the patch get restructured?");
+  // The constant is a JS-source string; evaluate it to get the concatenated code.
+  const injected = eval(m[1]); // eslint-disable-line no-eval
+  const expr = injected
+    .replace(/^if \(ctx\.agent\?\.name\) env\.PAPERCLIP_AGENT_SLUG = /, "")
+    .trim()
+    .replace(/;\s*$/, "");
+  const ctx = { agent: { name } };
+  const env = {};
+  // eslint-disable-next-line no-eval
+  return eval(`(function (ctx, env) { return ${expr}; })`)(ctx, env);
+}
+
+// Every slug the governor's DEFAULT_PROFILES and the watchdog roster know, keyed
+// by the display name PaperClip actually carries on the agent record.
+const ROSTER = [
+  ["Orchestrator", "orchestrator"],
+  ["Strategy", "strategy"],
+  ["Planner", "planner"],
+  ["Coder", "coder"],
+  ["Infrastructure", "infrastructure"],
+  ["Researcher", "researcher"],
+  ["Coach", "coach"],
+  ["Business", "business"],
+  ["Psychology", "psychology"],
+  ["QA", "qa"],
+  ["Security", "security"],
+  ["CostGuardian", "cost-guardian"],
+  ["Curator", "curator"],
+];
+
+test("every roster display name maps to its canonical slug", () => {
+  for (const [name, slug] of ROSTER) {
+    assert.equal(slugifyFromPatch(name), slug, `${name} must slug to ${slug}`);
+  }
+});
+
+test("an all-caps name is not split mid-acronym", () => {
+  // "QA" -> "qa", never "q-a": the boundary rule only fires lower→upper.
+  assert.equal(slugifyFromPatch("QA"), "qa");
+});
+
+test("spaces and stray punctuation normalize to single hyphens", () => {
+  assert.equal(slugifyFromPatch("Cost Guardian"), "cost-guardian");
+  assert.equal(slugifyFromPatch("  Coder  "), "coder");
+  assert.equal(slugifyFromPatch("Q&A / Testing"), "q-a-testing");
+});
+
+test("no leading or trailing hyphens survive", () => {
+  assert.equal(slugifyFromPatch("!Researcher!"), "researcher");
+});
+
+test("the injection is guarded on ctx.agent?.name", () => {
+  // An agent record without a name must not produce PAPERCLIP_AGENT_SLUG="" —
+  // an empty slug is a peer id, and an empty peer is its own accidental identity.
+  assert.match(PATCH_SRC, /if \(ctx\.agent\?\.name\) env\.PAPERCLIP_AGENT_SLUG/);
+});
+
+test("a missing anchor fails the build rather than shipping silently", () => {
+  // Shipping without the injection returns the platform to one shared memory
+  // peer. That has to be a build failure, not a warning nobody reads.
+  const block = PATCH_SRC.slice(PATCH_SRC.indexOf("AGENT_SLUG_INJECTION"));
+  assert.match(block, /FATAL: 'if \(ctx\.runId\)' anchor not found/);
+  assert.match(block, /process\.exit\(1\)/);
+});

--- a/tests/skills/test_agent_slug_identity.py
+++ b/tests/skills/test_agent_slug_identity.py
@@ -1,0 +1,102 @@
+"""Agent identity in the memory helper — observer/created_by_peer, and the
+fallback when the slug does not resolve.
+
+Two things are pinned here:
+
+1. `pc-memory record` attributes the write to PAPERCLIP_AGENT_SLUG, so memory is
+   per-agent rather than collapsed onto one shared peer.
+2. The fallback when no slug is set is an UNPRIVILEGED slug — not "operator".
+   governor/profiles.py maps "operator" to the SYSTEM profile (write: every
+   class), so the old fallback silently handed any agent whose identity failed to
+   resolve full write authority, defeating the per-agent memoryProfile it is
+   supposed to be checked against. An unknown slug falls to SPECIALIST, which is
+   least-privilege.
+
+Offline: curl is stubbed onto PATH and logs its argv; nothing is contacted.
+See docs/design/memory-system.md §18.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO / "apps" / "hermes" / "overrides" / "skills" / "playbooks" / "honcho-memory" / "scripts"
+PROFILES = REPO / "services" / "memory-governor" / "src" / "governor" / "profiles.py"
+
+CURL_STUB = """#!/bin/sh
+{
+for a in "$@"; do printf 'ARG:%s\\n' "$a"; done
+printf 'CALL-END\\n'
+} >> "$CURL_LOG"
+"""
+
+
+def _record(tmp_path, extra_env=None, unset=()):
+    """Run `pc-memory record` with a stubbed curl; return the JSON body sent."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    stub = bin_dir / "curl"
+    stub.write_text(CURL_STUB)
+    stub.chmod(0o755)
+    log = tmp_path / "curl.log"
+    log.write_text("")
+
+    env = dict(os.environ)
+    for name in ("PAPERCLIP_AGENT_SLUG", "GOVERNOR_AGENT_SLUG", *unset):
+        env.pop(name, None)
+    env.update(extra_env or {})
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["CURL_LOG"] = str(log)
+    env.setdefault("GOVERNOR_API_KEY", "test-key")
+
+    subprocess.run(
+        ["sh", str(SCRIPTS / "pc-memory.sh"), "record",
+         "--content", "the user's dog is named Biscuit"],
+        env=env, capture_output=True, text=True, timeout=30,
+    )
+    args = [l[4:] for l in log.read_text().splitlines() if l.startswith("ARG:")]
+    for i, a in enumerate(args):
+        if a == "-d" and i + 1 < len(args):
+            return json.loads(args[i + 1])
+    raise AssertionError(f"no JSON body in curl args: {args}")
+
+
+def test_record_attributes_the_write_to_the_agent_slug(tmp_path):
+    body = _record(tmp_path, {"PAPERCLIP_AGENT_SLUG": "researcher"})
+    assert body["observer"] == "researcher"
+    assert body["created_by_peer"] == "researcher"
+
+
+def test_governor_slug_is_the_second_source(tmp_path):
+    body = _record(tmp_path, {"GOVERNOR_AGENT_SLUG": "watchdog"})
+    assert body["created_by_peer"] == "watchdog"
+
+
+def test_paperclip_slug_wins_over_governor_slug(tmp_path):
+    body = _record(
+        tmp_path, {"PAPERCLIP_AGENT_SLUG": "coder", "GOVERNOR_AGENT_SLUG": "watchdog"}
+    )
+    assert body["created_by_peer"] == "coder"
+
+
+def test_fallback_is_not_the_privileged_operator_peer(tmp_path):
+    # The regression this guards: "operator" carries the SYSTEM profile, so an
+    # unresolved identity used to inherit write authority over every memory
+    # class. The fallback must be a slug the profile table does NOT special-case.
+    body = _record(tmp_path)
+    assert body["created_by_peer"] != "operator"
+    assert body["observer"] != "operator"
+    assert body["created_by_peer"] == "unknown-agent"
+
+
+def test_fallback_slug_is_absent_from_the_governor_profile_table(tmp_path):
+    # Pins the two files together: if someone later adds "unknown-agent" to
+    # DEFAULT_PROFILES with elevated write authority, this fails rather than
+    # quietly restoring the privilege bug.
+    profiles_src = PROFILES.read_text()
+    assert '"unknown-agent"' not in profiles_src, (
+        "the helper's fallback slug must stay out of DEFAULT_PROFILES so it "
+        "resolves to the least-privilege SPECIALIST default"
+    )


### PR DESCRIPTION
Found while verifying the v1.8.1 identity work end to end. Two defects on the write path that together meant **agent-level identity did not function at all**.

## 1. The slug was never set

Upstream's `buildPaperclipEnv` gives the spawned Hermes `PAPERCLIP_AGENT_ID` (a UUID) and `PAPERCLIP_COMPANY_ID` — but no slug. `grep -rn PAPERCLIP_AGENT_SLUG` across this repo returns exactly one hit: the helper *reading* it. Nothing ever wrote it.

So every agent's memory writes collapsed onto one fallback peer. Memory could not be attributed per agent, and v1.8.1's roster check would have reported the fallback rather than seeing real agent peers.

## 2. The fallback was a privileged identity

That fallback was `operator`, which `governor/profiles.py` maps to `SYSTEM` — `write: ALL_CLASSES`.

So an agent whose identity failed to resolve did not merely lose attribution; it **inherited unrestricted write authority**. Admission's `profiles.can_write` check was being evaluated against the wrong, more privileged identity — a specialist limited to `task_scoped`/`ephemeral` could write any class, including `durable_fact` and `pinned`. Least privilege inverted by a default.

## Fixes

- **`patch-adapter.mjs`** injects `PAPERCLIP_AGENT_SLUG` from `ctx.agent.name`, derived with the convention the platform already uses in two other places (`watchdog/roster.py`'s name→slug map and `profiles.py`'s keys): camel boundaries → hyphens, lowercase. `Researcher`→`researcher`, `CostGuardian`→`cost-guardian`, `QA`→`qa` (no mid-acronym split). A missing anchor **fails the build** — shipping without the injection silently returns the platform to one shared peer.
- **`pc-memory.sh`** falls back to `unknown-agent`: deliberately absent from `DEFAULT_PROFILES` so it resolves to the least-privilege `SPECIALIST` default, and named so the peer itself says identity resolution failed.

## Verification

- `tests/paperclip/agent-slug-injection.test.mjs` — pins the injected expression against all 13 roster display names, plus acronym handling, spacing/punctuation, the `ctx.agent?.name` guard, and the fail-loud contract.
- `tests/skills/test_agent_slug_identity.py` — attribution, `PAPERCLIP_AGENT_SLUG` > `GOVERNOR_AGENT_SLUG` precedence, the non-privileged fallback, and a guard that the fallback slug stays out of `DEFAULT_PROFILES` (so nobody restores the privilege bug by adding it later).
- Suites: node **17 passed**, skills **11 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)