### PR TITLE
feat(approval): wire HITL action-approval seam into the outbound-comment path

### DIFF
--- a/apps/paperclip/auth-proxy.mjs
+++ b/apps/paperclip/auth-proxy.mjs
@@ -31,6 +31,8 @@ import { readFileSync, readdirSync, statSync, existsSync, writeFileSync,
          mkdirSync, rmSync, appendFileSync } from "node:fs";
 import { join, resolve, relative, basename, dirname, sep, posix } from "node:path";
 import { pathToFileURL } from "node:url";
+import { randomUUID } from "node:crypto";
+import { createApprovalGate } from "./approval.mjs";
 
 // ── Configuration ───────────────────────────────────────────────────────────
 
@@ -73,6 +75,92 @@ const VOICE_BRIDGE_MARKER = "[voice-agent]";
 // scope. Disabled (503) unless both env vars are present.
 const GOVERNOR_BASE_URL = (process.env.GOVERNOR_BASE_URL || "").replace(/\/$/, "");
 const GOVERNOR_API_KEY = process.env.GOVERNOR_API_KEY || "";
+
+// ── HITL action-approval gate — OPTIONAL, inert by default ───────────────
+// Wires the tested approval seam (approval.mjs) into the outbound-comment path.
+// APPROVAL_REQUIRED_KINDS is EMPTY by default, so `requiresApproval` is false
+// for every action and this whole block is a no-op — the comment route is
+// byte-for-byte unchanged until an operator opts a kind in. Once `outbound_message`
+// is gated, every gated comment is decided by the configured provider
+// (`auto`=fail-closed deny / `allow`=bypass / `webhook`=external approver) and
+// an escalation_opened + autonomy_decision pair is emitted to the governor's
+// agent_events spine, lighting up the v1.7 escalation-SLA auditor.
+//
+// The action kind for an agent posting a comment. Gated only when listed in
+// APPROVAL_REQUIRED_KINDS.
+const APPROVAL_KIND_OUTBOUND_MESSAGE = "outbound_message";
+// Escalation dimensions for the emitted events. A human-gated action is the
+// "red" lane (goes to a human) from the "approval" source. Workspace is the
+// tenant dimension the SLA auditor rolls up by.
+const APPROVAL_WORKSPACE = process.env.APPROVAL_WORKSPACE || "default";
+const APPROVAL_LANE = "red";
+const APPROVAL_SOURCE = "approval";
+// Built once at boot from APPROVAL_PROVIDER / APPROVAL_REQUIRED_KINDS /
+// APPROVAL_WEBHOOK_URL. Throws loudly on an unknown provider (fail-loud, never
+// a silent bypass).
+const approvalGate = createApprovalGate();
+
+// Emit one escalation-taxonomy event to the governor's /escalation-event
+// endpoint. FAIL-OPEN telemetry: any error is logged and swallowed — a lost
+// emit must never flip an approval decision. No-op when the governor isn't
+// configured (single-tenant deploy with the gate off wouldn't reach here anyway,
+// since APPROVAL_REQUIRED_KINDS is empty).
+async function emitEscalationEvent(evt) {
+  if (!GOVERNOR_BASE_URL || !GOVERNOR_API_KEY) return;
+  try {
+    await fetch(`${GOVERNOR_BASE_URL}/escalation-event`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Governor-Key": GOVERNOR_API_KEY,
+      },
+      body: JSON.stringify(evt),
+    });
+  } catch (err) {
+    console.warn(`[auth-proxy] escalation-event emit failed (non-fatal): ${err.message}`);
+  }
+}
+
+// Run the outbound-message action through the approval gate. Returns
+// { approved, reason, escalationId } — escalationId is null when the action
+// wasn't gated. On a gated action, emits escalation_opened before deciding and
+// autonomy_decision after, so the SLA auditor can pair open→decision latency.
+async function gateOutboundMessage(
+  { agent, summary, issueId },
+  { gate = approvalGate, emit = emitEscalationEvent } = {},
+) {
+  const action = { kind: APPROVAL_KIND_OUTBOUND_MESSAGE, agent, summary };
+  if (!gate.requiresApproval(action)) {
+    return { approved: true, reason: "not gated", escalationId: null };
+  }
+  const escalationId = randomUUID();
+  const t0 = Date.now();
+  const base = {
+    escalation_id: escalationId,
+    lane: APPROVAL_LANE,
+    source: APPROVAL_SOURCE,
+    workspace: APPROVAL_WORKSPACE,
+    actor_peer: agent || "unknown-agent",
+    issue_id: issueId || null,
+  };
+  await emit({ ...base, event_type: "escalation_opened" });
+  const decision = await gate.requestApproval(action);
+  await emit({
+    ...base,
+    event_type: "autonomy_decision",
+    decision: decision.approved ? "approved" : "denied",
+    latency_ms: Date.now() - t0,
+  });
+  return { approved: decision.approved, reason: decision.reason, escalationId };
+}
+
+// Match POST /api/issues/<id>/comments and pull the issue id. Returns the issue
+// id string, or null when the request isn't the gated comment route.
+function outboundCommentIssueId(method, cleanPath) {
+  if (method !== "POST") return null;
+  const m = cleanPath.match(/^\/api\/issues\/([^/]+)\/comments$/);
+  return m ? m[1] : null;
+}
 
 const PROXY_PORT = parseInt(process.env.PORT || "3100", 10);
 const BACKEND_PORT = parseInt(process.env.PAPERCLIP_INTERNAL_PORT || "3099", 10);
