### PR TITLE
feat(voice): voice-core turn pipeline — phase 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,8 @@ jobs:
           pytest -q tests/memory-governor
       - name: watchdog
         run: pytest -q services/watchdog/tests
+      - name: voice-core
+        run: pytest -q services/voice-core/tests
       - name: skill helpers (canonical user-peer threading, A5)
         run: pytest -q tests/skills
       - name: canary stub self-test

--- a/services/voice-core/README.md
+++ b/services/voice-core/README.md
@@ -1,0 +1,38 @@
+# voice-core
+
+Provider-agnostic voice turn pipeline. **Phase 1** of the voice track
+(`docs/notes/plans/2026-07-22-voice-track.md`).
+
+```
+audio in ─▶ [VAD] ─▶ [STT] ─▶ [persona + agent turn] ─▶ [TTS] ─▶ audio out
+                └────────── barge-in cancels in-flight TTS ─────────┘
+```
+
+The core (`src/voicecore/`) is pure Python + stdlib — no audio device, no cloud
+SDK — so the whole turn loop, including barge-in, runs in CI against the `fake`
+provider. Real STT/TTS providers (Microsoft Voice Live, others) are pluggable
+adapters behind the `Transcriber` / `Synthesizer` Protocols and never leak into
+the core.
+
+## Pieces
+
+| Module | Role |
+|---|---|
+| `interfaces.py` | Value types (`AudioFrame`, `Transcript`, `TurnResult`) + Protocols (`Transcriber`, `Synthesizer`, `PersonaOverlay`) + `VadEvent`. |
+| `vad.py` | Pure two-state (silence/speech) activity detector with debounced end-of-speech and barge-in reporting. |
+| `pipeline.py` | Synchronous turn loop. `feed(frame) -> PipelineTick`. The agent turn is an injected callable — the core never imports an LLM client. |
+| `persona.py` | Minimal text-side persona overlay. |
+| `providers/fake.py` | Offline STT/TTS substrate for tests. |
+| `providers/voice_live.py` | Microsoft Voice Live adapter — **UNVERIFIED**, isolated, disabled until a live spike. |
+
+## Test
+
+```bash
+python -m pytest services/voice-core/tests -q   # 10 tests, fully offline
+```
+
+## Not in phase 1 (see the plan)
+
+Transports (web widget, Twilio, Discord), a verified live provider, per-turn
+latency observability, consent/recording-retention (Twilio surface). Each is a
+later phase; every surface ships behind its own Terraform flag.

--- a/services/voice-core/requirements.txt
+++ b/services/voice-core/requirements.txt
@@ -1,0 +1,4 @@
+# voice-core is stdlib-only at runtime (phase 1). Tests need pytest.
+# Real provider adapters (Microsoft Voice Live, etc.) add their own SDK deps in
+# a later phase, isolated to providers/.
+pytest>=8.0

--- a/services/voice-core/src/voicecore/__init__.py
+++ b/services/voice-core/src/voicecore/__init__.py
@@ -1,0 +1,29 @@
+"""voice-core — provider-agnostic voice turn pipeline (phase 1)."""
+
+from .interfaces import (
+    AudioFrame,
+    PersonaOverlay,
+    Synthesizer,
+    Transcriber,
+    Transcript,
+    TurnResult,
+    VadEvent,
+)
+from .persona import SimplePersona
+from .pipeline import PipelineTick, VoicePipeline
+from .vad import Vad, VadConfig
+
+__all__ = [
+    "AudioFrame",
+    "Transcript",
+    "TurnResult",
+    "VadEvent",
+    "Transcriber",
+    "Synthesizer",
+    "PersonaOverlay",
+    "SimplePersona",
+    "Vad",
+    "VadConfig",
+    "VoicePipeline",
+    "PipelineTick",
+]

