### PR TITLE
feat(multi-tenant): flag-gated deployable module — phase 1

### DIFF
--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -205,6 +205,31 @@ module "container_apps" {
 
 }
 
+# Multi-tenant module (control-plane + memory-store) — phase 1, FLAG-GATED.
+# multi_tenant_enabled defaults false => zero resources, no plan diff. See
+# docs/notes/plans/2026-07-22-full-multi-tenant.md. Deploys into the same
+# Container Apps Environment the container_apps module creates.
+module "multi_tenant" {
+  source = "../../modules/multi-tenant"
+
+  multi_tenant_enabled = var.multi_tenant_enabled
+
+  resource_group_name             = azurerm_resource_group.main.name
+  location                        = azurerm_resource_group.main.location
+  environment                     = var.environment
+  tags                            = local.common_tags
+  container_app_environment_id    = module.container_apps.environment_id
+  container_registry_id           = module.container_registry.id
+  container_registry_login_server = module.container_registry.login_server
+  key_vault_id                    = module.keyvault.id
+  key_vault_uri                   = module.keyvault.uri
+  app_insights_connection_string  = module.monitoring.connection_string
+
+  control_plane_image_tag = var.control_plane_image_tag
+  memory_store_image_tag  = var.memory_store_image_tag
+  azure_search_endpoint   = var.azure_search_endpoint
+}
+
 # Monitoring Module
 module "monitoring" {
   source                = "../../modules/monitoring"

--- a/infrastructure/environments/dev/variables.tf
+++ b/infrastructure/environments/dev/variables.tf
@@ -402,3 +402,28 @@ variable "cloudflare_origin_service" {
   type        = string
   default     = ""
 }
+
+# ── Multi-tenant module (phase 1) — FLAG-GATED, off by default ───────────────
+variable "multi_tenant_enabled" {
+  description = "Deploy the control-plane + memory-store multi-tenant apps. false (default) => zero resources, single-tenant stack unchanged. Provision control-plane-operator-key + azure_search_endpoint before enabling."
+  type        = bool
+  default     = false
+}
+
+variable "control_plane_image_tag" {
+  description = "control-plane container image tag (set by CI/CD when multi_tenant_enabled)."
+  type        = string
+  default     = "latest"
+}
+
+variable "memory_store_image_tag" {
+  description = "memory-store container image tag (set by CI/CD when multi_tenant_enabled)."
+  type        = string
+  default     = "latest"
+}
+
+variable "azure_search_endpoint" {
+  description = "Azure AI Search endpoint the control-plane provisions per-tenant indexes against. Required when multi_tenant_enabled = true."
+  type        = string
+  default     = ""
+}

--- a/infrastructure/modules/multi-tenant/main.tf
+++ b/infrastructure/modules/multi-tenant/main.tf
@@ -1,0 +1,223 @@
+# Multi-tenant module — control-plane + memory-store container apps.
+#
+# FLAG-GATED: every resource is count-gated on local.enabled. With
+# multi_tenant_enabled = false (default) the module is a no-op — zero resources,
+# no plan diff on the single-tenant stack.
+#
+# Both apps are internal-ingress only (no public IP); reachable over the ACA
+# environment's internal DNS. They share the platform's managed Postgres (the
+# postgres-connection-string Key Vault secret), matching the "one managed
+# Postgres" posture in the multi-tenant design.
+
+locals {
+  enabled = var.multi_tenant_enabled ? 1 : 0
+}
+
+# ── control-plane ────────────────────────────────────────────────────────────
+
+resource "azurerm_user_assigned_identity" "control_plane" {
+  count               = local.enabled
+  name                = "id-control-plane-${var.environment}"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  tags                = var.tags
+}
+
+resource "azurerm_role_assignment" "control_plane_acr_pull" {
+  count                = local.enabled
+  scope                = var.container_registry_id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_user_assigned_identity.control_plane[0].principal_id
+}
+
+resource "azurerm_role_assignment" "control_plane_kv_reader" {
+  count                = local.enabled
+  scope                = var.key_vault_id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_user_assigned_identity.control_plane[0].principal_id
+}
+
+resource "azurerm_container_app" "control_plane" {
+  count                        = local.enabled
+  name                         = "ca-control-plane-${var.environment}"
+  container_app_environment_id = var.container_app_environment_id
+  resource_group_name          = var.resource_group_name
+  revision_mode                = "Single"
+  workload_profile_name        = "Consumption"
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.control_plane[0].id]
+  }
+
+  registry {
+    server   = var.container_registry_login_server
+    identity = azurerm_user_assigned_identity.control_plane[0].id
+  }
+
+  # Shared managed Postgres — the control-plane reads/writes the tenant registry.
+  secret {
+    name                = "postgres-connection-string"
+    key_vault_secret_id = "${var.key_vault_uri}secrets/postgres-connection-string"
+    identity            = azurerm_user_assigned_identity.control_plane[0].id
+  }
+
+  # Operator key gating the control-plane admin surface. Fail-closed: the app
+  # returns 503 when CONTROL_PLANE_OPERATOR_KEY is unset. Seed this secret
+  # before enabling the module (scripts/seed-keyvault.sh, follow-on).
+  secret {
+    name                = "control-plane-operator-key"
+    key_vault_secret_id = "${var.key_vault_uri}secrets/control-plane-operator-key"
+    identity            = azurerm_user_assigned_identity.control_plane[0].id
+  }
+
+  template {
+    min_replicas = 0
+    max_replicas = 1
+
+    container {
+      name   = "control-plane"
+      image  = "${var.container_registry_login_server}/control-plane:${var.control_plane_image_tag}"
+      cpu    = 0.25
+      memory = "0.5Gi"
+
+      env {
+        name        = "PG_CONNSTR"
+        secret_name = "postgres-connection-string"
+      }
+      env {
+        name        = "CONTROL_PLANE_OPERATOR_KEY"
+        secret_name = "control-plane-operator-key"
+      }
+      env {
+        name  = "KV_URI"
+        value = var.key_vault_uri
+      }
+      env {
+        name  = "AZURE_SEARCH_ENDPOINT"
+        value = var.azure_search_endpoint
+      }
+      env {
+        name  = "AZURE_CLIENT_ID"
+        value = azurerm_user_assigned_identity.control_plane[0].client_id
+      }
+      env {
+        name  = "APPLICATIONINSIGHTS_CONNECTION_STRING"
+        value = var.app_insights_connection_string
+      }
+    }
+  }
+
+  ingress {
+    external_enabled = false
+    target_port      = 8000
+    transport        = "http"
+
+    traffic_weight {
+      percentage      = 100
+      latest_revision = true
+    }
+  }
+
+  tags = var.tags
+
+  depends_on = [
+    azurerm_role_assignment.control_plane_acr_pull,
+    azurerm_role_assignment.control_plane_kv_reader,
+  ]
+}
+
+# ── memory-store ─────────────────────────────────────────────────────────────
+
+resource "azurerm_user_assigned_identity" "memory_store" {
+  count               = local.enabled
+  name                = "id-memory-store-${var.environment}"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  tags                = var.tags
+}
+
+resource "azurerm_role_assignment" "memory_store_acr_pull" {
+  count                = local.enabled
+  scope                = var.container_registry_id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_user_assigned_identity.memory_store[0].principal_id
+}
+
+resource "azurerm_role_assignment" "memory_store_kv_reader" {
+  count                = local.enabled
+  scope                = var.key_vault_id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_user_assigned_identity.memory_store[0].principal_id
+}
+
+resource "azurerm_container_app" "memory_store" {
+  count                        = local.enabled
+  name                         = "ca-memory-store-${var.environment}"
+  container_app_environment_id = var.container_app_environment_id
+  resource_group_name          = var.resource_group_name
+  revision_mode                = "Single"
+  workload_profile_name        = "Consumption"
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.memory_store[0].id]
+  }
+
+  registry {
+    server   = var.container_registry_login_server
+    identity = azurerm_user_assigned_identity.memory_store[0].id
+  }
+
+  secret {
+    name                = "postgres-connection-string"
+    key_vault_secret_id = "${var.key_vault_uri}secrets/postgres-connection-string"
+    identity            = azurerm_user_assigned_identity.memory_store[0].id
+  }
+
+  template {
+    min_replicas = 0
+    max_replicas = 1
+
+    container {
+      name   = "memory-store"
+      image  = "${var.container_registry_login_server}/memory-store:${var.memory_store_image_tag}"
+      cpu    = 0.25
+      memory = "0.5Gi"
+
+      # tenant_id is derived per-request from a verified bearer token; RLS on
+      # the shared Postgres backstops isolation (see the module's memory-store
+      # reference + v1.7 aaf-0007).
+      env {
+        name        = "DATABASE_URL"
+        secret_name = "postgres-connection-string"
+      }
+      env {
+        name  = "AZURE_CLIENT_ID"
+        value = azurerm_user_assigned_identity.memory_store[0].client_id
+      }
+      env {
+        name  = "APPLICATIONINSIGHTS_CONNECTION_STRING"
+        value = var.app_insights_connection_string
+      }
+    }
+  }
+
+  ingress {
+    external_enabled = false
+    target_port      = 8000
+    transport        = "http"
+
+    traffic_weight {
+      percentage      = 100
+      latest_revision = true
+    }
+  }
+
+  tags = var.tags
+
+  depends_on = [
+    azurerm_role_assignment.memory_store_acr_pull,
+    azurerm_role_assignment.memory_store_kv_reader,
+  ]
+}

