### PR TITLE
fix(governor): ship the migrations in the image, and stop reporting success without them

### DIFF
--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -139,6 +139,11 @@ module "container_apps" {
   honcho_image_tag    = var.honcho_image_tag
   router_image_tag    = var.router_image_tag
   paperclip_image_tag = var.paperclip_image_tag
+  # Only consumed when memory_governor_enabled = true. Without these the module
+  # falls back to "latest", which this registry never publishes (aaf-0025 pins
+  # explicit tags), so enabling the governor would fail the image pull.
+  memory_governor_image_tag = var.memory_governor_image_tag
+  watchdog_image_tag        = var.watchdog_image_tag
 
   # Paperclip orchestrator config
   paperclip_public_url        = var.paperclip_public_url

--- a/infrastructure/environments/dev/variables.tf
+++ b/infrastructure/environments/dev/variables.tf
@@ -188,6 +188,18 @@ variable "router_image_tag" {
   default     = "latest"
 }
 
+variable "memory_governor_image_tag" {
+  description = "memory-governor container image tag. Consumed only when memory_governor_enabled = true; the governor image also backs the sweeper and digest jobs. Pin an explicit tag (aaf-0025) — \"latest\" is never published to the registry."
+  type        = string
+  default     = "latest"
+}
+
+variable "watchdog_image_tag" {
+  description = "watchdog container image tag, used by the watchdog job the governor module creates. Consumed only when memory_governor_enabled = true. Pin an explicit tag (aaf-0025)."
+  type        = string
+  default     = "latest"
+}
+
 variable "paperclip_image_tag" {
   description = "Paperclip orchestrator container image tag (set by CI/CD pipeline)"
   type        = string

--- a/services/memory-governor/Dockerfile
+++ b/services/memory-governor/Dockerfile
@@ -22,6 +22,13 @@ RUN groupadd --gid 1001 appgroup && \
 
 COPY --from=builder /install /usr/local
 COPY --chown=appuser:appgroup src/governor /app/governor
+# The schema overlay the governor applies on startup. governor/migrate.py
+# resolves MIGRATIONS_DIR relative to its own file — /app/governor/migrate.py →
+# parents[2] → "/" — so the SQL must land at /migrations, mirroring the repo
+# layout where it sits beside src/. Without this the image ships no migrations,
+# apply() finds nothing, and every flag lookup fails on a missing feature_flags
+# table while the boot log still says the schema is up to date.
+COPY --chown=appuser:appgroup migrations /migrations
 
 USER appuser
 

--- a/services/memory-governor/src/governor/migrate.py
+++ b/services/memory-governor/src/governor/migrate.py
@@ -28,8 +28,26 @@ CREATE TABLE IF NOT EXISTS governor_schema_migrations (
 """
 
 
+class MigrationsMissing(RuntimeError):
+    """MIGRATIONS_DIR is absent or holds no .sql files."""
+
+
 async def apply() -> list[str]:
     """Apply every not-yet-applied migration in order. Returns applied filenames."""
+    # An empty or missing directory used to fall through to the "schema up to
+    # date (0 known)" path below — a success message for having done nothing.
+    # That is how a governor image shipped without its migrations ran for a
+    # whole deploy: every flag lookup failed on a missing feature_flags table
+    # while the boot log claimed the schema was current. Nothing to apply is
+    # only good news when there was something to check.
+    if not MIGRATIONS_DIR.is_dir() or not any(MIGRATIONS_DIR.glob("*.sql")):
+        raise MigrationsMissing(
+            f"no .sql migrations found at {MIGRATIONS_DIR} — the governed-memory "
+            "schema cannot be applied. In a container this means the image was "
+            "built without its migrations directory (see the COPY in "
+            "services/memory-governor/Dockerfile); the governor will fail every "
+            "feature-flag lookup until it is present."
+        )
     pool = await db.pool()
     applied: list[str] = []
     async with pool.acquire() as conn:

--- a/tests/memory-governor/test_migrations.py
+++ b/tests/memory-governor/test_migrations.py
@@ -77,3 +77,51 @@ class TestIdempotent:
                         "skill_candidates_status_chk"):
             assert conname in _SQL_0002
             assert f"conname = '{conname}'" in _SQL_0002
+
+
+class TestMigrationsShipWithTheImage:
+    """The governor applies this overlay on startup, so the SQL has to BE in the
+    image. It was not: the Dockerfile copied only src/governor, migrate.py
+    resolved MIGRATIONS_DIR to a path that did not exist, and apply() logged
+    "schema up to date (0 known)" — a success message for having done nothing.
+    The governor then failed every feature-flag lookup on a missing
+    feature_flags table. These pin both halves of that fix."""
+
+    def test_dockerfile_copies_the_migrations_directory(self):
+        dockerfile = (
+            pathlib.Path(__file__).resolve().parents[2]
+            / "services" / "memory-governor" / "Dockerfile"
+        ).read_text()
+        assert re.search(r"^COPY\s+.*\bmigrations\s+/migrations\s*$", dockerfile, re.M), (
+            "the image must carry the migrations at /migrations — the path "
+            "governor/migrate.py resolves from its own location"
+        )
+
+    def test_migrate_refuses_to_report_success_on_an_empty_dir(self, tmp_path, monkeypatch):
+        # Nothing to apply is only good news when there was something to check.
+        import asyncio
+
+        from governor import migrate
+
+        monkeypatch.setattr(migrate, "MIGRATIONS_DIR", tmp_path / "absent")
+        try:
+            asyncio.run(migrate.apply())
+        except migrate.MigrationsMissing as exc:
+            assert "no .sql migrations found" in str(exc)
+        else:
+            raise AssertionError("apply() must raise when the directory is missing")
+
+    def test_migrate_refuses_a_present_but_empty_dir(self, tmp_path, monkeypatch):
+        import asyncio
+
+        from governor import migrate
+
+        empty = tmp_path / "migrations"
+        empty.mkdir()
+        monkeypatch.setattr(migrate, "MIGRATIONS_DIR", empty)
+        try:
+            asyncio.run(migrate.apply())
+        except migrate.MigrationsMissing:
+            pass
+        else:
+            raise AssertionError("apply() must raise when the directory holds no .sql")


### PR DESCRIPTION
Enabling the memory-governor on a real Azure deployment surfaced two defects that together made governed memory unusable — and quiet about it.

## 1. The image never contained its migrations

The Dockerfile copied only `src/governor`. `migrate.py` resolves `MIGRATIONS_DIR` relative to its own file — `/app/governor/migrate.py` → `parents[2]` → `/` → `/migrations` — a path that did not exist in the image. So the startup `apply()` found no SQL, `feature_flags` was never created, and every flag lookup failed:

```
asyncpg.exceptions.UndefinedTableError: relation "feature_flags" does not exist
```

## 2. `apply()` called that success

With an absent directory the glob is empty, so it fell through to `log.info("schema up to date (%d known)", 0)`. The live deploy logged this **seconds before the first `UndefinedTableError`**:

```
governor.migrate INFO schema up to date (0 known)
```

Nothing to apply is only good news when there was something to check. An empty or missing directory now raises `MigrationsMissing`, with the Dockerfile `COPY` named in the message. `main.py` still catches it, so the API keeps serving and the loops fail closed — what changes is that the failure is legible instead of a green log line.

## Also

`memory_governor_image_tag` / `watchdog_image_tag` are now passed through the dev environment. They never were, so enabling the governor there fell back to `latest`, which this registry does not publish (aaf-0025 pins explicit tags) — the pull would have failed right after the apply.

## Verification

Both defects were found by deploying, not by reading. Three new tests in `tests/memory-governor/test_migrations.py`: the Dockerfile `COPY` exists, and `apply()` raises on a missing directory and on a present-but-empty one. Suite: **232 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)