@@ -462,6 +550,29 @@ async function proxyWithJwt(clientReq, clientRes, claims) {
     bodyChunks.push(chunk);
   }
   const body = Buffer.concat(bodyChunks);
+
+  // HITL action-approval gate (inert unless APPROVAL_REQUIRED_KINDS opts the
+  // outbound_message kind in). Gate an agent posting a comment BEFORE it is
+  // forwarded to PaperClip — a denied action never reaches the backend.
+  const issueId = outboundCommentIssueId(clientReq.method, cleanPath);
+  if (issueId) {
+    let summary = "";
+    try {
+      const parsed = JSON.parse(body.toString("utf-8") || "{}");
+      summary = String(parsed.content ?? parsed.body ?? parsed.text ?? "").slice(0, 200);
+    } catch { /* non-JSON body — leave summary empty, still gate on kind */ }
+    const gate = await gateOutboundMessage({ agent: claims.sub, summary, issueId });
+    if (!gate.approved) {
+      clientRes.writeHead(403, { "Content-Type": "application/json" });
+      clientRes.end(JSON.stringify({
+        error: "Forbidden",
+        message: "Outbound message denied by approval gate",
+        reason: gate.reason,
+        escalationId: gate.escalationId,
+      }));
+      return;
+    }
+  }
 
   // Forward with session cookie
   const fwdHeaders = { ...clientReq.headers };
@@ -1714,4 +1825,6 @@ export {
   handleRequest,
   guardedHandler,
   server,
+  gateOutboundMessage,
+  outboundCommentIssueId,
 };