--- a/infrastructure/modules/multi-tenant/outputs.tf
+++ b/infrastructure/modules/multi-tenant/outputs.tf
@@ -1,0 +1,17 @@
+# Multi-tenant module — outputs. Null-safe when the module is disabled (the
+# count-gated resources produce empty lists, so index-0 is guarded with try()).
+
+output "enabled" {
+  description = "Whether the module deployed anything."
+  value       = var.multi_tenant_enabled
+}
+
+output "control_plane_fqdn" {
+  description = "Internal FQDN of the control-plane app, or empty when disabled."
+  value       = try(azurerm_container_app.control_plane[0].ingress[0].fqdn, "")
+}
+
+output "memory_store_fqdn" {
+  description = "Internal FQDN of the memory-store app, or empty when disabled."
+  value       = try(azurerm_container_app.memory_store[0].ingress[0].fqdn, "")
+}

--- a/infrastructure/modules/multi-tenant/variables.tf
+++ b/infrastructure/modules/multi-tenant/variables.tf
@@ -1,0 +1,84 @@
+# Multi-tenant module — inputs.
+#
+# Phase 1 of docs/notes/plans/2026-07-22-full-multi-tenant.md: promote the
+# experimental/multi-tenant/ reference (control-plane + memory-store) to a
+# deployable, FLAG-GATED module. Everything is count-gated on
+# multi_tenant_enabled; with it false (the default) the module creates ZERO
+# resources, so the single-tenant stack is byte-for-byte unchanged.
+
+variable "multi_tenant_enabled" {
+  description = "Master switch. false (default) => the module creates no resources. true => deploys the control-plane + memory-store container apps. Provision the control-plane-operator-key secret and azure_search_endpoint before enabling."
+  type        = bool
+  default     = false
+}
+
+# ── Pass-through platform inputs (from the dev environment composition) ──────
+variable "resource_group_name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "environment" {
+  type    = string
+  default = "dev"
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "container_app_environment_id" {
+  description = "The shared Container Apps Environment id these apps deploy into."
+  type        = string
+}
+
+variable "container_registry_id" {
+  description = "Container Registry id for the AcrPull role assignment."
+  type        = string
+}
+
+variable "container_registry_login_server" {
+  description = "Container Registry login server (e.g. myregistry.azurecr.io)."
+  type        = string
+}
+
+variable "key_vault_id" {
+  description = "Key Vault id for the Secrets User role assignment."
+  type        = string
+}
+
+variable "key_vault_uri" {
+  description = "Key Vault URI (https://<name>.vault.azure.net/) for secret references."
+  type        = string
+}
+
+variable "app_insights_connection_string" {
+  description = "Application Insights connection string for telemetry."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+# ── Image tags ──────────────────────────────────────────────────────────────
+variable "control_plane_image_tag" {
+  description = "control-plane container image tag."
+  type        = string
+  default     = "latest"
+}
+
+variable "memory_store_image_tag" {
+  description = "memory-store container image tag."
+  type        = string
+  default     = "latest"
+}
+
+# ── Service config ──────────────────────────────────────────────────────────
+variable "azure_search_endpoint" {
+  description = "Azure AI Search endpoint the control-plane provisions per-tenant indexes against. REQUIRED when multi_tenant_enabled = true (the control-plane reads AZURE_SEARCH_ENDPOINT at startup)."
+  type        = string
+  default     = ""
+}

--- a/scripts/build-and-push.sh
+++ b/scripts/build-and-push.sh
@@ -29,8 +29,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # All buildable services, in build order. cloudflared is intentionally absent.
-ALL_SERVICES="model-router memory-governor watchdog teams-bridge agent-runtime honcho paperclip"
-SELF_CONTAINED="model-router memory-governor watchdog teams-bridge"
+ALL_SERVICES="model-router memory-governor watchdog teams-bridge control-plane memory-store agent-runtime honcho paperclip"
+SELF_CONTAINED="model-router memory-governor watchdog teams-bridge control-plane memory-store"
 
 # Build-args for the paperclip upstream pin. These are READ FROM THE DOCKERFILE
 # ARG defaults rather than duplicated here: hardcoded copies drifted once (the
@@ -94,6 +94,8 @@ svc_meta() {
     memory-governor) echo "memory-governor|services/memory-governor|services/memory-governor/Dockerfile|self|" ;;
     watchdog)        echo "watchdog|services/watchdog|services/watchdog/Dockerfile|self|" ;;
     teams-bridge)    echo "teams-bridge|services/teams-bridge|services/teams-bridge/Dockerfile|self|" ;;
