### PR TITLE
fix(paperclip): deliver repo-owned skill fixes to deployments that already exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Maturity labels below are drawn from the tests, flags, and behavior in the repo,
 | Security hardening (fail-closed auth, RLS, prompt-injection fencing, secure-by-default firewalls) | Available |
 | GenAI observability traces to Application Insights | Shipped, disabled by default |
 | Governed memory (governor, retrieval planner, watchdog, migrations) | Shipped, disabled by default |
+| Agent memory identity (per-agent peers, roster check, alias map) | Shipped — verified on Azure, unverified self-hosted ([see below](#agent-memory-identity-across-the-deployment-flavors)) |
 | Governor ship-dark endpoints (review-queue digest, escalation SLA auditor) | Shipped, disabled by default |
 | Obsidian memory interface (two-way memory ↔ vault CLI) | Available (operator-run) |
 | Human action-approval seam (`apps/paperclip/approval.mjs`) | Shipped, not fully wired |
@@ -304,6 +305,23 @@ The local quickstart brings up PostgreSQL and the model router; the full platfor
 **Planned and future.** First-class Microsoft Voice Live integration, a second agent runtime, Discord as a control plane, full multi-tenant support with per-user RBAC, scheduled agent routines, a skills manager, more chat surfaces (WhatsApp, a web widget), the rest of the observability pipeline, private enterprise RAG over Azure AI Search, and Foundry Agent Service / Microsoft 365 publishing are on the roadmap, not shipped. See [`ROADMAP.md`](ROADMAP.md).
 
 ---
+
+
+### Agent memory identity across the deployment flavors
+
+AzureAgentForge is meant to run in three shapes, and agent identity is worth calling out per shape because only one of them has been exercised end to end.
+
+| Flavor | What it is | Agent identity |
+|---|---|---|
+| **1. Self-hosted primary** (`self-hosted-primary`, ~$35–45/mo) | Stack on hardware you own; Azure holds a dormant warm standby over one shared managed PostgreSQL | **Supported, not verified.** The compose stack runs the memory-governor and reads all three inputs from `.env`, and it pulls the same PaperClip image that carries the per-agent slug injection — so there is no known reason it differs. But no self-hosted site has run it, so treat it as untested rather than proven |
+| **2. Azure, self-hosted containers, not extensively hardened** (`cost-optimized`, measured ~$83/mo) | The default Azure path | **Verified.** Deployed and checked against the running containers: the declared roster classifies correctly, unexpected peers surface, and the slug injection is present in the deployed image |
+| **3. Azure, security-hardened** (`hardened`, ~$250+/mo) | Zone-redundant posture, longer retention, tighter network defaults | **Supported, not separately verified.** The hardened profile changes infrastructure posture, not the identity code path — it is the same governor image reading the same Terraform variables as flavor 2 |
+
+The three inputs are identical across all three; only the transport differs — `.env` keys on a self-hosted site, Terraform variables on Azure — so a roster written for one is valid for another verbatim. See [`docs/design/memory-system.md` §18](docs/design/memory-system.md#18-identity-the-canonical-user-peer).
+
+**If you run flavor 1 with the Azure standby:** keep the peer values identical on both sites. They share one managed PostgreSQL, so peer ids that differ between them fragment a single identity across a failover — the exact failure this design prevents. Treat them like the database URL: changed in both places or neither.
+
+Identity resolution runs inside governed-memory admission, so on any flavor it takes effect only where `MEMORY_CLASSES_ENABLED` is on. Deploying does not turn that on.
 
 ## What's not finished yet
 

--- a/deploy/mac-site/README.md
+++ b/deploy/mac-site/README.md
@@ -40,6 +40,15 @@ Bring the stack up **only** via `aaf-site local`, never a bare `docker compose u
 
 ## Memory peer identity
 
+> **Status on this path: supported, not verified.** Agent identity has been
+> deployed and checked end to end on the Azure path only. This stack runs the
+> same memory-governor image and reads the same three inputs, and it pulls the
+> same PaperClip image carrying the per-agent slug injection — so there is no
+> known reason it behaves differently here. But no self-hosted site has run it,
+> so treat it as untested rather than proven, and check
+> `pc-honcho list-peers` after enabling governed memory to confirm the peers you
+> expect are the peers you get.
+
 Governed memory is peer-scoped. Three inputs name who the peers are, and this
 site sets all three in `.env` — the Azure standby takes the same three as
 Terraform variables (`honcho_user_peer_id`, `honcho_agent_peer_ids`,

--- a/services/paperclip/Dockerfile
+++ b/services/paperclip/Dockerfile
@@ -310,6 +310,16 @@ COPY apps/hermes/src/skills /opt/hermes-skills
 # forking the Hermes submodule.
 COPY apps/hermes/overrides/skills /opt/hermes-skills
 
+# The same overrides again, kept separately so the entrypoint can tell
+# repo-owned files from agent-authored ones. The skills sync copies to a
+# PERSISTENT volume with `cp -rn` (no-clobber) so agent-created skills survive a
+# deploy — which also means a repo-owned helper fix never reaches a deployment
+# that already has the old file. A live example: the fix that stopped the memory
+# helper defaulting to a system-privileged peer shipped in the image and was
+# still not what agents ran, because the share kept the previous copy. These
+# files are code, not user content, so the entrypoint force-refreshes them.
+COPY apps/hermes/overrides/skills /opt/hermes-skill-overrides
+
 # Skill-helper wrappers on $PATH. The fresh-shell-per-terminal-call model
 # in Hermes means env-var-resolved helper paths (e.g. $DELEGATE_HELPER) get
 # lost between calls, leading to exit-127 loops. Symlinking the helper
@@ -318,6 +328,8 @@ RUN chmod +x /opt/hermes-skills/playbooks/agent-delegate/scripts/pc-delegate.sh 
  && ln -sf /opt/hermes-skills/playbooks/agent-delegate/scripts/pc-delegate.sh /usr/local/bin/pc-delegate \
  && chmod +x /opt/hermes-skills/playbooks/honcho-memory/scripts/pc-honcho.sh \
  && ln -sf /opt/hermes-skills/playbooks/honcho-memory/scripts/pc-honcho.sh /usr/local/bin/pc-honcho \
+ && chmod +x /opt/hermes-skills/playbooks/honcho-memory/scripts/pc-memory.sh \
+ && ln -sf /opt/hermes-skills/playbooks/honcho-memory/scripts/pc-memory.sh /usr/local/bin/pc-memory \
  && chmod +x /opt/hermes-skills/playbooks/web-research/scripts/research-doctor.sh \
  && ln -sf /opt/hermes-skills/playbooks/web-research/scripts/research-doctor.sh /usr/local/bin/research-doctor
 

--- a/services/paperclip/docker-entrypoint.sh
+++ b/services/paperclip/docker-entrypoint.sh
@@ -152,6 +152,20 @@ if [ -d "${OPT_SKILLS_SRC}" ]; then
   echo "[entrypoint] Synced optional Hermes skills to ${SKILLS_DST}"
 fi
 
+# Repo-owned skill overrides: force-refresh (clobber), unlike the no-clobber
+# syncs above. Those exist so agent-authored skills survive a deploy; the side
+# effect is that a REPO-owned helper fix never reaches a deployment whose volume
+# already holds the previous copy. That is how a fix to the memory helper's
+# identity fallback shipped in an image and still was not what agents ran.
+# These files are code we ship, not user content, so the newer image wins.
+# Deletions made through the Skills UI are still honoured — the .deleted marker
+# is processed after this block.
+OVERRIDES_SRC="/opt/hermes-skill-overrides"
+if [ -d "${OVERRIDES_SRC}" ]; then
+  cp -rf "${OVERRIDES_SRC}/." "${SKILLS_DST}/"
+  echo "[entrypoint] Refreshed repo-owned skill overrides in ${SKILLS_DST} (image wins)"
+fi
+
 # Honour the .deleted marker: skills deleted via the PaperClip Skills UI are
 # recorded here so they don't reappear after an image-based sync.
 DELETED_FILE="${SKILLS_DST}/.deleted"

--- a/tests/paperclip/skill-override-refresh.test.mjs
+++ b/tests/paperclip/skill-override-refresh.test.mjs
@@ -1,0 +1,75 @@
+/**
+ * Repo-owned skill overrides must reach a deployment that already has old copies.
+ *
+ * The skills sync copies image → persistent volume with `cp -rn` so
+ * agent-authored skills survive a deploy. The side effect: a repo-owned helper
+ * fix never lands where the volume already holds the previous file. That is not
+ * theoretical — the fix stopping the memory helper from defaulting to a
+ * system-privileged peer shipped in an image, was deployed, and still was not
+ * what agents ran, because the Azure file share kept the old copy:
+ *
+ *   image  → AGENT="${PAPERCLIP_AGENT_SLUG:-${GOVERNOR_AGENT_SLUG:-unknown-agent}}"
+ *   share  → AGENT="${PAPERCLIP_AGENT_SLUG:-${GOVERNOR_AGENT_SLUG:-operator}}"
+ *
+ * These pin the delivery mechanism: repo-owned overrides are staged separately
+ * and force-copied, and the memory helper is callable by name like its siblings.
+ *
+ * Offline: reads the Dockerfile and entrypoint.
+ */
+
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const DOCKERFILE = readFileSync(
+  new URL("../../services/paperclip/Dockerfile", import.meta.url), "utf-8",
+);
+const ENTRYPOINT = readFileSync(
+  new URL("../../services/paperclip/docker-entrypoint.sh", import.meta.url), "utf-8",
+);
+
+test("repo-owned overrides are staged in their own image directory", () => {
+  // Needed so the entrypoint can tell code-we-ship from user content; the
+  // merged /opt/hermes-skills cannot make that distinction.
+  assert.match(
+    DOCKERFILE,
+    /COPY apps\/hermes\/overrides\/skills \/opt\/hermes-skill-overrides/,
+  );
+});
+
+test("the entrypoint force-refreshes them, overriding the no-clobber sync", () => {
+  const block = ENTRYPOINT.slice(ENTRYPOINT.indexOf("OVERRIDES_SRC="));
+  assert.ok(block, "no override-refresh block found in the entrypoint");
+  assert.match(block, /cp -rf "\$\{OVERRIDES_SRC\}\/\." "\$\{SKILLS_DST\}\/"/);
+});
+
+test("the refresh runs after the no-clobber syncs, so the image wins", () => {
+  const builtIn = ENTRYPOINT.indexOf('cp -rn "${SKILLS_SRC}');
+  const optional = ENTRYPOINT.indexOf('cp -rn "${OPT_SKILLS_SRC}');
+  const refresh = ENTRYPOINT.indexOf('cp -rf "${OVERRIDES_SRC}');
+  assert.ok(builtIn > -1 && optional > -1 && refresh > -1);
+  assert.ok(refresh > builtIn && refresh > optional,
+    "a force-copy before the no-clobber passes would be undone by them");
+});
+
+test("UI deletions are still honoured after the refresh", () => {
+  // Force-copying resurrects a skill an operator deleted; the .deleted marker
+  // must be processed afterwards, or the refresh silently overrides that choice.
+  const refresh = ENTRYPOINT.indexOf('cp -rf "${OVERRIDES_SRC}');
+  const deleted = ENTRYPOINT.indexOf("DELETED_FILE=");
+  assert.ok(deleted > refresh,
+    ".deleted handling must come after the override refresh");
+});
+
+test("pc-memory is callable by name, like its sibling helpers", () => {
+  // Hermes spawns a fresh shell per terminal call, so env-resolved paths are
+  // lost between calls — the reason pc-delegate and pc-honcho are symlinked.
+  // pc-memory was documented as a command but never linked.
+  for (const helper of ["pc-delegate", "pc-honcho", "pc-memory"]) {
+    assert.match(
+      DOCKERFILE,
+      new RegExp(`ln -sf [^\\s]+ /usr/local/bin/${helper}\\b`),
+      `${helper} must be on PATH`,
+    );
+  }
+});


### PR DESCRIPTION
The identity fallback fix in #134 shipped in the image, was deployed to Azure dev, and **still was not what agents ran**. Read straight off the live file share:

```
image   AGENT="${PAPERCLIP_AGENT_SLUG:-${GOVERNOR_AGENT_SLUG:-unknown-agent}}"
share   AGENT="${PAPERCLIP_AGENT_SLUG:-${GOVERNOR_AGENT_SLUG:-operator}}"
```

## Why

The skills sync copies image → persistent volume with `cp -rn` so agent-authored skills survive a deploy. The side effect nobody had hit: a **repo-owned** helper fix never reaches a deployment whose volume already holds the old file.

This is not specific to identity. Every skill fix this repo has ever shipped has silently applied only to fresh installs. Here it meant the privileged-`operator` fallback stayed live on the very deployment that was supposed to have fixed it.

## Fix

- Overrides are staged separately at `/opt/hermes-skill-overrides` so the entrypoint can distinguish code-we-ship from user content, and force-copied **after** the no-clobber passes. Ordering matters in both directions: earlier and the refresh gets undone; the `.deleted` marker is still processed afterwards, so a skill an operator removed through the UI stays removed.
- `pc-memory` gets a `/usr/local/bin` symlink like `pc-delegate` and `pc-honcho`. It never had one, despite the design docs calling `pc-memory record` as a command — so it was either not callable at all, or resolved to the stale share copy.

## Verification

Five checks in `tests/paperclip/skill-override-refresh.test.mjs`: the staging directory exists, the force-copy is present, it is ordered after both no-clobber syncs and before `.deleted` handling, and all three helpers are on PATH. Suite: **22 passed**.

The live Azure share was corrected out-of-band so the running deployment stops serving the stale helper (verified: it now reads `unknown-agent`). This change is what makes the *next* deploy do that without anyone hand-editing a file share.

🤖 Generated with [Claude Code](https://claude.com/claude-code)