--- a/services/voice-core/src/voicecore/interfaces.py
+++ b/services/voice-core/src/voicecore/interfaces.py
@@ -1,0 +1,78 @@
+"""voice-core — provider-agnostic contracts + value types.
+
+Phase 1 of docs/notes/plans/2026-07-22-voice-track.md. The pipeline
+(pipeline.py) is written against these Protocols only; concrete STT/TTS/VAD
+providers (Microsoft Voice Live, others) are pluggable adapters that never
+leak into the core. Mirrors the model-router's provider-agnostic posture.
+
+Everything here is pure data + typing — no I/O, no cloud SDK — so the whole
+turn loop is unit-testable offline against the fake provider.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class AudioFrame:
+    """One fixed-duration chunk of PCM audio. `energy` is a normalized 0..1
+    loudness estimate the VAD reads; real adapters compute it (e.g. RMS), the
+    fake provider sets it directly. `pcm` is opaque to the core."""
+
+    energy: float
+    pcm: bytes = b""
+    is_final: bool = False
+
+
+@dataclass(frozen=True)
+class Transcript:
+    """A recognized utterance. `is_final` distinguishes a stable result from an
+    interim hypothesis (streaming STT emits many interims per final)."""
+
+    text: str
+    is_final: bool = True
+    confidence: float = 1.0
+
+
+@dataclass(frozen=True)
+class TurnResult:
+    """The outcome of one user turn through the pipeline."""
+
+    transcript: str
+    reply_text: str
+    output_frames: list[AudioFrame] = field(default_factory=list)
+    barged_in: bool = False
+
+
+class VadEvent(Enum):
+    """Voice-activity transitions the pipeline reacts to."""
+
+    SPEECH_START = "speech_start"
+    SPEECH_END = "speech_end"
+    BARGE_IN = "barge_in"  # user started speaking while TTS was playing
+
+
+@runtime_checkable
+class Transcriber(Protocol):
+    """Streaming or batch STT. `transcribe` turns buffered speech frames into a
+    final Transcript."""
+
+    def transcribe(self, frames: list[AudioFrame]) -> Transcript: ...
+
+
+@runtime_checkable
+class Synthesizer(Protocol):
+    """TTS. `synthesize` turns reply text into a list of audio frames to play."""
+
+    def synthesize(self, text: str) -> list[AudioFrame]: ...
+
+
+@runtime_checkable
+class PersonaOverlay(Protocol):
+    """Applies an agent persona to a user utterance before it reaches the agent
+    turn (voice_id/vibe live in AGENTS.md frontmatter; this is the text side)."""
+
+    def apply(self, utterance: str) -> str: ...

--- a/services/voice-core/src/voicecore/persona.py
+++ b/services/voice-core/src/voicecore/persona.py
@@ -1,0 +1,31 @@
+"""Persona overlay — the text side of an agent's voice persona.
+
+Voice identity (voice_id / vibe) lives in AGENTS.md frontmatter and is applied
+at the TTS layer. This overlay shapes the *prompt* side: it frames the user's
+spoken utterance for the agent turn so the reply stays in the agent's lane and
+register. Deliberately minimal in phase 1 — a labeled wrapper, not a second
+prompt engine.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SimplePersona:
+    """Wraps the utterance with the agent's name + a spoken-context marker.
+
+    `name` labels who is answering; `style` is a one-line register hint
+    (e.g. "warm, concise"). Empty style => just the spoken-context marker.
+    """
+
+    name: str = "assistant"
+    style: str = ""
+
+    def apply(self, utterance: str) -> str:
+        style = f" ({self.style})" if self.style else ""
+        return (
+            f"[voice turn for {self.name}{style}] "
+            f"The user said aloud: {utterance.strip()}"
+        )

