### PR TITLE
feat(voice): Discord voice — RTP parse + sequence tracking — phase 4 (stacked on #147)

### DIFF
--- a/services/voice-core/src/voicecore/surfaces/discord.py
+++ b/services/voice-core/src/voicecore/surfaces/discord.py
@@ -1,0 +1,118 @@
+"""Discord voice surface — offline-testable pieces of phase 4.
+
+Phase 4 of docs/notes/plans/2026-07-22-voice-track.md is Discord voice. The live
+part (a gateway voice connection, Opus decode via a native lib) needs a running
+bot + libopus; these are the parts that do NOT and are worth pinning by tests:
+
+  - RTP packet parsing (RFC 3550) — pure binary structure, the wire Discord
+    delivers voice on.
+  - a SequenceTracker that classifies each packet (in-order / duplicate /
+    reordered / gap) with 16-bit wraparound, so jitter and loss are observable
+    before the decode step.
+
+The Opus -> PCM decode itself is a native-lib dependency and is left as an
+injected `opus_decode` hook (unverified, like the Voice Live provider): the
+Discord adapter is structured and testable without pulling libopus into CI.
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from enum import Enum
+
+from ..interfaces import AudioFrame
+
+_RTP_MIN_HEADER = 12
+
+
+@dataclass(frozen=True)
+class RtpPacket:
+    version: int
+    padding: bool
+    extension: bool
+    csrc_count: int
+    marker: bool
+    payload_type: int
+    sequence: int
+    timestamp: int
+    ssrc: int
+    payload: bytes
+
+
+def parse_rtp_packet(data: bytes) -> RtpPacket:
+    """Parse an RFC 3550 RTP packet. Raises ValueError on a runt packet or a
+    non-v2 version (Discord always sends RTP v2)."""
+    if len(data) < _RTP_MIN_HEADER:
+        raise ValueError(f"RTP packet too short: {len(data)} < {_RTP_MIN_HEADER}")
+    b0, b1, seq, ts, ssrc = struct.unpack("!BBHII", data[:_RTP_MIN_HEADER])
+    version = b0 >> 6
+    if version != 2:
+        raise ValueError(f"unsupported RTP version {version} (expected 2)")
+    csrc_count = b0 & 0x0F
+    header_len = _RTP_MIN_HEADER + csrc_count * 4
+    if len(data) < header_len:
+        raise ValueError("RTP packet truncated within CSRC list")
+    return RtpPacket(
+        version=version,
+        padding=bool(b0 & 0x20),
+        extension=bool(b0 & 0x10),
+        csrc_count=csrc_count,
+        marker=bool(b1 & 0x80),
+        payload_type=b1 & 0x7F,
+        sequence=seq,
+        timestamp=ts,
+        ssrc=ssrc,
+        payload=data[header_len:],
+    )
+
+
+class PacketOrder(Enum):
+    IN_ORDER = "in_order"
+    DUPLICATE = "duplicate"
+    REORDERED = "reordered"  # older than the last seen
+    GAP = "gap"              # newer, but sequence numbers were skipped
+
+
+class SequenceTracker:
+    """Classify RTP sequence numbers with 16-bit wraparound. `observe` returns
+    the packet's relationship to the highest in-order sequence seen so far;
+    `missing` counts skipped numbers across GAPs (a loss estimate)."""
+
+    def __init__(self) -> None:
+        self._last: int | None = None
+        self.missing = 0
+
+    def observe(self, sequence: int) -> PacketOrder:
+        seq = sequence & 0xFFFF
+        if self._last is None:
+            self._last = seq
+            return PacketOrder.IN_ORDER
+        diff = (seq - self._last) & 0xFFFF
+        if diff == 0:
+            return PacketOrder.DUPLICATE
+        if diff < 0x8000:
+            # forward
+            if diff > 1:
+                self.missing += diff - 1
+                order = PacketOrder.GAP
+            else:
+                order = PacketOrder.IN_ORDER
+            self._last = seq
+            return order
+        # diff >= 0x8000 -> the new seq is behind the last: a late/reordered packet
+        return PacketOrder.REORDERED
+
+
+def frame_from_rtp(pkt: RtpPacket, opus_decode=None) -> AudioFrame:
+    """Turn an RTP packet's Opus payload into an AudioFrame. Requires an
+    injected `opus_decode(payload) -> (pcm: bytes, energy: float)`; without one
+    it raises (the native Opus dependency is not pulled into the offline core —
+    mirrors the Voice Live provider's unverified posture)."""
+    if opus_decode is None:
+        raise NotImplementedError(
+            "Opus decode requires a native decoder (inject opus_decode); the "
+            "Discord voice decode path is unverified until wired against libopus"
+        )
+    pcm, energy = opus_decode(pkt.payload)
+    return AudioFrame(energy=energy, pcm=pcm)

--- a/services/voice-core/tests/test_discord.py
+++ b/services/voice-core/tests/test_discord.py
@@ -1,0 +1,111 @@
+"""Discord voice surface — RTP parse + sequence tracking, offline."""
+
+import pathlib
+import struct
+import sys
+
+import pytest
+
+_SRC = pathlib.Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(_SRC))
+
+from voicecore.interfaces import AudioFrame  # noqa: E402
+from voicecore.surfaces.discord import (  # noqa: E402
+    PacketOrder,
+    SequenceTracker,
+    frame_from_rtp,
+    parse_rtp_packet,
+)
+
+
+def _rtp(seq=1, ts=160, ssrc=0xDEAD, pt=120, cc=0, payload=b"opus", marker=False):
+    b0 = (2 << 6) | (cc & 0x0F)
+    b1 = (0x80 if marker else 0) | (pt & 0x7F)
+    header = struct.pack("!BBHII", b0, b1, seq, ts, ssrc)
+    header += b"\x00\x00\x00\x00" * cc  # csrc identifiers
+    return header + payload
+
+
+# ── RTP parsing ───────────────────────────────────────────────────────────────
+
+def test_parse_basic_header_and_payload():
+    pkt = parse_rtp_packet(_rtp(seq=42, ts=960, ssrc=0x1234, pt=120, payload=b"xyz"))
+    assert pkt.version == 2
+    assert pkt.sequence == 42
+    assert pkt.timestamp == 960
+    assert pkt.ssrc == 0x1234
+    assert pkt.payload_type == 120
+    assert pkt.payload == b"xyz"
+
+
+def test_parse_with_csrc_offsets_payload():
+    pkt = parse_rtp_packet(_rtp(cc=2, payload=b"data"))
+    assert pkt.csrc_count == 2
+    assert pkt.payload == b"data"  # 8 CSRC bytes skipped
+
+
+def test_parse_marker_bit():
+    assert parse_rtp_packet(_rtp(marker=True)).marker is True
+    assert parse_rtp_packet(_rtp(marker=False)).marker is False
+
+
+def test_parse_runt_raises():
+    with pytest.raises(ValueError):
+        parse_rtp_packet(b"\x80\x78\x00")
+
+
+def test_parse_wrong_version_raises():
+    data = bytearray(_rtp())
+    data[0] = 0x40  # version 1
+    with pytest.raises(ValueError):
+        parse_rtp_packet(bytes(data))
+
+
+def test_parse_truncated_csrc_raises():
+    # claims 4 CSRCs (16 bytes) but only the 12-byte base header present
+    data = struct.pack("!BBHII", (2 << 6) | 4, 120, 1, 0, 0)
+    with pytest.raises(ValueError):
+        parse_rtp_packet(data)
+
+
+# ── sequence tracking ─────────────────────────────────────────────────────────
+
+def test_in_order_and_duplicate_and_gap():
+    t = SequenceTracker()
+    assert t.observe(10) is PacketOrder.IN_ORDER  # first
+    assert t.observe(11) is PacketOrder.IN_ORDER
+    assert t.observe(11) is PacketOrder.DUPLICATE
+    assert t.observe(15) is PacketOrder.GAP       # 12,13,14 missing
+    assert t.missing == 3
+
+
+def test_reordered_is_detected_without_advancing():
+    t = SequenceTracker()
+    t.observe(100)
+    t.observe(101)
+    assert t.observe(99) is PacketOrder.REORDERED
+    # a late packet does not move the high-water mark
+    assert t.observe(102) is PacketOrder.IN_ORDER
+
+
+def test_sequence_wraparound_is_in_order():
+    t = SequenceTracker()
+    t.observe(0xFFFF)
+    assert t.observe(0x0000) is PacketOrder.IN_ORDER  # 65535 -> 0 wraps forward
+    assert t.observe(0x0001) is PacketOrder.IN_ORDER
+
+
+# ── decode hook ───────────────────────────────────────────────────────────────
+
+def test_frame_from_rtp_requires_decoder():
+    pkt = parse_rtp_packet(_rtp(payload=b"opusdata"))
+    with pytest.raises(NotImplementedError):
+        frame_from_rtp(pkt)
+
+
+def test_frame_from_rtp_with_injected_decoder():
+    pkt = parse_rtp_packet(_rtp(payload=b"opusdata"))
+    frame = frame_from_rtp(pkt, opus_decode=lambda p: (b"pcm", 0.42))
+    assert isinstance(frame, AudioFrame)
+    assert frame.energy == 0.42
+    assert frame.pcm == b"pcm"


### PR DESCRIPTION
Phase 4 of the voice track (option 1). **Stacked on #147** → retarget to `main` as the stack merges.

## What
- `surfaces/discord.py`: `parse_rtp_packet` (RFC 3550; raises on runt/non-v2/truncated-CSRC) + `SequenceTracker` (in-order/duplicate/reordered/gap with 16-bit wraparound + loss counter). Opus→PCM decode is an injected, unverified hook — native libopus kept out of the offline core.
- 11 offline tests (suite now 36).

## Verify
`python -m pytest services/voice-core/tests -q` → 36 passed.

## Not in this phase
Live Discord voice-gateway connection + real libopus decoder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)