--- a/docs/notes/plans/2026-07-22-full-multi-tenant.md
+++ b/docs/notes/plans/2026-07-22-full-multi-tenant.md
@@ -1,0 +1,102 @@
+# Full multi-tenant — implementation plan (option 2)
+
+**Date:** 2026-07-22
+**Status:** plan / not started
+**Roadmap:** "Later" → Complete multi-tenant implementation (the
+`experimental/multi-tenant/` design), including multiple human users per tenant
+with per-user identity and RBAC.
+**Sizing:** multi-week (est. 4–6 weeks / 5 phases). This is a milestone, not a
+single PR. Ship each phase flag-gated; the single-tenant default deploy stays
+unchanged until a tenant is explicitly provisioned.
+
+## Where we are (what already exists)
+
+`experimental/multi-tenant/` is a badged **reference**, not wired into the live
+single-tenant stack:
+
+- `control-plane/` — tenant CRUD / provisioning control plane.
+- `memory-store/` — tenant-scoped memory API; `tenant_id` already derived from a
+  verified bearer token, Postgres RLS backstop (v1.7 aaf-0007..).
+- `tenant-console/` — playbook-driven onboarding (`provision_tenant.py`,
+  `src/tenantconsole/`, `playbooks/example-fieldservice`), per-tenant budget cap,
+  `DESIGN.md` / `RUNBOOK.md`.
+- `demos/tenant-console/` — static read-only operator demo.
+
+**The gap to "full":** (a) it is not deployable as the running topology; (b) a
+tenant has exactly one implicit principal — there is **no per-user identity or
+RBAC within a tenant**; (c) no per-user auth issuance/rotation; (d) the agent
+runtime + governor are single-workspace at deploy time.
+
+## Phases
+
+### Phase 1 — Promote the reference to a deployable module (week 1)
+- New `infrastructure/modules/multi-tenant/` composing control-plane +
+  memory-store as real ACA container apps behind a `multi_tenant_enabled`
+  variable (default **false** → zero change to single-tenant).
+- Key Vault secrets for the control-plane signing key + per-service keys via
+  `seed-keyvault.sh` (extend, keep idempotent).
+- `terraform validate` clean on both cost profiles; module off by default.
+- **Verify:** plan is a no-op with the flag false; with it true, `plan` adds the
+  two apps and nothing else.
+
+### Phase 2 — Per-user identity within a tenant (weeks 2–3)
+- Data model: `tenant_users` (tenant_id, user_id, email, status) + `user_roles`
+  (user_id, role) in the control-plane schema; RLS keyed on `tenant_id` AND
+  `user_id`.
+- Auth: control-plane issues **per-user** JWTs (sub=user_id, tenant claim, role
+  claims), HS256 from Key Vault, short TTL + refresh. Extends the existing
+  three-layer auth (`docs/jwt-api-authentication.md`) with a per-user layer —
+  do NOT overload the automation JWT.
+- Memory identity: thread `user_id` as the memory peer alongside `tenant_id` so
+  the governor's canonical-user-peer model (§18) is per (tenant,user), not
+  per-tenant. Reuse the v1.8.1 peer-identity + alias machinery.
+- **Verify:** two users in one tenant get isolated memory + distinct audit
+  actor_peer; a cross-tenant token is rejected by RLS (add an RLS negative test).
+
+### Phase 3 — RBAC enforcement (week 3–4)
+- Role set: `owner` / `operator` / `member` / `viewer` (start minimal, YAGNI).
+- A scope→role map at the control-plane + memory-store boundaries (mirror the
+  auth-proxy `SCOPE_MAP` pattern). Fail-closed: unknown role → no scopes.
+- Wire the HITL approval gate (option 3) per-role: e.g. `member`-initiated
+  `outbound_message` gated, `owner` bypass — reuses `APPROVAL_REQUIRED_KINDS`
+  keyed by role.
+- **Verify:** a `viewer` token cannot mutate; role changes take effect without
+  re-provision; offline RBAC matrix tests.
+
+### Phase 4 — Per-tenant agent runtime + governor workspace (week 4–5)
+- Make the governor workspace-parameterized per request (it already scopes most
+  queries by workspace) — confirm every `agent_events` / `documents` path
+  carries the tenant workspace, close any that default to a single workspace.
+- Per-tenant budget cap enforced through the model-router's existing per-caller
+  cap (`BUDGET_ENFORCE_MODE`), keyed by tenant.
+- **Verify:** tenant A's spend/memory never appears in tenant B's rollups
+  (`/escalation-sla`, `/memory-digest`, cost) — cross-tenant isolation test.
+
+### Phase 5 — Onboarding + operator console live (week 5–6)
+- Turn `provision_tenant.py` into the real provisioning path behind the
+  control-plane API; wire the (currently static) `demos/tenant-console` to live
+  control-plane data as a read-mostly operator console.
+- A second worked vertical pack (see the separate "second vertical example"
+  roadmap item) proves it is not single-vertical.
+- **Verify:** end-to-end — provision a fresh tenant, add two users with
+  different roles, exercise memory isolation + RBAC + budget cap, tear down.
+
+## Cross-cutting
+
+- **Security:** every phase adds RLS negative tests + a cross-tenant isolation
+  test; run `mrtek-vuln-scan` on the multi-tenant surface before merge (tenant
+  isolation is the #1 risk class).
+- **Flags:** `multi_tenant_enabled` (master, default false) gates all infra;
+  per-feature flags seed off. Single-tenant deploy is byte-for-byte unchanged
+  until a tenant exists.
+- **Docs:** promote `experimental/multi-tenant/*/DESIGN.md` decisions into ADRs
+  as they harden; update `docs/multi-tenant-architecture.md` from Draft.
+
+## Explicitly out of scope (this milestone)
+- Billing/invoicing integration (Stripe) — separate track.
+- Self-serve tenant signup UI — operator-provisioned first.
+- Cross-tenant admin super-console beyond the read-mostly operator view.
+
+## Dependencies / ordering
+Option 3 (HITL approval) lands first (done) — Phase 3 reuses its gate keyed by
+role. Otherwise self-contained; no dependency on the voice track (option 1).

--- a/docs/notes/plans/2026-07-22-voice-track.md
+++ b/docs/notes/plans/2026-07-22-voice-track.md
@@ -1,0 +1,102 @@
+# Voice track — implementation plan (option 1)
+
+**Date:** 2026-07-22
+**Status:** plan / not started
+**Roadmap:** "Later" → A voice track: shared infrastructure (streaming STT,
+low-latency TTS, VAD + barge-in, a persona overlay) that stays
+provider-agnostic across Microsoft Voice Live and other commercial STT/TTS
+providers, delivered over three surfaces (Discord voice, a web widget, a Twilio
+phone line with a PIN gate, consent, and recording retention).
+**Sizing:** multi-week greenfield (est. 6–8 weeks / 5 phases). Largest of the
+three options — nothing real-time-voice exists yet. Ship each surface
+flag-gated; default deploy stays voiceless.
+
+## Where we are (what already exists)
+
+- `apps/paperclip/auth-proxy.mjs` `POST /api/webhooks/voice/call-ended` — an
+  **end-of-call intake** webhook (post-call structured payload → PaperClip
+  issue), gated by `VOICE_WEBHOOK_SIGNING_SECRET`. This is NOT real-time voice;
+  it is a batch handoff and stays as-is.
+- No streaming STT, no TTS, no VAD/barge-in, no media transport. All greenfield.
+
+## Architecture (provider-agnostic core + three surface adapters)
+
+```
+audio in ─▶ [VAD] ─▶ [streaming STT] ─▶ [persona overlay + agent turn] ─▶ [TTS] ─▶ audio out
+                └──────── barge-in cancels in-flight TTS ────────┘
+```
+
+A single `services/voice-core/` owns the provider-agnostic pipeline behind a
+narrow interface (`Transcriber`, `Synthesizer`, `VAD`, `PersonaOverlay`); each
+surface (`discord` / `web` / `twilio`) is a thin transport adapter that feeds
+audio frames in and plays frames out. Providers (Microsoft Voice Live, others)
+are pluggable behind the STT/TTS interfaces — mirrors the model-router's
+provider-agnostic posture and the sandbox/approval seam factory pattern.
+
+## Phases
+
+### Phase 1 — Voice-core pipeline, offline-testable (weeks 1–2)
+- `services/voice-core/`: the interfaces + a `fake`/`local` provider (canned
+  transcripts + silence TTS) so the whole turn loop is unit-testable with **no
+  audio device and no cloud key**. VAD state machine (speech/silence/barge-in)
+  pure + tested. Persona overlay = the existing agent-prompt persona applied to
+  a turn.
+- Wire one real provider (Microsoft Voice Live) behind the STT/TTS interface,
+  isolated + marked **unverified** until a live spike (mirrors the `aca-job`
+  sandbox posture).
+- **Verify:** full turn loop (audio-in → transcript → agent turn → TTS frames)
+  runs offline against the fake provider; barge-in cancels in-flight synthesis
+  in a unit test.
+
+### Phase 2 — Web-widget surface (weeks 2–3, ship first — no telco/Discord deps)
+- A WebRTC/WebSocket audio bridge + a self-contained widget (`examples/` or a
+  `services/voice-web/`). Simplest surface to demo; no external account.
+- Consent banner + a visible recording indicator from day one.
+- **Verify:** a browser can hold a spoken turn end-to-end against the real
+  provider in a manual spike; the transport is offline-tested with a mock socket.
+
+### Phase 3 — Twilio phone line (weeks 3–5, highest-compliance surface)
+- Twilio Media Streams ↔ voice-core adapter (`services/voice-twilio/`).
+- **PIN gate** before the agent engages, explicit **consent** prompt, and a
+  **recording-retention** policy (retention window + deletion job). These are
+  hard requirements, not add-ons — telco + recording is the compliance-heavy
+  path.
+- Secrets (Twilio auth, PIN) from Key Vault; ingress via the existing
+  `cloudflare-tunnel` module.
+- **Verify:** an inbound call without the PIN never reaches the agent; recordings
+  are deleted after the retention window (job test); consent is logged.
+
+### Phase 4 — Discord voice surface (weeks 5–6)
+- Reuse the Discord voice primitives noted as present-but-unwired in the Hermes
+  submodule (Opus/NaCl, RTP). `services/voice-discord/` adapter to voice-core.
+- **Verify:** an in-channel voice session holds a turn; barge-in works over RTP.
+
+### Phase 5 — Persona + ops hardening (weeks 6–8)
+- Persona overlay per agent (voice_id/vibe already in AGENTS.md frontmatter —
+  reuse `agent-frontmatter-schema`).
+- Observability: per-turn latency spans (STT/agent/TTS) on the existing GenAI
+  OTel pipeline; cost attribution per call via the model-router per-caller cap.
+- Synthetic dogfooding canary (a scheduled canned call) — ties into the
+  separate "synthetic dogfooding" roadmap item.
+- **Verify:** turn-latency budget met on a real call; cost per call tracked;
+  canary alerts on repeated failure.
+
+## Cross-cutting
+
+- **Flags:** each surface behind its own Terraform variable
+  (`voice_web_enabled` / `voice_twilio_enabled` / `voice_discord_enabled`,
+  default false). No surface deploys by default.
+- **Provider-agnostic:** never import a provider SDK outside its interface
+  adapter; the model-router's provider-detection discipline is the template.
+- **Compliance:** consent + recording retention are gating requirements for the
+  Twilio surface, not follow-ons. Legal review before the phone line goes live.
+
+## Explicitly out of scope
+- On-device / edge STT (Mac-edge Ollama path) — later.
+- Multilingual voice — English first.
+- Voice-driven infra actions (destroy gate etc.) — text approval only for now.
+
+## Dependencies / ordering
+Independent of options 2 and 3. Build web surface first (no external account),
+Twilio last-but-highest-value. The end-of-call intake webhook is unrelated and
+untouched.

--- a/docs/superpowers/specs/2026-07-22-hitl-approval-wiring-design.md
+++ b/docs/superpowers/specs/2026-07-22-hitl-approval-wiring-design.md
@@ -1,0 +1,100 @@
+# HITL action-approval wiring — design
+
+**Date:** 2026-07-22
+**Status:** approved (approach A, gate `outbound_message`)
+**Roadmap item:** "Later" → Human-in-the-loop approval of agent actions; lights the v1.7 escalation-SLA auditor.
+
+## Why
+
+The action-approval seam (`apps/paperclip/approval.mjs`) shipped in v1.5 fully
+tested but **unwired** — importing it changes nothing. The v1.7 escalation-SLA
+auditor (`services/memory-governor/.../escalation_sla.py`) reads `agent_events`
+for `escalation_opened` / `autonomy_decision` (correlated by
+`payload.escalation_id`) but no emitter exists, so it reports an honest zero.
+This wires the seam into a real action path and emits the taxonomy the auditor
+already consumes — end to end, flag-gated, inert by default.
+
+## Scope
+
+Gate exactly ONE action kind as the reference wiring: `outbound_message` (an
+agent posting a comment via `POST /api/issues/*/comments`). Destructive tool
+calls (adapter path, vendored) are explicitly out of scope here.
+
+## Approach A — gate at the auth-proxy
+
+The auth-proxy owns the comment-post route (`proxyWithJwt`) and already reaches
+the governor (`GOVERNOR_BASE_URL` / `GOVERNOR_API_KEY`, VNet DNS). The governor
+owns the only `agent_events` writer (`db.emit_event`, gated `AGENT_EVENTS_ENABLED`,
+never raises) but exposes no emit endpoint — so the design adds one.
+
+### Components (owned files only)
+
+1. **Governor `POST /escalation-event`** (`main.py`, `require_key`).
+   Body: `{event_type, escalation_id, lane, source, workspace, actor_peer?,
+   issue_id?, decision?, latency_ms?}`. Validates `event_type ∈
+   {escalation_opened, escalation_acked, escalation_resolved, autonomy_decision}`;
+   builds the payload through `escalation_sla.escalation_payload(escalation_id,
+   lane=lane, source=source, workspace=workspace, **extra)` (raises on bad
+   lane/source → HTTP 400); calls `db.emit_event(...)`. `AGENT_EVENTS_ENABLED`
+   off → the write is a no-op; returns `{accepted: true}` either way.
+   `lane ∈ {red, yellow}`, `source ∈ {approval, presend, handoff}`.
+
+2. **auth-proxy wiring** (`auth-proxy.mjs`). Build one `createApprovalGate()`
+   at boot from env. In `proxyWithJwt`, after the body is buffered and before
+   the forward, for the comment route only: `action = {kind: "outbound_message",
+   agent: claims.sub, summary}`. If `gate.requiresApproval(action)`:
+   - mint `escalation_id = crypto.randomUUID()`, record `t0`;
+   - emit `escalation_opened` (fire-and-forget);
+   - `const {approved, reason} = await gate.requestApproval(action)`;
+   - emit `autonomy_decision` with `decision: approved ? "approved" : "denied"`
+     and `latency_ms: Date.now() - t0`;
+   - `approved` → forward as normal; `!approved` → **403** `{error, reason,
+     escalationId}`, do not forward.
+   Not gated → unchanged path (inert).
+
+3. **Terraform** — thread `APPROVAL_PROVIDER` (default `auto`),
+   `APPROVAL_REQUIRED_KINDS` (default **empty**), `APPROVAL_WEBHOOK_URL`
+   (default empty) onto the auth-proxy container env. Governor URL/key already
+   wired.
+
+### Data flow
+
+comment POST → `proxyWithJwt` → gate check → [gated] `escalation_opened` →
+decide (`auto`=deny / `allow`=approve / `webhook`=external) →
+`autonomy_decision{decision, latency_ms}` → 403 or forward. SLA auditor reads
+it via its documented retro path — **zero auditor changes**.
+
+## Error handling — two deliberate postures
+
+- **Gate = fail-closed.** Any gate error/timeout → denied (the seam already
+  does this). A gated kind with `auto` provider and no approver → denied.
+- **Emit = fail-open telemetry.** A governor `/escalation-event` POST failure
+  from the auth-proxy is logged and swallowed; it never flips an approve to a
+  deny. Mirrors `emit_event`'s "observability, not control flow". The decision
+  is computed independently of whether the emit lands.
+
+## Inert by default
+
+`APPROVAL_REQUIRED_KINDS` empty → `requiresApproval` false for every action →
+no escalation_id, no emit, no 403. The comment route is byte-for-byte unchanged
+until an operator opts `outbound_message` in AND sets a non-`auto` provider (or
+accepts fail-closed denials). No migration — `/escalation-event` reuses the
+existing `agent_events` table (migration 0001) and emitter.
+
+## Testing (all offline)
+
+- **Node** (`tests/approval/`): gated+`auto` → 403; gated+`allow` → forwarded;
+  empty-kinds → inert (no emit, forwarded); emit called with correct
+  `escalation_opened` + `autonomy_decision` payloads (injected governor
+  transport / fetch).
+- **Python** (governor tests): `/escalation-event` valid body emits with the
+  right payload; bad `lane`/`source` → 400; `AGENT_EVENTS_ENABLED` off → no-op,
+  `accepted: true`.
+
+## Out of scope / follow-ons
+
+- Destructive-tool-call gating (adapter patch, approach B).
+- A real `webhook` approver UI (Slack/Discord button) — the `webhook` provider
+  already delegates; the external approver endpoint is a separate deliverable.
+- `escalation_acked` / `escalation_resolved` emission for a two-step human
+  workflow — this wiring emits the synchronous open+decision pair only.

--- a/infrastructure/modules/container-apps/paperclip.tf
+++ b/infrastructure/modules/container-apps/paperclip.tf
@@ -358,6 +358,30 @@ resource "azurerm_container_app" "paperclip" {
         value = var.honcho_user_peer_id
       }
 
+      # ── HITL action-approval gate (auth-proxy) — inert by default ────────
+      # The v1.5 approval seam wired into the outbound-comment path. With
+      # approval_required_kinds empty (default) nothing is gated and this is a
+      # no-op. Emitting escalation events for the v1.7 SLA auditor additionally
+      # requires GOVERNOR_BASE_URL/GOVERNOR_API_KEY on this container (a
+      # separate secret-wiring follow-on); without them the gate still decides
+      # correctly and the emit is a fail-open no-op.
+      env {
+        name  = "APPROVAL_PROVIDER"
+        value = var.approval_provider
+      }
+      env {
+        name  = "APPROVAL_REQUIRED_KINDS"
+        value = var.approval_required_kinds
+      }
+      env {
+        name  = "APPROVAL_WEBHOOK_URL"
+        value = var.approval_webhook_url
+      }
+      env {
+        name  = "APPROVAL_WORKSPACE"
+        value = var.approval_workspace
+      }
+
       # ── Database ─────────────────────────────────────────────────────────
       env {
         name        = "DATABASE_URL"

--- a/infrastructure/modules/container-apps/variables.tf
+++ b/infrastructure/modules/container-apps/variables.tf
@@ -389,6 +389,38 @@ variable "honcho_deriver_job_timeout_seconds" {
   default     = 600
 }
 
+# ── HITL action-approval gate (auth-proxy) — inert by default ─────────────
+# Wires the v1.5 approval seam into the auth-proxy outbound-comment path. The
+# default (empty approval_required_kinds) is byte-for-byte the previous
+# behavior: nothing is gated. See docs/superpowers/specs/2026-07-22-hitl-approval-wiring-design.md.
+variable "approval_provider" {
+  description = "Approval gate provider for gated agent actions: 'auto' (gated action fails closed — the safe default), 'allow' (deliberate bypass), or 'webhook' (delegates to approval_webhook_url). Unknown values fail loud at auth-proxy boot."
+  type        = string
+  default     = "auto"
+  validation {
+    condition     = contains(["auto", "allow", "webhook"], var.approval_provider)
+    error_message = "approval_provider must be one of: auto, allow, webhook."
+  }
+}
+
+variable "approval_required_kinds" {
+  description = "Comma-separated action kinds gated behind human approval (e.g. \"outbound_message\"). EMPTY (default) gates nothing — the seam stays inert. A gated kind under provider 'auto' with no approver fails closed (denied)."
+  type        = string
+  default     = ""
+}
+
+variable "approval_webhook_url" {
+  description = "External approver endpoint for approval_provider = 'webhook'. POSTed the action; expects {approved:boolean}. Fails closed on any error. Empty unless the webhook provider is used."
+  type        = string
+  default     = ""
+}
+
+variable "approval_workspace" {
+  description = "Workspace/tenant dimension stamped on emitted escalation events (the SLA auditor rolls up by it). Single-tenant deploys can leave the default."
+  type        = string
+  default     = "default"
+}
+
 variable "brave_search_enabled" {
   description = "Enable the brave-search wrapper inside paperclip (mounts BRAVE_SEARCH_API_KEY from KV secret platform-brave-search-api-key). DuckDuckGo blocks Azure cloud IPs so this is the practical default; set false only if you want to disable web search entirely."
   type        = bool

--- a/services/memory-governor/src/governor/main.py
+++ b/services/memory-governor/src/governor/main.py
@@ -652,6 +652,66 @@ async def escalation_sla_endpoint(
     return stats
 
 
+class EscalationEventIn(BaseModel):
+    """An escalation-taxonomy event emitted by a wired approval surface (the
+    auth-proxy HITL gate today). The payload is rebuilt server-side through
+    `escalation_sla.escalation_payload` so the auditor's build-time discipline
+    (valid lane/source) is enforced at the choke point, not trusted from the
+    caller."""
+
+    event_type: str
+    escalation_id: str
+    lane: str
+    source: str
+    workspace: str
+    actor_peer: str = "auth-proxy"
+    issue_id: str | None = None
+    # autonomy_decision carries these; escalation_opened omits them.
+    decision: str | None = None
+    latency_ms: int | None = None
+
+
+@app.post("/escalation-event", dependencies=[Depends(require_key)])
+async def escalation_event_emit(evt: EscalationEventIn) -> dict[str, Any]:
+    """Emit one escalation-taxonomy event onto the `agent_events` spine so the
+    v1.7 escalation-SLA auditor can pair it. The single emit endpoint for wired
+    approval surfaces; validates the event type + rebuilds the payload through
+    the discipline helper (bad lane/source -> 400). `AGENT_EVENTS_ENABLED` off
+    makes the write a no-op — the endpoint still returns accepted, matching
+    `db.emit_event`'s fail-open, observability-not-control-flow posture."""
+    if evt.event_type not in escalation_sla.ROLLUP_EVENT_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"event_type must be one of {escalation_sla.ROLLUP_EVENT_TYPES}, "
+                f"got {evt.event_type!r}"
+            ),
+        )
+    extra: dict[str, Any] = {}
+    if evt.decision is not None:
+        extra["decision"] = evt.decision
+    if evt.latency_ms is not None:
+        extra["latency_ms"] = evt.latency_ms
+    try:
+        payload = escalation_sla.escalation_payload(
+            evt.escalation_id,
+            lane=evt.lane,
+            source=evt.source,
+            workspace=evt.workspace,
+            **extra,
+        )
+    except ValueError as exc:  # bad lane/source — discipline helper is strict
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    await db.emit_event(
+        event_type=evt.event_type,
+        actor_peer=evt.actor_peer,
+        payload=payload,
+        channel="approval",
+        issue_id=evt.issue_id,
+    )
+    return {"accepted": True, "event_type": evt.event_type, "escalation_id": evt.escalation_id}
+
+
 # ---------------------------------------------------------------------------
 # Skill candidates (automatic repetition detection -> skill autogen, 0008)
 # The miner proposes; the operator/curator disposes. The skill-curator job

--- a/services/paperclip/Dockerfile
+++ b/services/paperclip/Dockerfile
@@ -358,6 +358,11 @@ RUN chmod +x /usr/local/bin/write-hermes-config.sh
 
 # JWT auth proxy for automation API access (automation scripts, CI/CD)
 COPY apps/paperclip/auth-proxy.mjs /app/auth-proxy.mjs
+# auth-proxy.mjs imports ./approval.mjs (the HITL action-approval gate). It must
+# ship alongside auth-proxy.mjs or the ESM import fails at boot
+# (ERR_MODULE_NOT_FOUND) and the whole proxy — and the paperclip UI behind it —
+# never comes up.
+COPY apps/paperclip/approval.mjs /app/approval.mjs
 
 # Skills management UI — self-contained HTML page served by the auth-proxy
 COPY apps/paperclip/skills-ui.html /app/skills-ui.html

--- a/tests/auth-proxy/hitl-approval-wiring.test.mjs
+++ b/tests/auth-proxy/hitl-approval-wiring.test.mjs
@@ -1,0 +1,101 @@
+/**
+ * HITL approval-gate wiring unit tests (node:test, zero dependencies, offline).
+ *
+ * Run:  node --test tests/auth-proxy/hitl-approval-wiring.test.mjs
+ *
+ * Exercises the auth-proxy side of the HITL wiring: the outbound-comment route
+ * matcher and gateOutboundMessage's decide + emit behavior. The approval gate
+ * and the escalation-event emitter are INJECTED, so no network and no boot-time
+ * env singleton is touched — the module import is side-effect-free.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import { gateOutboundMessage, outboundCommentIssueId } from "../../apps/paperclip/auth-proxy.mjs";
+import { AutoGate, AllowGate } from "../../apps/paperclip/approval.mjs";
+
+const GATED = new Set(["outbound_message"]);
+
+/** A spy emit that records every event passed to gateOutboundMessage. */
+function spyEmit() {
+  const calls = [];
+  const fn = async (evt) => { calls.push(evt); };
+  fn.calls = calls;
+  return fn;
+}
+
+describe("outboundCommentIssueId", () => {
+  test("matches the comment POST route and extracts the issue id", () => {
+    assert.equal(outboundCommentIssueId("POST", "/api/issues/abc-123/comments"), "abc-123");
+  });
+  test("rejects other methods and paths", () => {
+    assert.equal(outboundCommentIssueId("GET", "/api/issues/abc-123/comments"), null);
+    assert.equal(outboundCommentIssueId("POST", "/api/issues/abc-123"), null);
+    assert.equal(outboundCommentIssueId("POST", "/api/issues/abc-123/comments/extra"), null);
+    assert.equal(outboundCommentIssueId("PATCH", "/api/issues/abc-123/comments"), null);
+  });
+});
+
+describe("gateOutboundMessage — inert by default", () => {
+  test("an un-gated kind passes, no escalation id, no emit", async () => {
+    const gate = new AutoGate({ requiredKinds: new Set() }); // nothing gated
+    const emit = spyEmit();
+    const r = await gateOutboundMessage(
+      { agent: "forge", summary: "hi", issueId: "i1" },
+      { gate, emit },
+    );
+    assert.equal(r.approved, true);
+    assert.equal(r.escalationId, null);
+    assert.equal(emit.calls.length, 0);
+  });
+});
+
+describe("gateOutboundMessage — gated", () => {
+  test("auto provider FAILS CLOSED and emits opened + denied decision", async () => {
+    const gate = new AutoGate({ requiredKinds: GATED });
+    const emit = spyEmit();
+    const r = await gateOutboundMessage(
+      { agent: "forge", summary: "post this", issueId: "i9" },
+      { gate, emit },
+    );
+    assert.equal(r.approved, false);
+    assert.ok(r.escalationId, "a gated action mints an escalation id");
+    assert.equal(emit.calls.length, 2);
+
+    const [opened, decision] = emit.calls;
+    assert.equal(opened.event_type, "escalation_opened");
+    assert.equal(opened.escalation_id, r.escalationId);
+    assert.equal(opened.lane, "red");
+    assert.equal(opened.source, "approval");
+    assert.equal(opened.actor_peer, "forge");
+    assert.equal(opened.issue_id, "i9");
+
+    assert.equal(decision.event_type, "autonomy_decision");
+    assert.equal(decision.escalation_id, r.escalationId);
+    assert.equal(decision.decision, "denied");
+    assert.equal(typeof decision.latency_ms, "number");
+  });
+
+  test("allow provider approves and emits opened + approved decision", async () => {
+    const gate = new AllowGate({ requiredKinds: GATED });
+    const emit = spyEmit();
+    const r = await gateOutboundMessage(
+      { agent: "atlas", summary: "ok", issueId: "i2" },
+      { gate, emit },
+    );
+    assert.equal(r.approved, true);
+    assert.ok(r.escalationId);
+    assert.equal(emit.calls.length, 2);
+    assert.equal(emit.calls[0].event_type, "escalation_opened");
+    assert.equal(emit.calls[1].event_type, "autonomy_decision");
+    assert.equal(emit.calls[1].decision, "approved");
+  });
+
+  test("a missing agent degrades to unknown-agent in the emitted actor_peer", async () => {
+    const gate = new AllowGate({ requiredKinds: GATED });
+    const emit = spyEmit();
+    await gateOutboundMessage({ agent: undefined, summary: "x", issueId: null }, { gate, emit });
+    assert.equal(emit.calls[0].actor_peer, "unknown-agent");
+  });
+});

--- a/tests/memory-governor/test_escalation_event.py
+++ b/tests/memory-governor/test_escalation_event.py
@@ -1,0 +1,163 @@
+"""POST /escalation-event emit endpoint — offline tests.
+
+The single emit endpoint for wired approval surfaces (the auth-proxy HITL gate).
+Called directly (asyncio.run) with a monkeypatched db.emit_event / fake pool,
+the test_escalation_sla.py convention. No DB, no HTTP.
+"""
+
+import asyncio
+
+import pytest
+
+from governor import db as governor_db
+from governor import main as governor_main
+from governor.main import EscalationEventIn
+from fastapi import HTTPException
+
+
+def _record_emit(monkeypatch):
+    """Replace db.emit_event with a recorder; returns the calls list."""
+    calls = []
+
+    async def _fake_emit(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(governor_db, "emit_event", _fake_emit)
+    return calls
+
+
+def test_autonomy_decision_emits_with_decision_and_latency(monkeypatch):
+    calls = _record_emit(monkeypatch)
+    out = asyncio.run(
+        governor_main.escalation_event_emit(
+            EscalationEventIn(
+                event_type="autonomy_decision",
+                escalation_id="esc-1",
+                lane="red",
+                source="approval",
+                workspace="tenant-a",
+                actor_peer="forge",
+                issue_id="i9",
+                decision="denied",
+                latency_ms=42,
+            )
+        )
+    )
+    assert out["accepted"] is True
+    assert out["escalation_id"] == "esc-1"
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["event_type"] == "autonomy_decision"
+    assert call["actor_peer"] == "forge"
+    assert call["issue_id"] == "i9"
+    assert call["channel"] == "approval"
+    payload = call["payload"]
+    assert payload["escalation_id"] == "esc-1"
+    assert payload["lane"] == "red"
+    assert payload["source"] == "approval"
+    assert payload["workspace"] == "tenant-a"
+    assert payload["decision"] == "denied"
+    assert payload["latency_ms"] == 42
+
+
+def test_escalation_opened_emits_without_decision_keys(monkeypatch):
+    calls = _record_emit(monkeypatch)
+    asyncio.run(
+        governor_main.escalation_event_emit(
+            EscalationEventIn(
+                event_type="escalation_opened",
+                escalation_id="esc-2",
+                lane="red",
+                source="approval",
+                workspace="tenant-a",
+            )
+        )
+    )
+    payload = calls[0]["payload"]
+    assert "decision" not in payload
+    assert "latency_ms" not in payload
+
+
+def test_unknown_event_type_is_400(monkeypatch):
+    _record_emit(monkeypatch)
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            governor_main.escalation_event_emit(
+                EscalationEventIn(
+                    event_type="not_a_real_event",
+                    escalation_id="esc-3",
+                    lane="red",
+                    source="approval",
+                    workspace="tenant-a",
+                )
+            )
+        )
+    assert exc.value.status_code == 400
+
+
+def test_bad_lane_is_400(monkeypatch):
+    _record_emit(monkeypatch)
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            governor_main.escalation_event_emit(
+                EscalationEventIn(
+                    event_type="autonomy_decision",
+                    escalation_id="esc-4",
+                    lane="purple",  # not in LANES
+                    source="approval",
+                    workspace="tenant-a",
+                )
+            )
+        )
+    assert exc.value.status_code == 400
+
+
+def test_bad_source_is_400(monkeypatch):
+    _record_emit(monkeypatch)
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            governor_main.escalation_event_emit(
+                EscalationEventIn(
+                    event_type="autonomy_decision",
+                    escalation_id="esc-5",
+                    lane="red",
+                    source="not_a_source",
+                    workspace="tenant-a",
+                )
+            )
+        )
+    assert exc.value.status_code == 400
+
+
+def test_flag_off_is_noop_but_accepted(monkeypatch):
+    """AGENT_EVENTS_ENABLED off → the real emitter writes nothing, but the
+    endpoint still reports accepted (fail-open, observability-not-control-flow)."""
+
+    executed = []
+
+    class _FakePool:
+        async def execute(self, *args):
+            executed.append(args)
+
+    async def _fake_pool():
+        return _FakePool()
+
+    async def _fake_flag(name):
+        return False  # AGENT_EVENTS_ENABLED off
+
+    monkeypatch.setattr(governor_db, "pool", _fake_pool)
+    monkeypatch.setattr(governor_db, "flag_enabled", _fake_flag)
+
+    out = asyncio.run(
+        governor_main.escalation_event_emit(
+            EscalationEventIn(
+                event_type="escalation_opened",
+                escalation_id="esc-6",
+                lane="red",
+                source="approval",
+                workspace="tenant-a",
+            )
+        )
+    )
+    assert out["accepted"] is True
+    assert executed == []  # no row written


