### PR TITLE
feat(voice): Twilio surface — PIN gate + Media Streams codec — phase 3 (stacked on #144)

### DIFF
--- a/services/voice-core/src/voicecore/surfaces/__init__.py
+++ b/services/voice-core/src/voicecore/surfaces/__init__.py
@@ -1,0 +1,3 @@
+"""voice-core surface adapters. Phase 3 ships the offline-testable Twilio pieces
+(PIN gate + Media Streams codec); the live websocket bridge lands with an
+account."""

--- a/services/voice-core/src/voicecore/surfaces/twilio.py
+++ b/services/voice-core/src/voicecore/surfaces/twilio.py
@@ -1,0 +1,155 @@
+"""Twilio phone surface — offline-testable pieces of phase 3.
+
+Phase 3 of docs/notes/plans/2026-07-22-voice-track.md is the Twilio phone line.
+The live parts (a real number, a running Media Streams websocket) need a Twilio
+account; these are the parts that do NOT — and that carry the compliance
+weight, so they are worth having pinned by tests before the wire is live:
+
+  - PinGate: the PIN a caller must enter (DTMF) before the agent engages.
+  - the Media Streams codec: parse inbound Twilio websocket events into typed
+    events + AudioFrames (stdlib G.711 μ-law decode for the VAD's energy), and
+    build outbound `media` messages.
+
+No Twilio SDK, no network — pure functions + a small state machine.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from enum import Enum
+
+from ..interfaces import AudioFrame
+
+# G.711 μ-law: peak decoded magnitude, used to normalize energy into 0..1.
+_ULAW_PEAK = 32124
+
+
+def ulaw_to_linear(ulaw_byte: int) -> int:
+    """Decode one G.711 μ-law byte to a signed 16-bit linear PCM sample."""
+    u = ~ulaw_byte & 0xFF
+    sign = u & 0x80
+    exponent = (u >> 4) & 0x07
+    mantissa = u & 0x0F
+    sample = ((mantissa << 3) + 0x84) << exponent
+    sample -= 0x84
+    return -sample if sign else sample
+
+
+def frame_energy_from_ulaw(payload: bytes) -> float:
+    """Normalized 0..1 loudness of a μ-law payload — the value the VAD reads."""
+    if not payload:
+        return 0.0
+    total = sum(abs(ulaw_to_linear(b)) for b in payload)
+    return min(1.0, (total / len(payload)) / _ULAW_PEAK)
+
+
+class TwilioEventKind(Enum):
+    START = "start"
+    MEDIA = "media"
+    DTMF = "dtmf"
+    STOP = "stop"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class TwilioEvent:
+    kind: TwilioEventKind
+    frame: AudioFrame | None = None
+    digit: str | None = None
+    stream_sid: str | None = None
+
+
+def parse_twilio_message(msg: dict) -> TwilioEvent:
+    """Turn one Twilio Media Streams websocket message into a typed event.
+
+    Media payloads (base64 μ-law) become an AudioFrame carrying the raw μ-law
+    bytes as pcm and a decoded energy estimate. Unknown events degrade to
+    UNKNOWN rather than raising — a resilient wire parser."""
+    event = (msg or {}).get("event")
+    if event == "start":
+        return TwilioEvent(
+            kind=TwilioEventKind.START,
+            stream_sid=(msg.get("start") or {}).get("streamSid") or msg.get("streamSid"),
+        )
+    if event == "media":
+        payload_b64 = (msg.get("media") or {}).get("payload", "")
+        try:
+            raw = base64.b64decode(payload_b64) if payload_b64 else b""
+        except Exception:  # noqa: BLE001 — malformed frame → silence, never crash
+            raw = b""
+        return TwilioEvent(
+            kind=TwilioEventKind.MEDIA,
+            frame=AudioFrame(energy=frame_energy_from_ulaw(raw), pcm=raw),
+            stream_sid=msg.get("streamSid"),
+        )
+    if event == "dtmf":
+        return TwilioEvent(
+            kind=TwilioEventKind.DTMF,
+            digit=(msg.get("dtmf") or {}).get("digit"),
+            stream_sid=msg.get("streamSid"),
+        )
+    if event == "stop":
+        return TwilioEvent(kind=TwilioEventKind.STOP, stream_sid=msg.get("streamSid"))
+    return TwilioEvent(kind=TwilioEventKind.UNKNOWN)
+
+
+def outbound_media(frame: AudioFrame, stream_sid: str) -> dict:
+    """Build the Twilio `media` websocket message that plays `frame` — its pcm
+    (μ-law bytes) base64-encoded, addressed to the stream."""
+    payload_b64 = base64.b64encode(frame.pcm).decode("ascii")
+    return {
+        "event": "media",
+        "streamSid": stream_sid,
+        "media": {"payload": payload_b64},
+    }
+
+
+class PinState(Enum):
+    COLLECTING = "collecting"
+    UNLOCKED = "unlocked"
+    LOCKED_OUT = "locked_out"
+
+
+class PinGate:
+    """DTMF PIN a caller must enter before the agent engages.
+
+    Fail-closed: starts COLLECTING (agent NOT engaged); only an exact PIN match
+    unlocks. After `max_attempts` wrong PINs it LOCKS OUT and never unlocks.
+    A wrong digit-run is discarded per attempt so the caller re-enters cleanly.
+    """
+
+    def __init__(self, expected_pin: str, max_attempts: int = 3) -> None:
+        if not expected_pin:
+            raise ValueError("expected_pin is required")
+        self._expected = expected_pin
+        self._max_attempts = max_attempts
+        self._buf = ""
+        self._attempts = 0
+        self._state = PinState.COLLECTING
+
+    @property
+    def state(self) -> PinState:
+        return self._state
+
+    @property
+    def unlocked(self) -> bool:
+        return self._state is PinState.UNLOCKED
+
+    @property
+    def locked_out(self) -> bool:
+        return self._state is PinState.LOCKED_OUT
+
+    def press(self, digit: str) -> PinState:
+        if self._state is not PinState.COLLECTING:
+            return self._state
+        self._buf += digit
+        if len(self._buf) >= len(self._expected):
+            if self._buf == self._expected:
+                self._state = PinState.UNLOCKED
+            else:
+                self._attempts += 1
+                self._buf = ""
+                if self._attempts >= self._max_attempts:
+                    self._state = PinState.LOCKED_OUT
+        return self._state

--- a/services/voice-core/tests/test_twilio.py
+++ b/services/voice-core/tests/test_twilio.py
@@ -1,0 +1,112 @@
+"""Twilio surface — PIN gate + Media Streams codec, offline."""
+
+import base64
+import pathlib
+import sys
+
+_SRC = pathlib.Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(_SRC))
+
+from voicecore.interfaces import AudioFrame  # noqa: E402
+from voicecore.surfaces.twilio import (  # noqa: E402
+    PinGate,
+    PinState,
+    TwilioEventKind,
+    frame_energy_from_ulaw,
+    outbound_media,
+    parse_twilio_message,
+    ulaw_to_linear,
+)
+
+
+# ── μ-law + energy ────────────────────────────────────────────────────────────
+
+def test_ulaw_silence_vs_loud_energy():
+    # 0xFF is the μ-law code nearest zero; 0x00 is near full-scale.
+    quiet = bytes([0xFF] * 8)
+    loud = bytes([0x00] * 8)
+    assert frame_energy_from_ulaw(quiet) < frame_energy_from_ulaw(loud)
+    assert frame_energy_from_ulaw(b"") == 0.0
+    assert 0.0 <= frame_energy_from_ulaw(loud) <= 1.0
+
+
+def test_ulaw_decode_sign():
+    # 0x80 and 0x00 are the two full-scale codes, opposite polarity, |peak|.
+    assert ulaw_to_linear(0x80) > 0
+    assert ulaw_to_linear(0x00) < 0
+    assert abs(ulaw_to_linear(0x80)) == abs(ulaw_to_linear(0x00))
+
+
+# ── inbound event parsing ─────────────────────────────────────────────────────
+
+def test_parse_start():
+    e = parse_twilio_message({"event": "start", "start": {"streamSid": "MZ1"}})
+    assert e.kind is TwilioEventKind.START
+    assert e.stream_sid == "MZ1"
+
+
+def test_parse_media_yields_frame():
+    payload = base64.b64encode(bytes([0x00] * 8)).decode()
+    e = parse_twilio_message({"event": "media", "media": {"payload": payload}})
+    assert e.kind is TwilioEventKind.MEDIA
+    assert isinstance(e.frame, AudioFrame)
+    assert e.frame.energy > 0.0
+    assert e.frame.pcm == bytes([0x00] * 8)
+
+
+def test_parse_media_malformed_payload_is_silence():
+    e = parse_twilio_message({"event": "media", "media": {"payload": "!!!not-base64"}})
+    assert e.kind is TwilioEventKind.MEDIA
+    assert e.frame.energy == 0.0
+
+
+def test_parse_dtmf_and_stop_and_unknown():
+    assert parse_twilio_message({"event": "dtmf", "dtmf": {"digit": "5"}}).digit == "5"
+    assert parse_twilio_message({"event": "stop"}).kind is TwilioEventKind.STOP
+    assert parse_twilio_message({"event": "mark"}).kind is TwilioEventKind.UNKNOWN
+    assert parse_twilio_message({}).kind is TwilioEventKind.UNKNOWN
+
+
+def test_outbound_media_round_trips_payload():
+    frame = AudioFrame(energy=0.0, pcm=b"\x01\x02\x03")
+    msg = outbound_media(frame, "MZ9")
+    assert msg["event"] == "media"
+    assert msg["streamSid"] == "MZ9"
+    assert base64.b64decode(msg["media"]["payload"]) == b"\x01\x02\x03"
+
+
+# ── PIN gate ──────────────────────────────────────────────────────────────────
+
+def test_correct_pin_unlocks():
+    g = PinGate("1234")
+    for d in "1234":
+        g.press(d)
+    assert g.unlocked is True
+    assert g.state is PinState.UNLOCKED
+
+
+def test_starts_locked_and_engages_only_after_pin():
+    g = PinGate("99")
+    assert g.unlocked is False  # fail-closed: agent not engaged yet
+    g.press("9")
+    assert g.unlocked is False
+    g.press("9")
+    assert g.unlocked is True
+
+
+def test_wrong_pin_attempts_then_lockout():
+    g = PinGate("11", max_attempts=2)
+    g.press("0"); g.press("0")  # attempt 1 wrong
+    assert g.state is PinState.COLLECTING
+    g.press("2"); g.press("2")  # attempt 2 wrong -> lockout
+    assert g.locked_out is True
+    # locked out never unlocks, even with the right pin
+    g.press("1"); g.press("1")
+    assert g.unlocked is False
+
+
+def test_press_after_unlock_is_noop():
+    g = PinGate("12")
+    g.press("1"); g.press("2")
+    assert g.unlocked
+    assert g.press("9") is PinState.UNLOCKED


### PR DESCRIPTION
Phase 3 of the voice track (option 1). **Stacked on #144** → retarget to `main` as the stack merges.

## What
- `surfaces/twilio.py`: **PinGate** — DTMF PIN before the agent engages; fail-closed (starts locked, exact-match unlocks, N wrong → permanent lockout). **Media Streams codec** — stdlib G.711 μ-law decode → VAD energy, `parse_twilio_message` (start/media/dtmf/stop/unknown; malformed payload → silence, never crash), `outbound_media` for TTS playback.
- 11 offline tests (suite now 25).

## Verify
`python -m pytest services/voice-core/tests -q` → 25 passed, offline.

## Not in this phase (needs a Twilio account)
Live Media Streams websocket bridge + TwiML, consent/recording-retention wired into the call flow (retention hook exists in phase-2 `WebVoiceSession`), verified STT/TTS provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)