### PR TITLE
feat(voice): web session + consent gate — phase 2 (stacked on #142)

### DIFF
--- a/services/voice-core/src/voicecore/__init__.py
+++ b/services/voice-core/src/voicecore/__init__.py
@@ -11,6 +11,12 @@ from .interfaces import (
 )
 from .persona import SimplePersona
 from .pipeline import PipelineTick, VoicePipeline
+from .transport import (
+    PumpResult,
+    SessionState,
+    Transport,
+    WebVoiceSession,
+)
 from .vad import Vad, VadConfig
 
 __all__ = [
@@ -26,4 +32,8 @@ __all__ = [
     "VadConfig",
     "VoicePipeline",
     "PipelineTick",
+    "Transport",
+    "WebVoiceSession",
+    "SessionState",
+    "PumpResult",
 ]

--- a/services/voice-core/src/voicecore/transport.py
+++ b/services/voice-core/src/voicecore/transport.py
@@ -1,0 +1,112 @@
+"""Transport-agnostic voice session — phase 2 (web surface core).
+
+The web-widget / Twilio / Discord surfaces differ only in how audio frames move
+on and off the wire. This layer is the part that does NOT differ: it pumps a
+`Transport` (any duplex frame stream) through a `VoicePipeline`, gated by
+explicit consent and tracking a recording flag. Pure and synchronous, so it is
+offline-testable against an in-memory fake transport — the real WebSocket /
+WebRTC bridge only has to implement `recv`/`send`.
+
+Consent is a hard gate from day one (the web plan requires a consent banner +
+recording indicator): no user frame is processed and nothing is recorded until
+`grant_consent()` is called. Revoking consent mid-session stops processing and
+recording immediately.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+from .interfaces import AudioFrame
+from .pipeline import PipelineTick, VoicePipeline
+
+
+@runtime_checkable
+class Transport(Protocol):
+    """A duplex audio frame stream. `recv` returns the next inbound frame or
+    None when none is currently available (or the stream closed); `send` plays
+    an outbound frame."""
+
+    def recv(self) -> AudioFrame | None: ...
+    def send(self, frame: AudioFrame) -> None: ...
+
+
+class SessionState(Enum):
+    AWAITING_CONSENT = "awaiting_consent"
+    ACTIVE = "active"
+    CLOSED = "closed"
+
+
+@dataclass
+class PumpResult:
+    """Outcome of pumping one inbound frame."""
+
+    state: SessionState
+    had_frame: bool = False  # transport.recv returned a frame this pump
+    processed: bool = False  # frame reached the pipeline
+    tick: PipelineTick | None = None
+
+
+@dataclass
+class WebVoiceSession:
+    pipeline: VoicePipeline
+    transport: Transport
+    record: bool = False
+    _state: SessionState = field(default=SessionState.AWAITING_CONSENT, init=False)
+    _recorded: list[AudioFrame] = field(default_factory=list, init=False)
+
+    @property
+    def state(self) -> SessionState:
+        return self._state
+
+    @property
+    def recording(self) -> bool:
+        # Recording is only ever true while active AND the flag is set — an
+        # unconsented or closed session records nothing.
+        return self.record and self._state is SessionState.ACTIVE
+
+    @property
+    def recorded_frames(self) -> list[AudioFrame]:
+        return list(self._recorded)
+
+    def grant_consent(self) -> None:
+        if self._state is SessionState.AWAITING_CONSENT:
+            self._state = SessionState.ACTIVE
+
+    def revoke_consent(self) -> None:
+        # Stop processing + recording immediately; a revoked session is closed.
+        self._state = SessionState.CLOSED
+
+    def purge_recording(self) -> int:
+        """Delete retained frames (the retention-policy hook). Returns how many
+        were dropped."""
+        n = len(self._recorded)
+        self._recorded.clear()
+        return n
+
+    def pump_once(self) -> PumpResult:
+        frame = self.transport.recv()
+        if frame is None:
+            return PumpResult(state=self._state, had_frame=False)
+        if self._state is not SessionState.ACTIVE:
+            # Pre-consent or closed: drop the frame, record nothing, process
+            # nothing. The caller keeps showing the consent banner.
+            return PumpResult(state=self._state, had_frame=True, processed=False)
+        if self.record:
+            self._recorded.append(frame)
+        tick = self.pipeline.feed(frame)
+        if tick.output_frame is not None:
+            self.transport.send(tick.output_frame)
+        return PumpResult(state=self._state, had_frame=True, processed=True, tick=tick)
+
+    def run(self, max_ticks: int = 10_000) -> list[PumpResult]:
+        """Pump until the transport yields no frame (drained) or max_ticks."""
+        results: list[PumpResult] = []
+        for _ in range(max_ticks):
+            r = self.pump_once()
+            if not r.had_frame:
+                break
+            results.append(r)
+        return results

--- a/services/voice-core/tests/test_transport.py
+++ b/services/voice-core/tests/test_transport.py
@@ -1,0 +1,94 @@
+"""Web-transport session tests — consent gate + pump loop, offline."""
+
+import pathlib
+import sys
+from collections import deque
+
+_SRC = pathlib.Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(_SRC))
+
+from voicecore.interfaces import AudioFrame  # noqa: E402
+from voicecore.pipeline import VoicePipeline  # noqa: E402
+from voicecore.providers.fake import FakeSynthesizer, FakeTranscriber  # noqa: E402
+from voicecore.transport import SessionState, WebVoiceSession  # noqa: E402
+from voicecore.vad import Vad, VadConfig  # noqa: E402
+
+
+class FakeTransport:
+    """In-memory duplex: `inbound` is drained by recv, `sent` captures send."""
+
+    def __init__(self, inbound):
+        self._inbound = deque(inbound)
+        self.sent = []
+
+    def recv(self):
+        return self._inbound.popleft() if self._inbound else None
+
+    def send(self, frame):
+        self.sent.append(frame)
+
+
+def _loud():
+    return AudioFrame(energy=0.8)
+
+
+def _quiet():
+    return AudioFrame(energy=0.0)
+
+
+def _session(transport, record=False):
+    pipe = VoicePipeline(
+        transcriber=FakeTranscriber(canned="hi"),
+        synthesizer=FakeSynthesizer(),
+        agent_fn=lambda _: "ok done",
+        vad=Vad(VadConfig(silence_hangover_frames=2)),
+    )
+    return WebVoiceSession(pipeline=pipe, transport=transport, record=record)
+
+
+def test_starts_awaiting_consent_and_drops_frames():
+    t = FakeTransport([_loud(), _quiet(), _quiet()])
+    s = _session(t)
+    assert s.state is SessionState.AWAITING_CONSENT
+    results = s.run()
+    # every frame dropped pre-consent; nothing processed, nothing sent
+    assert all(r.processed is False for r in results)
+    assert t.sent == []
+    assert s.recording is False
+
+
+def test_consent_activates_and_processes_a_turn():
+    # loud, quiet, quiet -> SPEECH_END; then quiets drain TTS ("ok done" -> 2 frames)
+    t = FakeTransport([_loud(), _quiet(), _quiet(), _quiet(), _quiet()])
+    s = _session(t)
+    s.grant_consent()
+    assert s.state is SessionState.ACTIVE
+    s.run()
+    # a turn ran and TTS frames were sent back over the transport
+    assert [f.pcm.decode() for f in t.sent] == ["ok", "done"]
+
+
+def test_recording_only_while_active_and_purge_clears():
+    t = FakeTransport([_loud(), _quiet(), _quiet(), _quiet()])
+    s = _session(t, record=True)
+    # pre-consent: no recording
+    assert s.recording is False
+    s.grant_consent()
+    assert s.recording is True
+    s.run()
+    assert len(s.recorded_frames) == 4  # all active frames retained
+    dropped = s.purge_recording()
+    assert dropped == 4
+    assert s.recorded_frames == []
+
+
+def test_revoke_consent_closes_and_stops_processing():
+    t = FakeTransport([_loud(), _loud()])
+    s = _session(t, record=True)
+    s.grant_consent()
+    s.revoke_consent()
+    assert s.state is SessionState.CLOSED
+    results = s.run()
+    assert all(r.processed is False for r in results)
+    assert t.sent == []
+    assert s.recording is False


### PR DESCRIPTION
Phase 2 of the voice track (option 1). **Stacked on #142** (base = `feat/voice-core-phase1`); retarget to `main` once #142 merges.

## What
- `transport.py`: `Transport` Protocol (recv/send) + `WebVoiceSession` — the surface-agnostic pump loop over the phase-1 pipeline, with a hard **consent gate** (nothing processed/recorded until `grant_consent()`; revoke closes immediately), a recording flag true only while ACTIVE, and `purge_recording()` retention hook.
- 4 offline tests (suite now 14): pre-consent drop, consent→turn→TTS-sent, recording+purge, revoke-closes.

## Verify
`python -m pytest services/voice-core/tests -q` → 14 passed, offline.

## Not in this phase
The real WebSocket/WebRTC bridge (recv/send impl) + browser widget UI; a verified live provider. Consent + recording-retention are load-bearing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)