--- a/services/voice-core/src/voicecore/pipeline.py
+++ b/services/voice-core/src/voicecore/pipeline.py
@@ -1,0 +1,102 @@
+"""The turn loop — provider-agnostic, synchronous, offline-testable.
+
+audio in -> VAD -> (on end of speech) STT -> persona -> agent turn -> TTS ->
+audio out, with barge-in cancelling in-flight synthesis.
+
+Synchronous by design: `feed(frame)` advances the machine one frame and returns
+a PipelineTick (what to play this tick, any VAD event, and a completed turn when
+one just finished). A real transport (web socket, Twilio media stream, Discord
+RTP) drives `feed` at frame cadence; tests drive it from a list. The agent turn
+itself is an injected callable, so the core never imports an LLM client.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Callable
+
+from .interfaces import (
+    AudioFrame,
+    PersonaOverlay,
+    Synthesizer,
+    Transcriber,
+    TurnResult,
+    VadEvent,
+)
+from .persona import SimplePersona
+from .vad import Vad
+
+AgentFn = Callable[[str], str]
+
+
+@dataclass
+class PipelineTick:
+    """The result of advancing the pipeline by one input frame."""
+
+    event: VadEvent | None = None
+    # A TTS frame to play this tick, or None (user speaking / nothing queued).
+    output_frame: AudioFrame | None = None
+    # Set on the tick a user turn completes (SPEECH_END drove a full turn).
+    turn: TurnResult | None = None
+
+
+class VoicePipeline:
+    def __init__(
+        self,
+        transcriber: Transcriber,
+        synthesizer: Synthesizer,
+        agent_fn: AgentFn,
+        persona: PersonaOverlay | None = None,
+        vad: Vad | None = None,
+    ) -> None:
+        self._stt = transcriber
+        self._tts = synthesizer
+        self._agent = agent_fn
+        self._persona = persona or SimplePersona()
+        self._vad = vad or Vad()
+        self._speech_buf: list[AudioFrame] = []
+        self._out: deque[AudioFrame] = deque()
+
+    @property
+    def tts_playing(self) -> bool:
+        return len(self._out) > 0
+
+    def feed(self, frame: AudioFrame) -> PipelineTick:
+        # tts_active is evaluated BEFORE this frame so a user frame that arrives
+        # while synthesis is queued is classified as a barge-in.
+        tts_active = self.tts_playing
+        event = self._vad.process(frame, tts_active)
+        tick = PipelineTick(event=event)
+
+        if event is VadEvent.BARGE_IN:
+            # Cancel in-flight synthesis; begin capturing the interrupting speech.
+            self._out.clear()
+            self._speech_buf = [frame]
+            return tick
+        if event is VadEvent.SPEECH_START:
+            self._speech_buf = [frame]
+            return tick
+        if event is VadEvent.SPEECH_END:
+            tick.turn = self._run_turn()
+            return tick
+
+        # No transition. Either mid-speech (buffer) or idle (drain one TTS frame).
+        if self._vad.in_speech:
+            self._speech_buf.append(frame)
+        elif self._out:
+            tick.output_frame = self._out.popleft()
+        return tick
+
+    def _run_turn(self) -> TurnResult:
+        frames, self._speech_buf = self._speech_buf, []
+        transcript = self._stt.transcribe(frames)
+        prompt = self._persona.apply(transcript.text)
+        reply = self._agent(prompt)
+        out_frames = self._tts.synthesize(reply)
+        self._out.extend(out_frames)
+        return TurnResult(
+            transcript=transcript.text,
+            reply_text=reply,
+            output_frames=list(out_frames),
+        )

--- a/services/voice-core/src/voicecore/providers/__init__.py
+++ b/services/voice-core/src/voicecore/providers/__init__.py
@@ -1,0 +1,7 @@
+"""voice-core providers. Phase 1 ships the offline `fake` provider only; real
+STT/TTS adapters (Microsoft Voice Live, others) land as separate modules behind
+the same interfaces."""
+
+from .fake import FakeSynthesizer, FakeTranscriber
+
+__all__ = ["FakeTranscriber", "FakeSynthesizer"]

--- a/services/voice-core/src/voicecore/providers/fake.py
+++ b/services/voice-core/src/voicecore/providers/fake.py
@@ -1,0 +1,40 @@
+"""Fake STT/TTS providers — the offline test substrate.
+
+No audio device, no cloud key. FakeTranscriber returns a canned transcript (or
+one derived from the frame count); FakeSynthesizer turns text into a
+deterministic list of silent frames (one per word by default). This is what
+lets the whole turn loop — including barge-in — run in CI.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ..interfaces import AudioFrame, Transcript
+
+
+@dataclass
+class FakeTranscriber:
+    """Returns `canned` when set; otherwise a placeholder naming the frame
+    count, so a test can assert the buffered speech reached the transcriber."""
+
+    canned: str | None = None
+
+    def transcribe(self, frames: list[AudioFrame]) -> Transcript:
+        text = self.canned if self.canned is not None else f"<{len(frames)} frames>"
+        return Transcript(text=text, is_final=True)
+
+
+@dataclass
+class FakeSynthesizer:
+    """One silent frame per word (bounded), each carrying its word as pcm so a
+    test can inspect what was 'spoken'. `energy` is 0 (silence) so synthesized
+    playback never re-triggers the VAD as user speech."""
+
+    frames_seen: list[str] = field(default_factory=list)
+
+    def synthesize(self, text: str) -> list[AudioFrame]:
+        words = text.split() or [""]
+        out = [AudioFrame(energy=0.0, pcm=w.encode("utf-8")) for w in words]
+        self.frames_seen.append(text)
+        return out

