### PR TITLE
fix(governor): make the migration chain self-consistent (feature_flags.updated_by)

### DIFF
--- a/services/memory-governor/migrations/0001_governed_memory_overlay.sql
+++ b/services/memory-governor/migrations/0001_governed_memory_overlay.sql
@@ -32,10 +32,14 @@ CREATE INDEX IF NOT EXISTS documents_memory_class_idx ON documents (memory_class
 CREATE INDEX IF NOT EXISTS documents_expires_at_idx   ON documents (expires_at);
 
 -- (b) governor-owned tables ---------------------------------------------------
+-- Column set matches infrastructure/migrations/0001_agent_events_and_feature_flags.sql.
+-- `updated_by` carries the provenance later flag seeds write; 0002a ALTERs it in
+-- for databases created before it was added here.
 CREATE TABLE IF NOT EXISTS feature_flags (
     name        text PRIMARY KEY,
     enabled     boolean     NOT NULL DEFAULT false,
     description text,
+    updated_by  text,
     updated_at  timestamptz NOT NULL DEFAULT now()
 );
 

--- a/services/memory-governor/migrations/0002a_feature_flags_updated_by.sql
+++ b/services/memory-governor/migrations/0002a_feature_flags_updated_by.sql
@@ -1,0 +1,20 @@
+-- feature_flags.updated_by — make this chain self-consistent.
+--
+-- 0003 and 0004 seed their flags with an `updated_by` provenance value, but the
+-- CREATE TABLE in 0001 never had that column: it only exists in the separate
+-- infrastructure/migrations chain. So this chain worked wherever the infra
+-- migrations had already run, and broke the moment it was applied on its own —
+-- which is exactly what the governor does at startup. On a fresh database the
+-- boot log read:
+--
+--   applying migration 0003_memory_digest_flag.sql
+--   asyncpg.exceptions.UndefinedColumnError:
+--     column "updated_by" of relation "feature_flags" does not exist
+--
+-- and apply() aborted, so 0004 never ran either.
+--
+-- Ordered 0002a so it lands before the first INSERT that needs the column,
+-- rather than editing an already-shipped migration. Idempotent: a database that
+-- got the column from the infra chain is untouched.
+
+ALTER TABLE feature_flags ADD COLUMN IF NOT EXISTS updated_by text;

--- a/tests/memory-governor/test_migrations.py
+++ b/tests/memory-governor/test_migrations.py
@@ -125,3 +125,70 @@ class TestMigrationsShipWithTheImage:
             pass
         else:
             raise AssertionError("apply() must raise when the directory holds no .sql")
+
+
+class TestChainIsSelfConsistent:
+    """The governor applies THIS chain on its own at startup. Anything a later
+    migration references must therefore be created by an earlier one in the same
+    chain — not by the separate infrastructure/migrations chain that happens to
+    have run first on long-lived databases.
+
+    The regression: 0003/0004 seed flags with `updated_by`, but 0001's CREATE
+    TABLE never had that column. It worked wherever the infra chain had already
+    run, and broke on the first fresh database:
+
+        applying migration 0003_memory_digest_flag.sql
+        UndefinedColumnError: column "updated_by" of relation "feature_flags"
+        does not exist
+    """
+
+    def _chain(self):
+        return sorted(_MIG.glob("*.sql"))
+
+    def test_every_feature_flags_insert_column_exists_earlier_in_the_chain(self):
+        provided: set[str] = set()
+        for path in self._chain():
+            sql = path.read_text()
+            create = re.search(
+                r"CREATE TABLE IF NOT EXISTS feature_flags\s*\((.*?)\);", sql, re.S | re.I
+            )
+            if create:
+                for line in create.group(1).splitlines():
+                    m = re.match(r"\s*([a-z_]+)\s+[a-z]", line, re.I)
+                    if m:
+                        provided.add(m.group(1).lower())
+            for m in re.finditer(
+                r"ALTER TABLE feature_flags\s+ADD COLUMN IF NOT EXISTS\s+([a-z_]+)",
+                sql, re.I,
+            ):
+                provided.add(m.group(1).lower())
+            for m in re.finditer(r"INSERT INTO feature_flags\s*\(([^)]*)\)", sql, re.I):
+                used = {c.strip().lower() for c in m.group(1).split(",") if c.strip()}
+                missing = used - provided
+                assert not missing, (
+                    f"{path.name} inserts into feature_flags column(s) {sorted(missing)} "
+                    "that no earlier migration in this chain creates — fine only if "
+                    "infrastructure/migrations ran first, which a fresh deploy does not do"
+                )
+
+    def test_the_two_chains_agree_on_the_feature_flags_columns(self):
+        def columns(sql: str) -> set[str]:
+            m = re.search(
+                r"CREATE TABLE IF NOT EXISTS feature_flags\s*\((.*?)\);", sql, re.S | re.I
+            )
+            assert m, "feature_flags CREATE TABLE not found"
+            return {
+                mm.group(1).lower()
+                for line in m.group(1).splitlines()
+                if (mm := re.match(r"\s*([a-z_]+)\s+[a-z]", line, re.I))
+            }
+
+        infra = (
+            pathlib.Path(__file__).resolve().parents[2]
+            / "infrastructure" / "migrations" / "0001_agent_events_and_feature_flags.sql"
+        ).read_text()
+        local = (_MIG / "0001_governed_memory_overlay.sql").read_text()
+        assert columns(local) == columns(infra), (
+            "the two feature_flags definitions have drifted; a database built by "
+            "one chain then migrated by the other is how the updated_by break happened"
+        )


### PR DESCRIPTION
With the migrations finally shipping in the image (#135), applying them against a **fresh** database got two files further and then failed:

```
applying migration 0003_memory_digest_flag.sql
asyncpg.exceptions.UndefinedColumnError: column "updated_by" of relation "feature_flags" does not exist
```

## Cause: two divergent definitions of the same table

| Chain | `feature_flags` columns |
|---|---|
| `infrastructure/migrations/0001_agent_events_and_feature_flags.sql` | name, enabled, description, **updated_by**, updated_at |
| `services/memory-governor/migrations/0001_governed_memory_overlay.sql` | name, enabled, description, updated_at |

The service-local `0003` and `0004` seed their flags **with** `updated_by`. So this chain only worked where the infrastructure chain had already run — and broke the moment it ran on its own, which is exactly what the governor does at startup. `apply()` aborted on `0003`, so `0004` never ran either.

## Fix

- **`0002a_feature_flags_updated_by.sql`** — idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`, ordered before the first INSERT that needs the column rather than editing an already-shipped migration. A database that got the column from the infra chain is untouched.
- **`0001`'s CREATE TABLE** now matches the infra chain's column set, so fresh databases are correct without needing the ALTER.

## Verification

Two contract checks that would have caught this without a deploy:

1. every column a later INSERT references must be created by an earlier migration **in the same chain**;
2. the two chains' `feature_flags` column sets must agree.

I confirmed the first actually fails on the pre-fix files — it reports `0003_memory_digest_flag.sql` / `['updated_by']`. Suite: **234 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)