### PR DESCRIPTION
## What

Wires the v1.5 action-approval seam (`apps/paperclip/approval.mjs`) — shipped tested but **unwired** — into a real action path, and adds the event emitter the v1.7 escalation-SLA auditor was waiting on. End to end, **inert by default**.

Option 3 of the next-big-features analysis. Options 2 (full multi-tenant) and 1 (voice) are multi-week milestones with phase plans in `docs/notes/plans/2026-07-22-*.md`.

## Changes

- **auth-proxy** (`apps/paperclip/auth-proxy.mjs`): build one `createApprovalGate()` at boot; in `proxyWithJwt`, gate an agent posting a comment (`POST /api/issues/*/comments`) as kind `outbound_message` **before** it reaches PaperClip. Gated → mint `escalation_id`, emit `escalation_opened`, decide (`auto`=fail-closed / `allow`=bypass / `webhook`=external), emit `autonomy_decision{decision,latency_ms}`, 403 on deny. `gateOutboundMessage` + `outboundCommentIssueId` are injectable + exported for offline tests.
- **governor** (`services/memory-governor/.../main.py`): new `POST /escalation-event` (`require_key`) — the single emit endpoint for wired approval surfaces. Rebuilds the payload through `escalation_sla.escalation_payload` (bad lane/source → 400) and calls the existing `db.emit_event` (gated `AGENT_EVENTS_ENABLED`, never raises).
- **terraform**: `APPROVAL_PROVIDER` (auto) / `APPROVAL_REQUIRED_KINDS` (empty) / `APPROVAL_WEBHOOK_URL` / `APPROVAL_WORKSPACE` on the auth-proxy container, each a new variable.

## Two deliberate error postures

- **Gate = fail-closed** — any gate error/timeout → denied; a gated kind under `auto` with no approver → denied.
- **Emit = fail-open telemetry** — a lost `/escalation-event` POST logs and continues; it never flips a decision. Mirrors `emit_event`'s "observability, not control flow".

## Inert by default

`APPROVAL_REQUIRED_KINDS` empty → nothing gated → the comment route is byte-for-byte unchanged. No migration (reuses `agent_events`, migration 0001).

## Tests (all offline)

- 6 node (auth-proxy wiring) + 6 pytest (governor endpoint). Full node suite **64 pass**; governor escalation suite **29 pass**; `terraform validate` clean.

## Follow-ons (noted, not in this PR)

- Emitting SLA events needs `GOVERNOR_BASE_URL`/`GOVERNOR_API_KEY` threaded to the paperclip container (separate secret-wiring). Until then the gate decides correctly and the emit is a fail-open no-op.
- `webhook` external-approver UI (Slack/Discord button); `escalation_acked`/`resolved` two-step human workflow.

Spec: `docs/superpowers/specs/2026-07-22-hitl-approval-wiring-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)