--- a/services/voice-core/src/voicecore/providers/voice_live.py
+++ b/services/voice-core/src/voicecore/providers/voice_live.py
@@ -1,0 +1,55 @@
+"""Microsoft Voice Live STT/TTS adapter — UNVERIFIED, isolated.
+
+Wired behind the same Transcriber / Synthesizer Protocols the pipeline uses, so
+switching from `fake` to this is a one-line provider swap. Deliberately NOT
+enabled anywhere: the actual streaming calls raise until a live spike confirms
+the request/response contract against a real Voice Live endpoint (mirrors the
+`aca-job` sandbox provider's "reconciled but unverified" posture). This keeps a
+real provider present and type-checked without pretending it works.
+
+Enable path (a later phase): implement the two `# SPIKE:` sections against the
+Voice Live streaming API, drop the NotImplementedError guards, add an
+integration test behind a credentials-gated marker.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..interfaces import AudioFrame, Transcript
+
+
+@dataclass
+class VoiceLiveConfig:
+    endpoint: str = ""
+    api_key: str = ""
+    voice: str = "en-US-AvaNeural"
+    verified: bool = False  # flip only after the live spike passes
+
+
+class VoiceLiveTranscriber:
+    def __init__(self, config: VoiceLiveConfig) -> None:
+        self.config = config
+
+    def transcribe(self, frames: list[AudioFrame]) -> Transcript:
+        if not self.config.verified:
+            raise NotImplementedError(
+                "VoiceLiveTranscriber is unverified — enable only after a live "
+                "spike confirms the Voice Live streaming-STT contract"
+            )
+        # SPIKE: stream frames to the Voice Live STT endpoint, return the final.
+        raise NotImplementedError("Voice Live STT streaming not yet implemented")
+
+
+class VoiceLiveSynthesizer:
+    def __init__(self, config: VoiceLiveConfig) -> None:
+        self.config = config
+
+    def synthesize(self, text: str) -> list[AudioFrame]:
+        if not self.config.verified:
+            raise NotImplementedError(
+                "VoiceLiveSynthesizer is unverified — enable only after a live "
+                "spike confirms the Voice Live TTS contract"
+            )
+        # SPIKE: call Voice Live TTS, chunk the returned audio into AudioFrames.
+        raise NotImplementedError("Voice Live TTS not yet implemented")

--- a/services/voice-core/src/voicecore/vad.py
+++ b/services/voice-core/src/voicecore/vad.py
@@ -1,0 +1,70 @@
+"""Voice-activity detection — a pure state machine.
+
+No audio libraries, no I/O: it consumes AudioFrame.energy and emits VadEvents.
+This is the piece that makes barge-in correct — a SPEECH_START while TTS is
+playing is reported as BARGE_IN so the pipeline can cancel in-flight synthesis.
+
+Debounced end-of-speech: a single sub-threshold frame does not end a turn;
+`silence_hangover_frames` consecutive silent frames do. Prevents a brief pause
+mid-sentence from cutting the user off.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .interfaces import AudioFrame, VadEvent
+
+
+@dataclass(frozen=True)
+class VadConfig:
+    # Frame energy (0..1) at or above which a frame counts as speech.
+    speech_energy_threshold: float = 0.15
+    # Consecutive silent frames required to declare SPEECH_END (debounce).
+    silence_hangover_frames: int = 3
+
+
+class Vad:
+    """Two-state (SILENCE / SPEECH) activity detector.
+
+    `process(frame, tts_active)` returns exactly one VadEvent or None per frame:
+      - SILENCE + speech            -> SPEECH_START (or BARGE_IN if tts_active)
+      - SPEECH  + hangover of silence -> SPEECH_END
+    """
+
+    _SILENCE = "silence"
+    _SPEECH = "speech"
+
+    def __init__(self, config: VadConfig | None = None) -> None:
+        self.config = config or VadConfig()
+        self._state = self._SILENCE
+        self._silence_run = 0
+
+    @property
+    def in_speech(self) -> bool:
+        return self._state == self._SPEECH
+
+    def reset(self) -> None:
+        self._state = self._SILENCE
+        self._silence_run = 0
+
+    def process(self, frame: AudioFrame, tts_active: bool = False) -> VadEvent | None:
+        is_speech = frame.energy >= self.config.speech_energy_threshold
+
+        if self._state == self._SILENCE:
+            if is_speech:
+                self._state = self._SPEECH
+                self._silence_run = 0
+                return VadEvent.BARGE_IN if tts_active else VadEvent.SPEECH_START
+            return None
+
+        # _SPEECH
+        if is_speech:
+            self._silence_run = 0
+            return None
+        self._silence_run += 1
+        if self._silence_run >= self.config.silence_hangover_frames:
+            self._state = self._SILENCE
+            self._silence_run = 0
+            return VadEvent.SPEECH_END
+        return None

