### PR TITLE
feat(multi-tenant): per-user identity (tokens + require_principal) — phase 2 (stacked on #143)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,11 @@ jobs:
           pytest -q tests/memory-governor
       - name: watchdog
         run: pytest -q services/watchdog/tests
+      - name: multi-tenant per-user identity (offline)
+        run: |
+          pip install fastapi
+          pytest -q experimental/multi-tenant/control-plane/tests/test_user_tokens.py \
+                    experimental/multi-tenant/memory-store/tests/test_user_auth.py
       - name: skill helpers (canonical user-peer threading, A5)
         run: pytest -q tests/skills
       - name: canary stub self-test

--- a/experimental/multi-tenant/control-plane/tests/conftest.py
+++ b/experimental/multi-tenant/control-plane/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Put the control-plane dir on sys.path so tests can import user_tokens
+without installing the service."""
+
+import pathlib
+import sys
+
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT))

--- a/experimental/multi-tenant/control-plane/tests/test_user_tokens.py
+++ b/experimental/multi-tenant/control-plane/tests/test_user_tokens.py
@@ -1,0 +1,92 @@
+"""Per-user token issue/verify — offline unit tests."""
+
+import pytest
+
+from user_tokens import (
+    Principal,
+    TokenError,
+    issue_user_token,
+    verify_user_token,
+)
+
+SECRET = "test-signing-secret"
+
+
+def _token(**over):
+    kw = dict(user_id="u1", tenant_id="t1", role="operator", secret=SECRET)
+    kw.update(over)
+    return issue_user_token(**kw)
+
+
+def test_round_trip_returns_full_principal():
+    tok = _token()
+    p = verify_user_token(tok, SECRET)
+    assert p == Principal(user_id="u1", tenant_id="t1", role="operator")
+
+
+def test_issue_rejects_unknown_role():
+    with pytest.raises(ValueError):
+        _token(role="superadmin")
+
+
+def test_issue_rejects_empty_ids():
+    with pytest.raises(ValueError):
+        _token(user_id="")
+    with pytest.raises(ValueError):
+        _token(tenant_id="")
+
+
+def test_tampered_payload_fails_signature():
+    header, payload, sig = _token().split(".")
+    # swap in a different payload (role escalation attempt) keeping the old sig
+    forged_payload = payload[:-2] + ("AA" if not payload.endswith("AA") else "BB")
+    with pytest.raises(TokenError):
+        verify_user_token(f"{header}.{forged_payload}.{sig}", SECRET)
+
+
+def test_alg_none_is_rejected():
+    import base64
+    import json
+
+    header = base64.urlsafe_b64encode(
+        json.dumps({"alg": "none", "typ": "JWT"}).encode()
+    ).rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"sub": "u1", "tenant_id": "t1", "role": "owner"}).encode()
+    ).rstrip(b"=").decode()
+    with pytest.raises(TokenError):
+        verify_user_token(f"{header}.{payload}.", SECRET)
+
+
+def test_wrong_secret_is_rejected():
+    with pytest.raises(TokenError):
+        verify_user_token(_token(), "other-secret")
+
+
+def test_expired_token_is_rejected():
+    tok = issue_user_token(
+        user_id="u1", tenant_id="t1", role="member", secret=SECRET,
+        ttl_seconds=100, now=1000,
+    )
+    # clock past exp (1000 + 100)
+    with pytest.raises(TokenError):
+        verify_user_token(tok, SECRET, now=1101)
+    # still valid before exp
+    assert verify_user_token(tok, SECRET, now=1050).user_id == "u1"
+
+
+def test_missing_claim_is_rejected():
+    # hand-build a validly-signed token missing the role claim
+    import base64
+    import hashlib
+    import hmac
+    import json
+
+    def b64(raw):
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+    h = b64(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+    p = b64(json.dumps({"sub": "u1", "tenant_id": "t1"}).encode())  # no role
+    sig = b64(hmac.new(SECRET.encode(), f"{h}.{p}".encode(), hashlib.sha256).digest())
+    with pytest.raises(TokenError):
+        verify_user_token(f"{h}.{p}.{sig}", SECRET)

--- a/experimental/multi-tenant/control-plane/user_tokens.py
+++ b/experimental/multi-tenant/control-plane/user_tokens.py
@@ -1,0 +1,133 @@
+# Reference design — part of the multi-tenant roadmap. Phase 2 of
+# docs/notes/plans/2026-07-22-full-multi-tenant.md: per-user identity within a
+# tenant. The control-plane is the identity authority — it MINTS the per-user
+# access tokens the data-plane services (memory-store, ...) verify.
+
+"""Per-user access tokens (HS256, stdlib only — no external JWT dependency).
+
+A token carries the user's identity AND their tenant AND their role, so a
+downstream service derives all three from one verified credential and never
+trusts a client-supplied tenant/user/role. This is the issuing + verifying
+half; the memory-store's require_principal is the consuming half.
+
+Design notes:
+  - `sub` is the user_id, `tenant_id` scopes it, `role` drives RBAC downstream.
+  - Fail-closed everywhere: alg-confusion (alg != HS256, alg=none) is rejected,
+    a bad signature is rejected, an expired token is rejected. A token missing
+    sub/tenant_id/role is rejected — a principal is only ever fully-formed.
+  - No secret is embedded; the caller passes it (from Key Vault / env), so this
+    module has no I/O and is trivially unit-testable.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+from dataclasses import dataclass
+
+# Roles, least- to most-privileged. RBAC enforcement (phase 3) maps these to
+# allowed scopes; the token just carries the assertion.
+ROLES = ("viewer", "member", "operator", "owner")
+
+
+class TokenError(Exception):
+    """Raised on any verification failure (fail-closed)."""
+
+
+@dataclass(frozen=True)
+class Principal:
+    user_id: str
+    tenant_id: str
+    role: str
+
+
+def _b64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(seg: str) -> bytes:
+    pad = "=" * (-len(seg) % 4)
+    return base64.urlsafe_b64decode(seg + pad)
+
+
+def issue_user_token(
+    *,
+    user_id: str,
+    tenant_id: str,
+    role: str,
+    secret: str,
+    ttl_seconds: int = 3600,
+    now: float | None = None,
+) -> str:
+    """Mint an HS256 token for (user_id, tenant_id, role). Raises ValueError on
+    a bad role or empty id — a token is never issued for an invalid principal."""
+    if role not in ROLES:
+        raise ValueError(f"role must be one of {ROLES}, got {role!r}")
+    if not user_id or not tenant_id:
+        raise ValueError("user_id and tenant_id are required")
+    if not secret:
+        raise ValueError("secret is required to issue a token")
+    issued = int(now if now is not None else time.time())
+    header = {"alg": "HS256", "typ": "JWT"}
+    payload = {
+        "sub": str(user_id),
+        "tenant_id": str(tenant_id),
+        "role": role,
+        "iat": issued,
+        "exp": issued + int(ttl_seconds),
+    }
+    header_b64 = _b64url_encode(json.dumps(header, separators=(",", ":")).encode())
+    payload_b64 = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+    sig = hmac.new(secret.encode(), signing_input, hashlib.sha256).digest()
+    return f"{header_b64}.{payload_b64}.{_b64url_encode(sig)}"
+
+
+def verify_user_token(token: str, secret: str, *, now: float | None = None) -> Principal:
+    """Verify an HS256 token and return the Principal. Raises TokenError on any
+    failure (malformed, alg confusion, bad signature, expired, missing claim)."""
+    if not secret:
+        raise TokenError("no signing secret configured")
+    try:
+        header_b64, payload_b64, sig_b64 = token.split(".")
+    except ValueError as exc:
+        raise TokenError("malformed token") from exc
+
+    try:
+        header = json.loads(_b64url_decode(header_b64))
+    except Exception as exc:  # noqa: BLE001
+        raise TokenError("malformed token header") from exc
+    if header.get("alg") != "HS256":
+        raise TokenError("unsupported token algorithm")  # rejects alg=none / confusion
+
+    expected = hmac.new(
+        secret.encode(), f"{header_b64}.{payload_b64}".encode(), hashlib.sha256
+    ).digest()
+    try:
+        provided = _b64url_decode(sig_b64)
+    except Exception as exc:  # noqa: BLE001
+        raise TokenError("malformed signature") from exc
+    if not hmac.compare_digest(expected, provided):
+        raise TokenError("invalid token signature")
+
+    try:
+        claims = json.loads(_b64url_decode(payload_b64))
+    except Exception as exc:  # noqa: BLE001
+        raise TokenError("malformed token payload") from exc
+
+    exp = claims.get("exp")
+    clock = now if now is not None else time.time()
+    if exp is not None and clock >= float(exp):
+        raise TokenError("token expired")
+
+    user_id = claims.get("sub")
+    tenant_id = claims.get("tenant_id")
+    role = claims.get("role")
+    if not user_id or not tenant_id or not role:
+        raise TokenError("token missing sub/tenant_id/role")
+    if role not in ROLES:
+        raise TokenError(f"unknown role in token: {role!r}")
+    return Principal(user_id=str(user_id), tenant_id=str(tenant_id), role=role)

--- a/experimental/multi-tenant/memory-store/app/auth.py
+++ b/experimental/multi-tenant/memory-store/app/auth.py
@@ -24,8 +24,22 @@ import hmac
 import json
 import os
 import time
+from dataclasses import dataclass
 
 from fastapi import Header, HTTPException
+
+# Roles a per-user token may carry (phase 2). Kept in sync with the control-
+# plane issuer (control-plane/user_tokens.py ROLES).
+ROLES = ("viewer", "member", "operator", "owner")
+
+
+@dataclass(frozen=True)
+class Principal:
+    """The verified caller: who they are, which tenant, what role."""
+
+    tenant_id: str
+    user_id: str
+    role: str
 
 
 def _b64url_decode(seg: str) -> bytes:
@@ -89,3 +103,29 @@ async def require_tenant(authorization: str | None = Header(default=None)) -> st
     if not tenant_id:
         raise HTTPException(status_code=401, detail="token missing tenant_id claim")
     return str(tenant_id)
+
+
+async def require_principal(authorization: str | None = Header(default=None)) -> Principal:
+    """Phase 2: verify the bearer token and return the full Principal
+    (tenant_id + user_id + role), not just the tenant. Same fail-closed posture
+    as require_tenant: no secret -> 503; missing/invalid token, or a token
+    missing sub/tenant_id/role, -> 401. A partial identity is never returned —
+    downstream RBAC (phase 3) can trust every field.
+    """
+    secret = _signing_secret()
+    if not secret:
+        raise HTTPException(
+            status_code=503,
+            detail="memory-store authentication not configured (MEMORY_STORE_JWT_SECRET unset)",
+        )
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise HTTPException(status_code=401, detail="missing bearer token")
+    claims = _verify_hs256(authorization[7:].strip(), secret)
+    tenant_id = claims.get("tenant_id")
+    user_id = claims.get("sub")
+    role = claims.get("role")
+    if not tenant_id or not user_id or not role:
+        raise HTTPException(status_code=401, detail="token missing tenant_id/sub/role claim")
+    if role not in ROLES:
+        raise HTTPException(status_code=401, detail=f"unknown role in token: {role!r}")
+    return Principal(tenant_id=str(tenant_id), user_id=str(user_id), role=role)

--- a/experimental/multi-tenant/memory-store/tests/test_user_auth.py
+++ b/experimental/multi-tenant/memory-store/tests/test_user_auth.py
@@ -1,0 +1,77 @@
+"""require_principal — offline tests, including control-plane issuer interop.
+
+Sync tests driving the async dependency via asyncio.run (no pytest-asyncio
+needed). Proves a token minted by the control-plane issuer verifies to the same
+Principal the memory-store derives — the phase-2 identity contract end to end.
+"""
+
+import asyncio
+import pathlib
+import sys
+
+import pytest
+from fastapi import HTTPException
+
+# control-plane issuer (sibling service) on the path for the interop test.
+_CP = pathlib.Path(__file__).resolve().parents[3] / "control-plane"
+sys.path.insert(0, str(_CP))
+
+from app.auth import Principal, require_principal  # noqa: E402
+from user_tokens import issue_user_token  # noqa: E402
+
+SECRET = "shared-user-secret"
+
+
+def _call(authorization):
+    return asyncio.run(require_principal(authorization=authorization))
+
+
+def test_issuer_token_verifies_to_matching_principal(monkeypatch):
+    monkeypatch.setenv("MEMORY_STORE_JWT_SECRET", SECRET)
+    tok = issue_user_token(user_id="u9", tenant_id="t9", role="owner", secret=SECRET)
+    p = _call(f"Bearer {tok}")
+    assert p == Principal(tenant_id="t9", user_id="u9", role="owner")
+
+
+def test_missing_secret_fails_closed_503(monkeypatch):
+    monkeypatch.delenv("MEMORY_STORE_JWT_SECRET", raising=False)
+    # also ensure the /secrets file fallback isn't present in CI
+    with pytest.raises(HTTPException) as exc:
+        _call("Bearer whatever")
+    assert exc.value.status_code == 503
+
+
+def test_missing_bearer_is_401(monkeypatch):
+    monkeypatch.setenv("MEMORY_STORE_JWT_SECRET", SECRET)
+    with pytest.raises(HTTPException) as exc:
+        _call(None)
+    assert exc.value.status_code == 401
+
+
+def test_wrong_secret_is_401(monkeypatch):
+    monkeypatch.setenv("MEMORY_STORE_JWT_SECRET", SECRET)
+    tok = issue_user_token(user_id="u1", tenant_id="t1", role="member", secret="other")
+    with pytest.raises(HTTPException) as exc:
+        _call(f"Bearer {tok}")
+    assert exc.value.status_code == 401
+
+
+def test_tenant_only_token_missing_sub_role_is_401(monkeypatch):
+    # a legacy require_tenant-style token (tenant_id only) must NOT satisfy the
+    # stricter principal contract.
+    import base64
+    import hashlib
+    import hmac
+    import json
+
+    monkeypatch.setenv("MEMORY_STORE_JWT_SECRET", SECRET)
+
+    def b64(raw):
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+    h = b64(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+    p = b64(json.dumps({"tenant_id": "t1"}).encode())
+    sig = b64(hmac.new(SECRET.encode(), f"{h}.{p}".encode(), hashlib.sha256).digest())
+    with pytest.raises(HTTPException) as exc:
+        _call(f"Bearer {h}.{p}.{sig}")
+    assert exc.value.status_code == 401


### PR DESCRIPTION
Phase 2 of full multi-tenant (option 2). **Stacked on #143** (base = `feat/multi-tenant-phase1`); retarget to `main` after #143 merges.

## What
- `control-plane/user_tokens.py`: the identity authority's per-user token issuer + verifier — HS256, stdlib-only, fail-closed (rejects alg=none/confusion, bad sig, expiry, any token missing `sub`/`tenant_id`/`role`). Roles: viewer < member < operator < owner.
- `memory-store/app/auth.py`: `require_principal` dependency returning the full `Principal(tenant_id, user_id, role)`, alongside the existing tenant-only `require_tenant`.
- 13 offline tests incl. issuer↔consumer interop (a control-plane token verifies to the memory-store Principal; a legacy tenant-only token is rejected). Wired into CI.

## Verify
`pytest experimental/multi-tenant/control-plane/tests/test_user_tokens.py experimental/multi-tenant/memory-store/tests/test_user_auth.py` → 13 passed, offline.

## Remaining phase-2 item (needs live Postgres)
Extend the `memory_records` RLS policy + db scope-setter to key on `(tenant_id, user_id)` — same live-PG requirement as the existing `test_rls.py`. Phase 3 consumes `role` for RBAC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)