### PR TITLE
feat(voice): ops — latency + cost attribution — phase 5 (stacked on #149)

### DIFF
--- a/services/voice-core/src/voicecore/ops.py
+++ b/services/voice-core/src/voicecore/ops.py
@@ -1,0 +1,97 @@
+"""Voice ops — per-turn latency + cost attribution (phase 5).
+
+Phase 5 of docs/notes/plans/2026-07-22-voice-track.md is persona + ops
+hardening. Observability is the offline-testable half: a voice turn's
+felt quality is its end-to-end latency (STT + agent + TTS), and its cost must
+attribute to the caller. This is the pure aggregation core; wiring it onto the
+GenAI OTel pipeline + the model-router per-caller cap is the live follow-on.
+
+Pure and deterministic — durations and costs are passed in, never measured from
+a clock here, so tests pin exact percentiles and totals.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class TurnLatency:
+    """Per-stage latency of one voice turn, in milliseconds."""
+
+    stt_ms: float
+    agent_ms: float
+    tts_ms: float
+
+    @property
+    def total_ms(self) -> float:
+        return self.stt_ms + self.agent_ms + self.tts_ms
+
+
+def _percentile(sorted_values: list[float], pct: float) -> float:
+    """Nearest-rank percentile over an already-sorted list (pct in 0..100)."""
+    if not sorted_values:
+        return 0.0
+    rank = math.ceil(pct / 100 * len(sorted_values))
+    idx = min(max(rank, 1), len(sorted_values)) - 1
+    return sorted_values[idx]
+
+
+class LatencyAggregator:
+    """Accumulates TurnLatency samples and reports stage + total stats."""
+
+    def __init__(self) -> None:
+        self._totals: list[float] = []
+        self._stt: list[float] = []
+        self._agent: list[float] = []
+        self._tts: list[float] = []
+
+    def add(self, turn: TurnLatency) -> None:
+        self._totals.append(turn.total_ms)
+        self._stt.append(turn.stt_ms)
+        self._agent.append(turn.agent_ms)
+        self._tts.append(turn.tts_ms)
+
+    @property
+    def count(self) -> int:
+        return len(self._totals)
+
+    def stats(self) -> dict:
+        if not self._totals:
+            return {"count": 0}
+        st = sorted(self._totals)
+        mean = sum(self._totals) / len(self._totals)
+        return {
+            "count": self.count,
+            "mean_total_ms": mean,
+            "max_total_ms": max(self._totals),
+            "p50_total_ms": _percentile(st, 50),
+            "p95_total_ms": _percentile(st, 95),
+            "mean_stt_ms": sum(self._stt) / len(self._stt),
+            "mean_agent_ms": sum(self._agent) / len(self._agent),
+            "mean_tts_ms": sum(self._tts) / len(self._tts),
+        }
+
+
+@dataclass
+class CostLedger:
+    """Per-caller cost attribution for voice turns. `attribute` accumulates a
+    turn's cost against a caller (agent/tenant); totals roll up per caller and
+    across all callers — the input to the model-router per-caller cap."""
+
+    _by_caller: dict[str, float] = field(default_factory=dict)
+
+    def attribute(self, caller: str, cost: float) -> None:
+        if cost < 0:
+            raise ValueError("cost must be non-negative")
+        self._by_caller[caller] = self._by_caller.get(caller, 0.0) + cost
+
+    def total(self, caller: str) -> float:
+        return self._by_caller.get(caller, 0.0)
+
+    def grand_total(self) -> float:
+        return sum(self._by_caller.values())
+
+    def breakdown(self) -> dict[str, float]:
+        return dict(self._by_caller)

--- a/services/voice-core/tests/test_ops.py
+++ b/services/voice-core/tests/test_ops.py
@@ -1,0 +1,55 @@
+"""Voice ops — latency aggregation + cost attribution, offline."""
+
+import pathlib
+import sys
+
+import pytest
+
+_SRC = pathlib.Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(_SRC))
+
+from voicecore.ops import CostLedger, LatencyAggregator, TurnLatency  # noqa: E402
+
+
+def test_turn_total_is_sum_of_stages():
+    assert TurnLatency(stt_ms=120, agent_ms=800, tts_ms=90).total_ms == 1010
+
+
+def test_empty_aggregator_reports_zero_count():
+    assert LatencyAggregator().stats() == {"count": 0}
+
+
+def test_latency_stats_over_samples():
+    agg = LatencyAggregator()
+    # totals: 100, 200, 300, 400, 1000 (5 samples)
+    for stt, agent, tts in [
+        (10, 80, 10), (20, 160, 20), (30, 240, 30), (40, 320, 40), (100, 800, 100)
+    ]:
+        agg.add(TurnLatency(stt, agent, tts))
+    s = agg.stats()
+    assert s["count"] == 5
+    assert s["max_total_ms"] == 1000
+    assert s["p50_total_ms"] == 300      # nearest-rank median of the 5 totals
+    assert s["p95_total_ms"] == 1000     # top sample
+    assert s["mean_total_ms"] == pytest.approx((100 + 200 + 300 + 400 + 1000) / 5)
+    assert s["mean_agent_ms"] == pytest.approx((80 + 160 + 240 + 320 + 800) / 5)
+
+
+def test_cost_attribution_rolls_up_per_caller():
+    led = CostLedger()
+    led.attribute("alfred", 0.01)
+    led.attribute("alfred", 0.02)
+    led.attribute("gandalf", 0.05)
+    assert led.total("alfred") == pytest.approx(0.03)
+    assert led.total("gandalf") == pytest.approx(0.05)
+    assert led.grand_total() == pytest.approx(0.08)
+    assert led.breakdown() == {"alfred": pytest.approx(0.03), "gandalf": pytest.approx(0.05)}
+
+
+def test_unknown_caller_total_is_zero():
+    assert CostLedger().total("nobody") == 0.0
+
+
+def test_negative_cost_rejected():
+    with pytest.raises(ValueError):
+        CostLedger().attribute("x", -0.01)


### PR DESCRIPTION
Phase 5 (final) of the voice track (option 1). **Stacked on #149** → retarget to `main` as the stack merges. **Completes the voice track's offline phases (1-5).**

## What
- `ops.py`: `TurnLatency` (per-stage + total), `LatencyAggregator` (count, mean/max/p50/p95 + per-stage means), `CostLedger` (per-caller attribution → grand total, feeding the router per-caller cap). Pure — durations/costs passed in, no clock.
- 6 offline tests (suite now **42**).

## Verify
`python -m pytest services/voice-core/tests -q` → 42 passed.

## Live follow-on
Wire latency onto the GenAI OTel pipeline; cost onto the model-router per-caller path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)