--- a/services/voice-core/tests/test_pipeline.py
+++ b/services/voice-core/tests/test_pipeline.py
@@ -1,0 +1,97 @@
+"""Turn-loop tests — full pipeline over the fake provider, offline."""
+
+import pathlib
+import sys
+
+_SRC = pathlib.Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(_SRC))
+
+from voicecore.interfaces import AudioFrame, VadEvent  # noqa: E402
+from voicecore.pipeline import VoicePipeline  # noqa: E402
+from voicecore.providers.fake import FakeSynthesizer, FakeTranscriber  # noqa: E402
+from voicecore.vad import Vad, VadConfig  # noqa: E402
+
+
+def _loud():
+    return AudioFrame(energy=0.8)
+
+
+def _quiet():
+    return AudioFrame(energy=0.0)
+
+
+def _pipeline(agent_fn, canned="hello there"):
+    return VoicePipeline(
+        transcriber=FakeTranscriber(canned=canned),
+        synthesizer=FakeSynthesizer(),
+        agent_fn=agent_fn,
+        vad=Vad(VadConfig(silence_hangover_frames=2)),
+    )
+
+
+def test_full_turn_produces_transcript_reply_and_playback():
+    seen = []
+
+    def agent(prompt):
+        seen.append(prompt)
+        return "hi back"
+
+    p = _pipeline(agent, canned="good morning")
+    # speak (2 loud), then go quiet for the hangover to end the turn.
+    p.feed(_loud())
+    p.feed(_loud())
+    p.feed(_quiet())
+    end = p.feed(_quiet())  # SPEECH_END -> turn runs here
+
+    assert end.event is VadEvent.SPEECH_END
+    assert end.turn is not None
+    assert end.turn.transcript == "good morning"
+    assert end.turn.reply_text == "hi back"
+    assert len(end.turn.output_frames) == 2  # "hi back" -> 2 words
+    # persona overlay reached the agent with the spoken utterance embedded.
+    assert "good morning" in seen[0]
+
+
+def test_tts_frames_drain_on_idle_ticks():
+    p = _pipeline(lambda _: "one two three")
+    p.feed(_loud())
+    p.feed(_quiet())
+    p.feed(_quiet())  # SPEECH_END queues 3 output frames
+    played = []
+    for _ in range(5):  # idle ticks drain the queue, one frame per tick
+        tick = p.feed(_quiet())
+        if tick.output_frame is not None:
+            played.append(tick.output_frame.pcm.decode())
+    assert played == ["one", "two", "three"]
+    assert p.tts_playing is False
+
+
+def test_barge_in_cancels_in_flight_synthesis():
+    p = _pipeline(lambda _: "a fairly long spoken reply here")
+    p.feed(_loud())
+    p.feed(_quiet())
+    p.feed(_quiet())  # SPEECH_END -> 6 output frames queued
+    assert p.tts_playing is True
+    p.feed(_quiet())  # play one frame
+    # user interrupts while TTS still queued
+    tick = p.feed(_loud())
+    assert tick.event is VadEvent.BARGE_IN
+    assert p.tts_playing is False  # remaining synthesis cancelled
+
+
+def test_two_sequential_turns():
+    replies = iter(["first reply", "second reply"])
+    p = _pipeline(lambda _: next(replies), canned="x")
+    # turn 1
+    p.feed(_loud())
+    p.feed(_quiet())
+    t1 = p.feed(_quiet())
+    # drain
+    for _ in range(3):
+        p.feed(_quiet())
+    # turn 2
+    p.feed(_loud())
+    p.feed(_quiet())
+    t2 = p.feed(_quiet())
+    assert t1.turn.reply_text == "first reply"
+    assert t2.turn.reply_text == "second reply"

