### PR TITLE
feat(multi-tenant): RBAC enforcement — phase 3 (stacked on #145)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,11 +131,12 @@ jobs:
           pytest -q tests/memory-governor
       - name: watchdog
         run: pytest -q services/watchdog/tests
-      - name: multi-tenant per-user identity (offline)
+      - name: multi-tenant per-user identity + RBAC (offline)
         run: |
           pip install fastapi
           pytest -q experimental/multi-tenant/control-plane/tests/test_user_tokens.py \
-                    experimental/multi-tenant/memory-store/tests/test_user_auth.py
+                    experimental/multi-tenant/memory-store/tests/test_user_auth.py \
+                    experimental/multi-tenant/memory-store/tests/test_rbac.py
       - name: skill helpers (canonical user-peer threading, A5)
         run: pytest -q tests/skills
       - name: canary stub self-test

--- a/experimental/multi-tenant/memory-store/app/rbac.py
+++ b/experimental/multi-tenant/memory-store/app/rbac.py
@@ -1,0 +1,80 @@
+# Reference design — part of the multi-tenant roadmap. Phase 3 of
+# docs/notes/plans/2026-07-22-full-multi-tenant.md: RBAC enforcement.
+
+"""Role-based access control for the tenant data plane.
+
+Phase 2 gave every caller a verified Principal (tenant_id, user_id, role). This
+maps role -> allowed scopes and provides `require_scope`, a FastAPI dependency
+factory that admits a request only if the caller's role grants the scope.
+
+Fail-closed by construction:
+  - An unknown role grants NO scopes (an unrecognized role can do nothing, never
+    everything) — the map is consulted with a default of the empty set.
+  - `require_scope` composes `require_principal` (phase 2), so it inherits the
+    503-on-unconfigured / 401-on-bad-token posture; a role that lacks the scope
+    gets 403.
+
+Mirrors the auth-proxy SCOPE_MAP pattern (a request needs a scope; a caller
+either has it or is refused). The role->scope table is intentionally small
+(YAGNI): grow it when a real need appears, not before.
+"""
+
+from __future__ import annotations
+
+from fastapi import Depends, HTTPException
+
+from .auth import ROLES, Principal, require_principal
+
+# Data-plane scopes. Keep names aligned with the auth-proxy scope vocabulary
+# (resource:verb) so operators reason about one model.
+SCOPE_MEMORY_READ = "memory:read"
+SCOPE_MEMORY_WRITE = "memory:write"
+SCOPE_MEMORY_DELETE = "memory:delete"
+SCOPE_TENANT_ADMIN = "tenant:admin"
+SCOPE_USER_MANAGE = "user:manage"
+
+# role -> the scopes it grants. Monotonic: each higher role is a superset of the
+# one below, which keeps the model easy to reason about.
+ROLE_SCOPES: dict[str, frozenset[str]] = {
+    "viewer": frozenset({SCOPE_MEMORY_READ}),
+    "member": frozenset({SCOPE_MEMORY_READ, SCOPE_MEMORY_WRITE}),
+    "operator": frozenset(
+        {SCOPE_MEMORY_READ, SCOPE_MEMORY_WRITE, SCOPE_MEMORY_DELETE}
+    ),
+    "owner": frozenset(
+        {
+            SCOPE_MEMORY_READ,
+            SCOPE_MEMORY_WRITE,
+            SCOPE_MEMORY_DELETE,
+            SCOPE_TENANT_ADMIN,
+            SCOPE_USER_MANAGE,
+        }
+    ),
+}
+
+# Contract guard: every declared role must have an entry, so adding a role to
+# auth.ROLES without granting it scopes fails loudly here at import, not silently
+# at request time with an accidental empty grant.
+assert set(ROLES) == set(ROLE_SCOPES), (
+    f"ROLE_SCOPES {sorted(ROLE_SCOPES)} out of sync with auth.ROLES {sorted(ROLES)}"
+)
+
+
+def role_grants(role: str, scope: str) -> bool:
+    """True iff `role` grants `scope`. Unknown role -> False (empty grant)."""
+    return scope in ROLE_SCOPES.get(role, frozenset())
+
+
+def require_scope(scope: str):
+    """Build a dependency that admits the request only if the caller's role
+    grants `scope`, else 403. Composes the phase-2 principal verification."""
+
+    async def _dep(principal: Principal = Depends(require_principal)) -> Principal:
+        if not role_grants(principal.role, scope):
+            raise HTTPException(
+                status_code=403,
+                detail=f"role '{principal.role}' lacks required scope '{scope}'",
+            )
+        return principal
+
+    return _dep

--- a/experimental/multi-tenant/memory-store/tests/test_rbac.py
+++ b/experimental/multi-tenant/memory-store/tests/test_rbac.py
@@ -1,0 +1,72 @@
+"""RBAC role->scope enforcement — offline tests."""
+
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+from app.auth import Principal
+from app.rbac import (
+    ROLE_SCOPES,
+    SCOPE_MEMORY_DELETE,
+    SCOPE_MEMORY_READ,
+    SCOPE_MEMORY_WRITE,
+    SCOPE_TENANT_ADMIN,
+    require_scope,
+    role_grants,
+)
+
+
+def _p(role):
+    return Principal(tenant_id="t1", user_id="u1", role=role)
+
+
+def _admit(scope, principal):
+    """Run the require_scope dependency directly with an explicit principal."""
+    return asyncio.run(require_scope(scope)(principal=principal))
+
+
+def test_matrix_is_monotonic():
+    # each higher role is a strict superset of the one below
+    assert ROLE_SCOPES["viewer"] < ROLE_SCOPES["member"]
+    assert ROLE_SCOPES["member"] < ROLE_SCOPES["operator"]
+    assert ROLE_SCOPES["operator"] < ROLE_SCOPES["owner"]
+
+
+def test_role_grants_expected_scopes():
+    assert role_grants("viewer", SCOPE_MEMORY_READ)
+    assert not role_grants("viewer", SCOPE_MEMORY_WRITE)
+    assert role_grants("member", SCOPE_MEMORY_WRITE)
+    assert not role_grants("member", SCOPE_MEMORY_DELETE)
+    assert role_grants("operator", SCOPE_MEMORY_DELETE)
+    assert not role_grants("operator", SCOPE_TENANT_ADMIN)
+    assert role_grants("owner", SCOPE_TENANT_ADMIN)
+
+
+def test_unknown_role_grants_nothing():
+    assert not role_grants("superadmin", SCOPE_MEMORY_READ)
+    assert not role_grants("", SCOPE_MEMORY_READ)
+
+
+def test_require_scope_admits_when_granted():
+    p = _p("member")
+    assert _admit(SCOPE_MEMORY_WRITE, p) is p  # returns the principal through
+
+
+def test_require_scope_403_when_lacking():
+    with pytest.raises(HTTPException) as exc:
+        _admit(SCOPE_MEMORY_DELETE, _p("member"))
+    assert exc.value.status_code == 403
+
+
+def test_viewer_cannot_write():
+    with pytest.raises(HTTPException) as exc:
+        _admit(SCOPE_MEMORY_WRITE, _p("viewer"))
+    assert exc.value.status_code == 403
+
+
+def test_owner_can_manage_users():
+    from app.rbac import SCOPE_USER_MANAGE
+
+    p = _p("owner")
+    assert _admit(SCOPE_USER_MANAGE, p) is p


### PR DESCRIPTION
Phase 3 of full multi-tenant (option 2). **Stacked on #145** → retarget to `main` as the stack merges.

## What
- `memory-store/app/rbac.py`: monotonic role→scope table (viewer<member<operator<owner) + `require_scope(scope)` dependency composing phase-2 `require_principal` (403 when the role lacks the scope). Fail-closed — unknown role grants ∅; import-time assert keeps `ROLE_SCOPES` in sync with `auth.ROLES`.
- 7 offline tests (matrix, per-role grants, unknown-role-nothing, admit/deny, viewer-cannot-write, owner-can-manage-users). Added to CI.

## Verify
`pytest experimental/multi-tenant/memory-store/tests/test_rbac.py` → 7 passed, offline.

## Remaining phase-3 integration
Key the option-3 HITL approval gate by role (member `outbound_message` gated, owner bypass) — cross-service wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)