+    control-plane)   echo "control-plane|experimental/multi-tenant/control-plane|experimental/multi-tenant/control-plane/Dockerfile|self|" ;;
+    memory-store)    echo "memory-store|experimental/multi-tenant/memory-store|experimental/multi-tenant/memory-store/Dockerfile|self|" ;;
     agent-runtime)   echo "hermes|.|services/agent-runtime/Dockerfile|upstream|apps/hermes/src apps/hermes/overrides/skills" ;;
     honcho)          echo "honcho|.|services/honcho/Dockerfile|upstream|apps/honcho/src apps/honcho/docker-entrypoint.sh" ;;
     paperclip)       echo "paperclip|.|services/paperclip/Dockerfile|upstream|apps/paperclip apps/hermes/src build/skills/skills-manifest.json build/skills/agent-skill-mapping.json" ;;

--- a/scripts/seed-keyvault.sh
+++ b/scripts/seed-keyvault.sh
@@ -36,7 +36,8 @@ DRY_RUN=0
 GENERATE="postgres-admin-password governor-api-key router-api-key \
 paperclip-admin-password \
 paperclip-agent-jwt-secret paperclip-auth-secret paperclip-automation-jwt-secret \
-paperclip-automation-token auth-password gateway-token"
+paperclip-automation-token auth-password gateway-token \
+control-plane-operator-key"
 
 # Secrets sourced from the environment. Every name here is referenced by a
 # container app's Key Vault secret mount (infrastructure/modules/container-apps),


### PR DESCRIPTION
Phase 1 of full multi-tenant (`docs/notes/plans/2026-07-22-full-multi-tenant.md`, option 2). Promotes the `experimental/multi-tenant/` reference to a deployable, **flag-gated** module.

## What
- `infrastructure/modules/multi-tenant/`: control-plane + memory-store as ACA container apps — per-app managed identity, AcrPull + Key Vault Secrets User roles, internal-only ingress :8000, scale-to-zero. Share the platform's managed Postgres. Everything **count-gated on `multi_tenant_enabled` (default false)** → zero resources, no plan diff on the single-tenant stack.
- Wired into `environments/dev`; `multi_tenant_enabled` / `control_plane_image_tag` / `memory_store_image_tag` / `azure_search_endpoint` variables.
- `build-and-push.sh`: control-plane + memory-store added as self-contained images.

## Verify
`terraform validate` clean (module registered via init). No resources until `multi_tenant_enabled = true`.

## Remaining phase-1 follow-ons
`seed-keyvault.sh` entry for `control-plane-operator-key`; a live `terraform plan` proving zero-diff-when-disabled. Phases 2-5 (per-user identity, RBAC, per-tenant workspace/budget, live onboarding) per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)