--- a/services/voice-core/tests/test_vad.py
+++ b/services/voice-core/tests/test_vad.py
@@ -1,0 +1,60 @@
+"""VAD state-machine tests — pure, offline."""
+
+import pathlib
+import sys
+
+_SRC = pathlib.Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(_SRC))
+
+from voicecore.interfaces import AudioFrame, VadEvent  # noqa: E402
+from voicecore.vad import Vad, VadConfig  # noqa: E402
+
+
+def _loud():
+    return AudioFrame(energy=0.8)
+
+
+def _quiet():
+    return AudioFrame(energy=0.01)
+
+
+def test_speech_start_on_first_loud_frame():
+    vad = Vad(VadConfig(silence_hangover_frames=2))
+    assert vad.process(_quiet()) is None
+    assert vad.process(_loud()) is VadEvent.SPEECH_START
+    assert vad.in_speech is True
+
+
+def test_speech_end_requires_full_hangover():
+    vad = Vad(VadConfig(silence_hangover_frames=3))
+    vad.process(_loud())  # SPEECH_START
+    # A single quiet frame mid-utterance must NOT end the turn.
+    assert vad.process(_quiet()) is None
+    assert vad.process(_loud()) is None  # resumes, resets the silence run
+    assert vad.process(_quiet()) is None
+    assert vad.process(_quiet()) is None
+    assert vad.process(_quiet()) is VadEvent.SPEECH_END
+    assert vad.in_speech is False
+
+
+def test_barge_in_when_tts_active():
+    vad = Vad()
+    # Speech starting while TTS is playing is a BARGE_IN, not a plain start.
+    assert vad.process(_loud(), tts_active=True) is VadEvent.BARGE_IN
+
+
+def test_plain_start_when_tts_idle():
+    vad = Vad()
+    assert vad.process(_loud(), tts_active=False) is VadEvent.SPEECH_START
+
+
+def test_threshold_boundary_is_inclusive():
+    vad = Vad(VadConfig(speech_energy_threshold=0.15))
+    assert vad.process(AudioFrame(energy=0.15)) is VadEvent.SPEECH_START
+
+
+def test_reset_returns_to_silence():
+    vad = Vad()
+    vad.process(_loud())
+    vad.reset()
+    assert vad.in_speech is False


### PR DESCRIPTION
Phase 1 of the voice track (`docs/notes/plans/2026-07-22-voice-track.md`, option 1). Greenfield — starts with a pure, offline-testable core.

## What
- `services/voice-core/src/voicecore/`: `AudioFrame`/`Transcript`/`TurnResult` + `Transcriber`/`Synthesizer`/`PersonaOverlay` Protocols; a pure VAD state machine (debounced end-of-speech + barge-in); the synchronous turn loop (`feed(frame) -> PipelineTick`, agent turn injected so the core imports no LLM client); minimal persona overlay; offline fake STT/TTS.
- `providers/voice_live.py`: Microsoft Voice Live adapter behind the same Protocols — **isolated + UNVERIFIED** (raises until a live spike), so a real provider is present/type-checked without pretending to work.
- 10 offline tests; wired into CI.

## Verify
`python -m pytest services/voice-core/tests -q` → 10 passed, fully offline.

## Not in this PR
Transports (web/Twilio/Discord), a verified live provider, latency observability, consent/recording-retention — later phases, each flag-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)