### PR TITLE
feat(multi-tenant): per-tenant budget cap — phase 4 (stacked on #146)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
         run: |
           pip install fastapi
           pytest -q experimental/multi-tenant/control-plane/tests/test_user_tokens.py \
+                    experimental/multi-tenant/control-plane/tests/test_tenant_budget.py \
                     experimental/multi-tenant/memory-store/tests/test_user_auth.py \
                     experimental/multi-tenant/memory-store/tests/test_rbac.py
       - name: skill helpers (canonical user-peer threading, A5)

--- a/experimental/multi-tenant/control-plane/tenant_budget.py
+++ b/experimental/multi-tenant/control-plane/tenant_budget.py
@@ -1,0 +1,86 @@
+# Reference design — part of the multi-tenant roadmap. Phase 4 of
+# docs/notes/plans/2026-07-22-full-multi-tenant.md: per-tenant budget cap.
+
+"""Per-tenant daily budget cap — the pure ledger + enforcement logic.
+
+Phase 4 enforces a per-tenant daily spend cap, keyed by tenant the way the
+model-router already keys its per-caller cap. This module is the offline core:
+an in-memory ledger + a three-mode enforcement decision (off / warn / block),
+matching the router's BUDGET_ENFORCE_MODE vocabulary. The production wire (read
+the tenant's cap from the control-plane, persist spend) sits on top of this;
+the decision logic lives here so it is unit-testable with no clock and no DB.
+
+Day is injected (a 'YYYY-MM-DD' string), never read from a clock, so tests are
+deterministic and the same ledger is reusable across process restarts when the
+caller supplies the current day.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class BudgetMode(Enum):
+    OFF = "off"      # observe only — always allow
+    WARN = "warn"    # allow, but signal an overage
+    BLOCK = "block"  # deny once the cap would be exceeded
+
+
+class BudgetDecision(Enum):
+    ALLOW = "allow"
+    WARN = "warn"
+    BLOCK = "block"
+
+
+class TenantBudget:
+    """Daily spend ledger with a per-tenant cap.
+
+    caps: tenant_id -> daily cap. Unknown tenants fall back to `default_cap`.
+    A non-positive cap means "no spend allowed" (every charge trips the mode);
+    to allow unlimited spend, use mode=OFF or a very large cap.
+    """
+
+    def __init__(
+        self,
+        caps: dict[str, float] | None = None,
+        *,
+        default_cap: float = 0.0,
+        mode: BudgetMode = BudgetMode.BLOCK,
+    ) -> None:
+        self._caps = dict(caps or {})
+        self._default_cap = default_cap
+        self._mode = mode
+        self._spent: dict[tuple[str, str], float] = {}
+
+    def cap_for(self, tenant_id: str) -> float:
+        return self._caps.get(tenant_id, self._default_cap)
+
+    def spent(self, tenant_id: str, day: str) -> float:
+        return self._spent.get((tenant_id, day), 0.0)
+
+    def remaining(self, tenant_id: str, day: str) -> float:
+        return max(0.0, self.cap_for(tenant_id) - self.spent(tenant_id, day))
+
+    def check(self, tenant_id: str, amount: float, day: str) -> BudgetDecision:
+        """Decide whether charging `amount` is allowed, WITHOUT recording it.
+
+        Under cap -> ALLOW regardless of mode. Over cap -> the mode decides:
+        OFF -> ALLOW, WARN -> WARN, BLOCK -> BLOCK. Fail-closed default is BLOCK.
+        """
+        projected = self.spent(tenant_id, day) + amount
+        if projected <= self.cap_for(tenant_id):
+            return BudgetDecision.ALLOW
+        if self._mode is BudgetMode.OFF:
+            return BudgetDecision.ALLOW
+        if self._mode is BudgetMode.WARN:
+            return BudgetDecision.WARN
+        return BudgetDecision.BLOCK
+
+    def record(self, tenant_id: str, amount: float, day: str) -> BudgetDecision:
+        """Charge `amount` and return the decision. A BLOCK is NOT recorded (the
+        spend never happened); ALLOW and WARN accumulate."""
+        decision = self.check(tenant_id, amount, day)
+        if decision is not BudgetDecision.BLOCK:
+            key = (tenant_id, day)
+            self._spent[key] = self._spent.get(key, 0.0) + amount
+        return decision

--- a/experimental/multi-tenant/control-plane/tests/test_tenant_budget.py
+++ b/experimental/multi-tenant/control-plane/tests/test_tenant_budget.py
@@ -1,0 +1,74 @@
+"""Per-tenant daily budget cap — offline tests."""
+
+import pytest
+
+from tenant_budget import BudgetDecision, BudgetMode, TenantBudget
+
+DAY = "2026-07-22"
+
+
+def _budget(mode=BudgetMode.BLOCK):
+    return TenantBudget({"t1": 1.00, "t2": 0.50}, default_cap=0.10, mode=mode)
+
+
+def test_under_cap_allows_regardless_of_mode():
+    for mode in BudgetMode:
+        b = _budget(mode)
+        assert b.check("t1", 0.50, DAY) is BudgetDecision.ALLOW
+
+
+def test_over_cap_blocks_in_block_mode():
+    b = _budget(BudgetMode.BLOCK)
+    assert b.check("t2", 0.75, DAY) is BudgetDecision.BLOCK
+
+
+def test_over_cap_warns_in_warn_mode():
+    b = _budget(BudgetMode.WARN)
+    assert b.check("t2", 0.75, DAY) is BudgetDecision.WARN
+
+
+def test_over_cap_allows_in_off_mode():
+    b = _budget(BudgetMode.OFF)
+    assert b.check("t2", 0.75, DAY) is BudgetDecision.ALLOW
+
+
+def test_unknown_tenant_uses_default_cap():
+    b = _budget()
+    assert b.cap_for("nope") == 0.10
+    assert b.check("nope", 0.20, DAY) is BudgetDecision.BLOCK
+    assert b.check("nope", 0.05, DAY) is BudgetDecision.ALLOW
+
+
+def test_record_accumulates_and_blocks_at_boundary():
+    b = _budget(BudgetMode.BLOCK)
+    assert b.record("t2", 0.40, DAY) is BudgetDecision.ALLOW
+    assert b.remaining("t2", DAY) == pytest.approx(0.10)
+    # next charge would exceed 0.50 -> blocked, and NOT recorded
+    assert b.record("t2", 0.20, DAY) is BudgetDecision.BLOCK
+    assert b.spent("t2", DAY) == pytest.approx(0.40)
+    # a charge that fits still goes through
+    assert b.record("t2", 0.10, DAY) is BudgetDecision.ALLOW
+    assert b.remaining("t2", DAY) == pytest.approx(0.0)
+
+
+def test_per_day_isolation():
+    b = _budget()
+    b.record("t1", 1.00, "2026-07-22")
+    assert b.remaining("t1", "2026-07-22") == pytest.approx(0.0)
+    # a new day starts fresh
+    assert b.remaining("t1", "2026-07-23") == pytest.approx(1.00)
+
+
+def test_per_tenant_isolation():
+    b = _budget()
+    b.record("t1", 1.00, DAY)
+    # t2's ledger is untouched by t1's spend
+    assert b.spent("t2", DAY) == 0.0
+    assert b.remaining("t2", DAY) == pytest.approx(0.50)
+
+
+def test_warn_mode_records_overage():
+    b = _budget(BudgetMode.WARN)
+    assert b.record("t2", 0.75, DAY) is BudgetDecision.WARN
+    # warn allows the spend, so it accumulates (unlike block)
+    assert b.spent("t2", DAY) == pytest.approx(0.75)


### PR DESCRIPTION
Phase 4 of full multi-tenant (option 2). **Stacked on #146** → retarget to `main` as the stack merges. Offline core of the per-tenant daily spend cap.

## What
- `control-plane/tenant_budget.py`: `TenantBudget` daily ledger keyed by (tenant, day); `check` (decide, no record) + `record` (a BLOCK is never recorded; WARN/ALLOW accumulate). Three modes (off/warn/block) matching the model-router's `BUDGET_ENFORCE_MODE`; fail-closed default BLOCK; unknown tenant → default_cap; day injected (no clock).
- 9 offline tests (modes, default-cap, boundary/block-not-recorded, per-day + per-tenant isolation). Added to CI.

## Verify
`pytest experimental/multi-tenant/control-plane/tests/test_tenant_budget.py` → 9 passed.

## Live follow-on
Wire the cap read (control-plane) + spend persistence into the model-router's per-caller path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)