### PR TITLE
docs: add self-hosted-primary architecture diagram (diagram #6)

### DIFF
--- a/docs/assets/diagrams/README.md
+++ b/docs/assets/diagrams/README.md
@@ -11,7 +11,7 @@ companions for embedding in Markdown.
 Each diagram is a pair: a `.drawio` editable source (open at
 [app.diagrams.net](https://app.diagrams.net) or with the VS Code Draw.io
 extension) and a rendered `.svg` companion for `<img>` embeds in Markdown. All
-five diagrams below are complete and embedded in the docs.
+six diagrams below are complete and embedded in the docs.
 
 > **SVG re-export.** The committed `.svg` is hand-authored to match the
 > `.drawio` for review. For pixel-perfect fidelity (and after any edit to the
@@ -21,7 +21,7 @@ five diagrams below are complete and embedded in the docs.
 
 ## Diagram set
 
-All five diagrams share the same conventions and naming so the set reads as one
+All six diagrams share the same conventions and naming so the set reads as one
 family. Each is embedded in the doc named in its row.
 
 | # | File | Scope |
@@ -31,6 +31,7 @@ family. Each is embedded in the doc named in its row.
 | 3 | `request-dataflow.{drawio,svg}` | Sequence-style agent/request flow: user → PaperClip → Hermes → Model Router → Foundry, with Honcho memory reads/writes, governor admission/retrieval, budget + fallback decisions. |
 | 4 | `deploy-pipeline.{drawio,svg}` | Build/deploy: `az acr build` → Key Vault seeding → `terraform plan` → destroy-aware approval gate → `apply` → post-deploy smoke (Forge Console + reference GitHub Actions pipeline). |
 | 5 | `multi-tenant.{drawio,svg}` | Multi-tenant target architecture: schema-per-tenant, RLS, per-tenant routing (marked *design target*, ~20–30% implemented). |
+| 6 | `self-hosted-primary.{drawio,svg}` | Two-site failover topology: owned hardware as the live compose site, Azure as a dormant warm standby, the shared always-on PostgreSQL pivot, single-writer lease in Key Vault, one Cloudflare tunnel with two connectors, host-automation timers, and the `aaf-site` switch. Embedded in [`docs/design/self-hosted-primary.md`](../../design/self-hosted-primary.md). |
 
 ## Shared conventions
 
@@ -51,6 +52,10 @@ Apply these to every diagram in the set so they stay visually consistent.
   **Container Apps Environment** (solid, `app-subnet`).
 - Private data services (PostgreSQL, Key Vault) sit inside the VNet and carry a
   lock marker; PostgreSQL is VNet-injected with public access disabled.
+- The self-hosted-primary diagram adds two site-level conventions: a **slate**
+  dashed boundary for the owned-hardware site (vs. blue for Azure), and
+  **muted grey dashed fill** for dormant standby services woken by a lease flip
+  (an extension of the optional-service convention).
 
 ### Layout
 - Layered top-to-bottom: **chat surfaces / ingress → app services → memory &
@@ -90,4 +95,4 @@ docs/assets/diagrams/
 ```
 
 Use lowercase, hyphenated subjects (`system-architecture`, `network-topology`,
-`request-dataflow`, `deploy-pipeline`, `multi-tenant`).
+`request-dataflow`, `deploy-pipeline`, `multi-tenant`, `self-hosted-primary`).

--- a/docs/assets/diagrams/self-hosted-primary.drawio
+++ b/docs/assets/diagrams/self-hosted-primary.drawio
@@ -1,0 +1,542 @@
+<mxfile host="app.diagrams.net" agent="AzureAgentForge architecture style proof" version="24.7.7" type="device">
+  <diagram id="aaf-self-hosted-primary" name="AAF Self-Hosted Primary">
+    <mxGraphModel dx="2200" dy="1400" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1654" pageHeight="1169" math="0" shadow="0" background="#FFFFFF">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+
+        <!-- ============================================================ -->
+        <!-- TITLE BLOCK                                                   -->
+        <!-- ============================================================ -->
+        <mxCell id="title-bar" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#0B3D66;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="40" y="32" width="1574" height="62" as="geometry" />
+        </mxCell>
+        <mxCell id="title-text" value="AzureAgentForge — Self-Hosted Primary · Cloud Warm Standby" style="text;html=1;align=left;verticalAlign=middle;fontColor=#FFFFFF;fontSize=22;fontStyle=1;spacingLeft=20;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="52" y="32" width="1000" height="62" as="geometry" />
+        </mxCell>
+        <mxCell id="title-sub" value="Owned hardware runs the stack · Azure sleeps until a lease flip · steady-state ≈ $35–45/mo · reference topology" style="text;html=1;align=right;verticalAlign=middle;fontColor=#BBD7EE;fontSize=12;spacingRight=20;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="852" y="32" width="750" height="62" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- PUBLIC EDGE BAND (left)                                       -->
+        <!-- ============================================================ -->
+        <mxCell id="grp-public" value="Public edge · one Cloudflare tunnel — the hostname never moves" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F5F7FA;strokeColor=#AEB9C4;dashed=0;verticalAlign=top;fontColor=#5B7A95;fontSize=11;fontStyle=1;align=left;spacingLeft=12;spacingTop=6;arcSize=4;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="100" y="116" width="690" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="user" value="End user" style="sketch=0;outlineConnect=0;fontColor=#23272E;gradientColor=none;fillColor=#0B3D66;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;shape=mxgraph.azure2019.user;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="146" y="148" width="46" height="46" as="geometry" />
+        </mxCell>
+        <mxCell id="cf-edge" value="Cloudflare edge&#10;tunnel origin → live site only" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#E8862F;fontColor=#23272E;fontSize=11;arcSize=12;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;verticalAlign=middle;" vertex="1" parent="1">
+          <mxGeometry x="280" y="146" width="230" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="cf-note" value="failover = lease flip,&#10;not a DNS change" style="text;html=1;align=left;verticalAlign=middle;fontColor=#5B6B7B;fontSize=10;fontStyle=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="540" y="146" width="230" height="60" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- OPERATOR CONTROL BAND (right)                                 -->
+        <!-- ============================================================ -->
+        <mxCell id="grp-operator" value="Operator control plane · every failover is a deliberate action" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F5F7FA;strokeColor=#AEB9C4;dashed=0;verticalAlign=top;fontColor=#5B7A95;fontSize=11;fontStyle=1;align=left;spacingLeft=12;spacingTop=6;arcSize=4;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="830" y="116" width="724" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="operator" value="Operator" style="sketch=0;outlineConnect=0;fontColor=#23272E;gradientColor=none;fillColor=#44546A;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;shape=mxgraph.azure2019.user;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="872" y="148" width="46" height="46" as="geometry" />
+        </mxCell>
+        <mxCell id="aaf-site" value="aaf-site {status | local | cloud}&#10;flips lease · syncs shares · wakes / sleeps cloud" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#44546A;strokeWidth=1.5;fontColor=#23272E;fontSize=11;fontStyle=1;arcSize=12;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;verticalAlign=middle;" vertex="1" parent="1">
+          <mxGeometry x="1000" y="146" width="330" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="aaf-site-note" value="cloud --force = evacuation&#10;(skips share sync · loud warning)" style="text;html=1;align=left;verticalAlign=middle;fontColor=#5B6B7B;fontSize=10;fontStyle=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="1350" y="146" width="196" height="60" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- SELF-HOSTED PRIMARY SITE BOUNDARY (left)                      -->
+        <!-- ============================================================ -->
+        <mxCell id="home-site" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#44546A;dashed=1;dashPattern=8 4;strokeWidth=2;verticalAlign=top;arcSize=2;" vertex="1" parent="1">
+          <mxGeometry x="100" y="262" width="690" height="716" as="geometry" />
+        </mxCell>
+        <mxCell id="home-icon" value="" style="sketch=0;outlineConnect=0;gradientColor=none;fillColor=#44546A;strokeColor=none;dashed=0;html=1;shape=mxgraph.azure2019.virtual_machine;" vertex="1" parent="1">
+          <mxGeometry x="114" y="272" width="26" height="26" as="geometry" />
+        </mxCell>
+        <mxCell id="home-lbl" value="Self-hosted primary site · owned hardware (Apple-silicon mini / mini-PC / WSL2) · normally holds the lease" style="text;html=1;align=left;verticalAlign=middle;fontColor=#44546A;fontSize=12;fontStyle=1;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="146" y="270" width="640" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- Compose stack box -->
+        <mxCell id="compose" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F2F8FD;strokeColor=#0B6BB0;dashed=0;strokeWidth=1.5;verticalAlign=top;arcSize=2;opacity=90;" vertex="1" parent="1">
+          <mxGeometry x="124" y="314" width="642" height="404" as="geometry" />
+        </mxCell>
+        <mxCell id="compose-lbl" value="Docker Compose stack · deploy/mac-site (shared with windows-site) · brought up only via the site switch" style="text;html=1;align=left;verticalAlign=middle;fontColor=#0B6BB0;fontSize=11;fontStyle=1;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="138" y="320" width="620" height="26" as="geometry" />
+        </mxCell>
+
+        <!-- Row 1: lease-guard + cloudflared connector (live) -->
+        <mxCell id="c-leaseguard" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#44546A;strokeWidth=1.5;verticalAlign=top;arcSize=6;" vertex="1" parent="1">
+          <mxGeometry x="146" y="354" width="290" height="88" as="geometry" />
+        </mxCell>
+        <mxCell id="c-leaseguard-t" value="lease-guard  (init container)" style="text;html=1;align=left;verticalAlign=middle;fontColor=#1B2733;fontSize=13;fontStyle=1;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="158" y="360" width="270" height="22" as="geometry" />
+        </mxCell>
+        <mxCell id="c-leaseguard-d" value="refuses to start the stack unless the&#10;lease mirror (~/aaf/active-site) names this site" style="text;html=1;align=left;verticalAlign=top;fontColor=#5B6B7B;fontSize=10;spacingLeft=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="158" y="388" width="270" height="48" as="geometry" />
+        </mxCell>
+
+        <mxCell id="c-cfd" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFF7EF;strokeColor=#E8862F;strokeWidth=1.5;verticalAlign=top;arcSize=6;" vertex="1" parent="1">
+          <mxGeometry x="460" y="354" width="286" height="88" as="geometry" />
+        </mxCell>
+        <mxCell id="c-cfd-t" value="cloudflared connector — LIVE" style="text;html=1;align=left;verticalAlign=middle;fontColor=#1B2733;fontSize=13;fontStyle=1;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="472" y="360" width="266" height="22" as="geometry" />
+        </mxCell>
+        <mxCell id="c-cfd-d" value="compose &quot;live&quot; profile · started only when&#10;this site holds the lease · same tunnel as standby" style="text;html=1;align=left;verticalAlign=top;fontColor=#5B6B7B;fontSize=10;spacingLeft=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="472" y="388" width="266" height="48" as="geometry" />
+        </mxCell>
+
+        <!-- Row 2: PaperClip + Hermes/Router -->
+        <mxCell id="c-paperclip" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#0078D4;strokeWidth=1.5;verticalAlign=top;arcSize=6;" vertex="1" parent="1">
+          <mxGeometry x="146" y="462" width="290" height="88" as="geometry" />
+        </mxCell>
+        <mxCell id="c-paperclip-t" value="PaperClip" style="text;html=1;align=left;verticalAlign=middle;fontColor=#1B2733;fontSize=13;fontStyle=1;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="158" y="468" width="270" height="22" as="geometry" />
+        </mxCell>
+        <mxCell id="c-paperclip-d" value="orchestrator + web UI · :3100&#10;local bind-mounted workspace shares" style="text;html=1;align=left;verticalAlign=top;fontColor=#5B6B7B;fontSize=10;spacingLeft=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="158" y="496" width="270" height="48" as="geometry" />
+        </mxCell>
+
+        <mxCell id="c-hermes" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#0078D4;strokeWidth=1.5;verticalAlign=top;arcSize=6;" vertex="1" parent="1">
+          <mxGeometry x="460" y="462" width="286" height="88" as="geometry" />
+        </mxCell>
+        <mxCell id="c-hermes-t" value="Hermes + Model Router" style="text;html=1;align=left;verticalAlign=middle;fontColor=#1B2733;fontSize=13;fontStyle=1;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="472" y="468" width="266" height="22" as="geometry" />
+        </mxCell>
+        <mxCell id="c-hermes-d" value="agent runtime · 13-role hierarchy&#10;all inference egress via the router (budgets + fallback)" style="text;html=1;align=left;verticalAlign=top;fontColor=#5B6B7B;fontSize=10;spacingLeft=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="472" y="496" width="266" height="48" as="geometry" />
+        </mxCell>
+
+        <!-- Row 3: Honcho + lease mirror -->
+        <mxCell id="c-honcho" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#0078D4;strokeWidth=1.5;verticalAlign=top;arcSize=6;" vertex="1" parent="1">
+          <mxGeometry x="146" y="570" width="290" height="88" as="geometry" />
+        </mxCell>
+        <mxCell id="c-honcho-t" value="Honcho" style="text;html=1;align=left;verticalAlign=middle;fontColor=#1B2733;fontSize=13;fontStyle=1;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="158" y="576" width="270" height="22" as="geometry" />
+        </mxCell>
+        <mxCell id="c-honcho-d" value="agent memory · no local Postgres —&#10;connects out to the shared Flexible Server" style="text;html=1;align=left;verticalAlign=top;fontColor=#5B6B7B;fontSize=10;spacingLeft=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="158" y="604" width="270" height="48" as="geometry" />
+        </mxCell>
+
+        <mxCell id="c-mirror" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F7F8F5;strokeColor=#8593A1;strokeWidth=1.5;dashed=1;verticalAlign=top;arcSize=6;" vertex="1" parent="1">
+          <mxGeometry x="460" y="570" width="286" height="88" as="geometry" />
+        </mxCell>
+        <mxCell id="c-mirror-t" value="Lease mirror  ~/aaf/active-site" style="text;html=1;align=left;verticalAlign=middle;fontColor=#1B2733;fontSize=13;fontStyle=1;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="472" y="576" width="266" height="22" as="geometry" />
+        </mxCell>
+        <mxCell id="c-mirror-d" value="written by the site switch before every bring-up —&#10;the host never holds a service principal" style="text;html=1;align=left;verticalAlign=top;fontColor=#5B6B7B;fontSize=10;spacingLeft=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="472" y="604" width="266" height="48" as="geometry" />
+        </mxCell>
+
+        <!-- Host automation box -->
+        <mxCell id="host-auto" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F7F8F5;strokeColor=#8593A1;dashed=1;strokeWidth=1.5;verticalAlign=top;arcSize=2;" vertex="1" parent="1">
+          <mxGeometry x="124" y="738" width="642" height="216" as="geometry" />
+        </mxCell>
+        <mxCell id="host-auto-lbl" value="Host automation · launchd (macOS) / Task Scheduler → WSL2 (Windows) · each job is a no-op without the lease" style="text;html=1;align=left;verticalAlign=middle;fontColor=#5B6B7B;fontSize=11;fontStyle=1;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="138" y="744" width="620" height="26" as="geometry" />
+        </mxCell>
+        <mxCell id="ha-boot" value="boot-guard · startup + every 5 min — stops the stack if the authoritative lease moved (does nothing on Key Vault errors)" style="text;html=1;align=left;verticalAlign=middle;fontColor=#42505E;fontSize=10;spacingLeft=8;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="146" y="776" width="600" height="26" as="geometry" />
+        </mxCell>
+        <mxCell id="ha-image" value="image freshness · every 10 min — registry login + compose pull; roll the live profile only on a digest change" style="text;html=1;align=left;verticalAlign=middle;fontColor=#42505E;fontSize=10;spacingLeft=8;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="146" y="808" width="600" height="26" as="geometry" />
+        </mxCell>
+        <mxCell id="ha-fw" value="firewall keeper · every 15 min — upsert the shared-PG &quot;home-ip&quot; rule when the home WAN address rotates" style="text;html=1;align=left;verticalAlign=middle;fontColor=#42505E;fontSize=10;spacingLeft=8;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="146" y="840" width="600" height="26" as="geometry" />
+        </mxCell>
+        <mxCell id="ha-sync" value="warm-standby share sync · hourly — azcopy the file shares local→cloud; stamps standby_sync_completed for the watchdog" style="text;html=1;align=left;verticalAlign=middle;fontColor=#42505E;fontSize=10;spacingLeft=8;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="146" y="872" width="600" height="26" as="geometry" />
+        </mxCell>
+        <mxCell id="ha-curator" value="skill curator · daily — one-shot maintenance job (compose &quot;jobs&quot; profile)" style="text;html=1;align=left;verticalAlign=middle;fontColor=#42505E;fontSize=10;spacingLeft=8;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="146" y="904" width="600" height="26" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- AZURE REGION BOUNDARY (right)                                 -->
+        <!-- ============================================================ -->
+        <mxCell id="region" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#0078D4;dashed=1;dashPattern=8 4;strokeWidth=2;verticalAlign=top;arcSize=2;" vertex="1" parent="1">
+          <mxGeometry x="830" y="262" width="724" height="716" as="geometry" />
+        </mxCell>
+        <mxCell id="region-icon" value="" style="sketch=0;outlineConnect=0;gradientColor=none;fillColor=#0078D4;strokeColor=none;dashed=0;html=1;shape=mxgraph.azure2019.azure;" vertex="1" parent="1">
+          <mxGeometry x="844" y="272" width="26" height="26" as="geometry" />
+        </mxCell>
+        <mxCell id="region-lbl" value="Azure region · warm standby compute + the shared data plane" style="text;html=1;align=left;verticalAlign=middle;fontColor=#0078D4;fontSize=12;fontStyle=1;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="876" y="270" width="600" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- Dormant CAE -->
+        <mxCell id="standby" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F4F5F7;strokeColor=#8593A1;dashed=1;strokeWidth=1.5;verticalAlign=top;arcSize=2;" vertex="1" parent="1">
+          <mxGeometry x="854" y="314" width="676" height="212" as="geometry" />
+        </mxCell>
+        <mxCell id="standby-icon" value="" style="sketch=0;outlineConnect=0;gradientColor=none;fillColor=#8593A1;strokeColor=none;dashed=0;html=1;shape=mxgraph.azure2019.container_instances;" vertex="1" parent="1">
+          <mxGeometry x="868" y="324" width="24" height="24" as="geometry" />
+        </mxCell>
+        <mxCell id="standby-lbl" value="Container Apps Environment — DORMANT · scale-to-zero / asleep · woken only by aaf-site cloud" style="text;html=1;align=left;verticalAlign=middle;fontColor=#5B6B7B;fontSize=11;fontStyle=1;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="898" y="323" width="620" height="26" as="geometry" />
+        </mxCell>
+
+        <mxCell id="s-paperclip" value="PaperClip&#10;(asleep)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#8593A1;dashed=1;fontColor=#5B6B7B;fontSize=11;arcSize=8;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;verticalAlign=middle;" vertex="1" parent="1">
+          <mxGeometry x="878" y="366" width="146" height="64" as="geometry" />
+        </mxCell>
+        <mxCell id="s-hermes" value="Hermes + Router&#10;(asleep)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#8593A1;dashed=1;fontColor=#5B6B7B;fontSize=11;arcSize=8;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;verticalAlign=middle;" vertex="1" parent="1">
+          <mxGeometry x="1042" y="366" width="146" height="64" as="geometry" />
+        </mxCell>
+        <mxCell id="s-honcho" value="Honcho&#10;(asleep)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#8593A1;dashed=1;fontColor=#5B6B7B;fontSize=11;arcSize=8;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;verticalAlign=middle;" vertex="1" parent="1">
+          <mxGeometry x="1206" y="366" width="146" height="64" as="geometry" />
+        </mxCell>
+        <mxCell id="s-cfd" value="cloudflared&#10;connector (idle)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#E8862F;dashed=1;fontColor=#5B6B7B;fontSize=11;arcSize=8;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;verticalAlign=middle;" vertex="1" parent="1">
+          <mxGeometry x="1370" y="366" width="146" height="64" as="geometry" />
+        </mxCell>
+        <mxCell id="standby-note" value="same images · same tunnel · same shared DB — a lease flip makes this the live site with shares at most one hour stale" style="text;html=1;align=left;verticalAlign=middle;fontColor=#5B6B7B;fontSize=10;fontStyle=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="878" y="448" width="640" height="60" as="geometry" />
+        </mxCell>
+
+        <!-- Shared data plane: PostgreSQL + Key Vault -->
+        <mxCell id="data-pg" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F3FAF4;strokeColor=#3C7A47;strokeWidth=1.5;verticalAlign=top;arcSize=6;" vertex="1" parent="1">
+          <mxGeometry x="854" y="556" width="330" height="150" as="geometry" />
+        </mxCell>
+        <mxCell id="data-pg-ico" value="" style="sketch=0;outlineConnect=0;gradientColor=none;fillColor=#3C7A47;strokeColor=none;dashed=0;html=1;shape=mxgraph.azure2019.azure_database_for_postgresql_servers;" vertex="1" parent="1">
+          <mxGeometry x="866" y="568" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="data-pg-t" value="PostgreSQL Flexible Server — SHARED" style="text;html=1;align=left;verticalAlign=middle;fontColor=#1B2733;fontSize=13;fontStyle=1;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="904" y="566" width="276" height="22" as="geometry" />
+        </mxCell>
+        <mxCell id="data-pg-d" value="always-on · the failover pivot — the database never moves&#10;both sites connect over the public endpoint, IP-firewalled,&#10;sslmode=require · pgvector · RPO ≈ 0 for a site switch" style="text;html=1;align=left;verticalAlign=top;fontColor=#5B6B7B;fontSize=10;spacingLeft=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="866" y="604" width="308" height="92" as="geometry" />
+        </mxCell>
+
+        <mxCell id="data-kv" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F3FAF4;strokeColor=#3C7A47;strokeWidth=1.5;verticalAlign=top;arcSize=6;" vertex="1" parent="1">
+          <mxGeometry x="1200" y="556" width="330" height="150" as="geometry" />
+        </mxCell>
+        <mxCell id="data-kv-ico" value="" style="sketch=0;outlineConnect=0;gradientColor=none;fillColor=#3C7A47;strokeColor=none;dashed=0;html=1;shape=mxgraph.azure2019.key_vaults;" vertex="1" parent="1">
+          <mxGeometry x="1212" y="568" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="data-kv-t" value="Key Vault — the lease authority" style="text;html=1;align=left;verticalAlign=middle;fontColor=#1B2733;fontSize=13;fontStyle=1;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="1250" y="566" width="270" height="22" as="geometry" />
+        </mxCell>
+        <mxCell id="data-kv-d" value="secret platform-active-site ∈ {cloud, local} —&#10;the single-writer lease (anti-split-brain)&#10;plus app credentials · public access default-deny + IP allowlist" style="text;html=1;align=left;verticalAlign=top;fontColor=#5B6B7B;fontSize=10;spacingLeft=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="1212" y="604" width="308" height="92" as="geometry" />
+        </mxCell>
+
+        <!-- Supporting services row: ACR / Files / Log Analytics -->
+        <mxCell id="data-acr" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#0078D4;strokeWidth=1.5;verticalAlign=top;arcSize=6;" vertex="1" parent="1">
+          <mxGeometry x="854" y="736" width="200" height="118" as="geometry" />
+        </mxCell>
+        <mxCell id="data-acr-ico" value="" style="sketch=0;outlineConnect=0;gradientColor=none;fillColor=#0078D4;strokeColor=none;dashed=0;html=1;shape=mxgraph.azure2019.container_registries;" vertex="1" parent="1">
+          <mxGeometry x="866" y="748" width="28" height="28" as="geometry" />
+        </mxCell>
+        <mxCell id="data-acr-t" value="Container Registry" style="text;html=1;align=left;verticalAlign=middle;fontColor=#1B2733;fontSize=12;fontStyle=1;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="902" y="748" width="150" height="22" as="geometry" />
+        </mxCell>
+        <mxCell id="data-acr-d" value="one image source&#10;for both sites&#10;(arm64 + amd64 tags)" style="text;html=1;align=left;verticalAlign=top;fontColor=#5B6B7B;fontSize=10;spacingLeft=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="866" y="784" width="180" height="62" as="geometry" />
+        </mxCell>
+
+        <mxCell id="data-files" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#0078D4;strokeWidth=1.5;verticalAlign=top;arcSize=6;" vertex="1" parent="1">
+          <mxGeometry x="1078" y="736" width="228" height="118" as="geometry" />
+        </mxCell>
+        <mxCell id="data-files-ico" value="" style="sketch=0;outlineConnect=0;gradientColor=none;fillColor=#0078D4;strokeColor=none;dashed=0;html=1;shape=mxgraph.azure2019.files;" vertex="1" parent="1">
+          <mxGeometry x="1090" y="748" width="28" height="28" as="geometry" />
+        </mxCell>
+        <mxCell id="data-files-t" value="Azure Files shares" style="text;html=1;align=left;verticalAlign=middle;fontColor=#1B2733;fontSize=12;fontStyle=1;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="1126" y="748" width="170" height="22" as="geometry" />
+        </mxCell>
+        <mxCell id="data-files-d" value="agent workspaces + gateway&#10;config · standby copy, refreshed&#10;by the hourly sync — at most 1 h stale" style="text;html=1;align=left;verticalAlign=top;fontColor=#5B6B7B;fontSize=10;spacingLeft=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="1090" y="784" width="208" height="62" as="geometry" />
+        </mxCell>
+
+        <mxCell id="data-la" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#8593A1;strokeWidth=1.5;verticalAlign=top;arcSize=6;" vertex="1" parent="1">
+          <mxGeometry x="1330" y="736" width="200" height="118" as="geometry" />
+        </mxCell>
+        <mxCell id="data-la-ico" value="" style="sketch=0;outlineConnect=0;gradientColor=none;fillColor=#8593A1;strokeColor=none;dashed=0;html=1;shape=mxgraph.azure2019.log_analytics_workspaces;" vertex="1" parent="1">
+          <mxGeometry x="1342" y="748" width="28" height="28" as="geometry" />
+        </mxCell>
+        <mxCell id="data-la-t" value="Log Analytics" style="text;html=1;align=left;verticalAlign=middle;fontColor=#1B2733;fontSize=12;fontStyle=1;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="1378" y="748" width="150" height="22" as="geometry" />
+        </mxCell>
+        <mxCell id="data-la-d" value="minimal retention&#10;(self-hosted-primary&#10;profile keeps logs lean)" style="text;html=1;align=left;verticalAlign=top;fontColor=#5B6B7B;fontSize=10;spacingLeft=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="1342" y="784" width="180" height="62" as="geometry" />
+        </mxCell>
+
+        <!-- Cost note inside region -->
+        <mxCell id="cost-note" value="steady-state cloud spend ≈ $35–45/mo — the always-on shared server is the price of RPO-0 failover" style="text;html=1;align=left;verticalAlign=middle;fontColor=#5B6B7B;fontSize=10;fontStyle=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="858" y="912" width="670" height="40" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- LLM BACKENDS BAND (bottom-left)                               -->
+        <!-- ============================================================ -->
+        <mxCell id="grp-llm" value="LLM backends (external inference)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FBF7F0;strokeColor=#C9A45B;dashed=0;verticalAlign=top;fontColor=#8A6D1F;fontSize=11;fontStyle=1;align=left;spacingLeft=12;spacingTop=6;arcSize=4;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="100" y="1002" width="690" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="llm-foundry" value="Azure AI Foundry&#10;(primary)" style="sketch=0;outlineConnect=0;fontColor=#23272E;gradientColor=none;fillColor=#FFFFFF;strokeColor=#C9A45B;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;shape=mxgraph.azure2019.cognitive_services;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="160" y="1036" width="44" height="44" as="geometry" />
+        </mxCell>
+        <mxCell id="llm-fallback" value="OpenAI-compatible&#10;endpoint (fallback)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#C9A45B;dashed=1;fontColor=#23272E;fontSize=11;arcSize=12;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;verticalAlign=middle;" vertex="1" parent="1">
+          <mxGeometry x="330" y="1034" width="180" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="llm-note" value="egress from whichever site is live,&#10;always via the Model Router (budget caps)" style="text;html=1;align=left;verticalAlign=middle;fontColor=#5B6B7B;fontSize=10;fontStyle=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="540" y="1034" width="240" height="60" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- REQUEST FLOW EDGES (numbered, navy)                           -->
+        <!-- ============================================================ -->
+        <mxCell id="e1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=block;endFill=1;strokeColor=#0B3D66;strokeWidth=2;exitX=1;exitY=0.5;entryX=0;entryY=0.5;" edge="1" parent="1" source="user" target="cf-edge">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e1-n" value="1" style="text;html=1;align=center;verticalAlign=middle;fontColor=#FFFFFF;fontSize=10;fontStyle=1;fillColor=#0B3D66;strokeColor=none;rounded=1;arcSize=50;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="228" y="160" width="20" height="20" as="geometry" />
+        </mxCell>
+
+        <mxCell id="e2" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=block;endFill=1;strokeColor=#0B3D66;strokeWidth=2;exitX=0.75;exitY=1;entryX=0.5;entryY=0;" edge="1" parent="1" source="cf-edge" target="c-cfd">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="452" y="250" />
+              <mxPoint x="603" y="250" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e2-n" value="2" style="text;html=1;align=center;verticalAlign=middle;fontColor=#FFFFFF;fontSize=10;fontStyle=1;fillColor=#0B3D66;strokeColor=none;rounded=1;arcSize=50;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="520" y="240" width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="e2-lbl" value="live connector only (lease holder)" style="text;html=1;align=left;verticalAlign=middle;fontColor=#0B3D66;fontSize=10;fontStyle=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="548" y="226" width="220" height="24" as="geometry" />
+        </mxCell>
+
+        <mxCell id="e3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=block;endFill=1;strokeColor=#0B3D66;strokeWidth=2;exitX=0.1;exitY=1;entryX=0.75;entryY=0;" edge="1" parent="1" source="c-cfd" target="c-paperclip">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="490" y="452" />
+              <mxPoint x="364" y="452" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e3-n" value="3" style="text;html=1;align=center;verticalAlign=middle;fontColor=#FFFFFF;fontSize=10;fontStyle=1;fillColor=#0B3D66;strokeColor=none;rounded=1;arcSize=50;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="412" y="442" width="20" height="20" as="geometry" />
+        </mxCell>
+
+        <mxCell id="e4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=block;endFill=1;strokeColor=#0B3D66;strokeWidth=2;exitX=1;exitY=0.5;entryX=0;entryY=0.5;" edge="1" parent="1" source="c-paperclip" target="c-hermes">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e4-n" value="4" style="text;html=1;align=center;verticalAlign=middle;fontColor=#FFFFFF;fontSize=10;fontStyle=1;fillColor=#0B3D66;strokeColor=none;rounded=1;arcSize=50;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="438" y="496" width="20" height="20" as="geometry" />
+        </mxCell>
+
+        <mxCell id="e5" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;startArrow=block;startFill=1;endArrow=block;endFill=1;strokeColor=#2E6CA3;strokeWidth=2;exitX=0.25;exitY=1;entryX=0.25;entryY=0;" edge="1" parent="1" source="c-hermes" target="c-honcho">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="532" y="560" />
+              <mxPoint x="291" y="560" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e5-n" value="5" style="text;html=1;align=center;verticalAlign=middle;fontColor=#FFFFFF;fontSize=10;fontStyle=1;fillColor=#2E6CA3;strokeColor=none;rounded=1;arcSize=50;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="400" y="550" width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="e5-lbl" value="memory read / write" style="text;html=1;align=left;verticalAlign=middle;fontColor=#2E6CA3;fontSize=10;fontStyle=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="300" y="548" width="130" height="24" as="geometry" />
+        </mxCell>
+
+        <mxCell id="e6" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;startArrow=block;startFill=1;endArrow=block;endFill=1;strokeColor=#3C7A47;strokeWidth=2;exitX=0.5;exitY=1;entryX=0;entryY=0.5;" edge="1" parent="1" source="c-honcho" target="data-pg">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="291" y="700" />
+              <mxPoint x="798" y="700" />
+              <mxPoint x="798" y="631" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e6-n" value="6" style="text;html=1;align=center;verticalAlign=middle;fontColor=#FFFFFF;fontSize=10;fontStyle=1;fillColor=#3C7A47;strokeColor=none;rounded=1;arcSize=50;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="788" y="650" width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="e6-lbl" value="TLS · public endpoint · IP-firewalled — crosses both site boundaries; the DB itself never moves" style="text;html=1;align=center;verticalAlign=middle;fontColor=#3C7A47;fontSize=10;fontStyle=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="335" y="680" width="420" height="24" as="geometry" />
+        </mxCell>
+
+        <mxCell id="e7" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=block;endFill=1;strokeColor=#C9851F;strokeWidth=2;exitX=1;exitY=0.75;entryX=0.5;entryY=0;" edge="1" parent="1" source="c-hermes" target="llm-foundry">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="818" y="530" />
+              <mxPoint x="818" y="988" />
+              <mxPoint x="182" y="988" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e7-n" value="7" style="text;html=1;align=center;verticalAlign=middle;fontColor=#FFFFFF;fontSize=10;fontStyle=1;fillColor=#C9851F;strokeColor=none;rounded=1;arcSize=50;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="300" y="978" width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="e7b" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=block;endFill=1;strokeColor=#C9851F;strokeWidth=1.5;dashed=1;dashPattern=4 4;exitX=0.5;exitY=1;entryX=0.5;entryY=0;" edge="1" parent="1" source="llm-foundry" target="llm-fallback">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="182" y="1092" />
+              <mxPoint x="420" y="1104" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- CONTROL / LEASE / SYNC EDGES (dotted)                         -->
+        <!-- ============================================================ -->
+        <!-- aaf-site -> Key Vault (lease flip) -->
+        <mxCell id="ec1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=open;endFill=0;dashed=1;dashPattern=2 4;strokeColor=#44546A;strokeWidth=1.8;exitX=0.5;exitY=1;entryX=1;entryY=0.5;" edge="1" parent="1" source="aaf-site" target="data-kv">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="1165" y="246" />
+              <mxPoint x="1542" y="246" />
+              <mxPoint x="1542" y="631" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="ec1-lbl" value="writes the lease (platform-active-site)" style="text;html=1;align=left;verticalAlign=middle;fontColor=#44546A;fontSize=10;fontStyle=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="1300" y="530" width="230" height="24" as="geometry" />
+        </mxCell>
+
+        <!-- aaf-site -> standby (wake/sleep) -->
+        <mxCell id="ec2" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=open;endFill=0;dashed=1;dashPattern=2 4;strokeColor=#44546A;strokeWidth=1.8;exitX=0.25;exitY=1;entryX=0.75;entryY=0;" edge="1" parent="1" source="aaf-site" target="standby">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="1082" y="228" />
+              <mxPoint x="1361" y="228" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="ec2-lbl" value="wakes / sleeps the cloud apps" style="text;html=1;align=left;verticalAlign=middle;fontColor=#44546A;fontSize=10;fontStyle=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="1090" y="286" width="200" height="24" as="geometry" />
+        </mxCell>
+
+        <!-- aaf-site -> lease mirror -->
+        <mxCell id="ec3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=open;endFill=0;dashed=1;dashPattern=2 4;strokeColor=#44546A;strokeWidth=1.8;exitX=0;exitY=0.5;entryX=1;entryY=0.5;" edge="1" parent="1" source="aaf-site" target="c-mirror">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="778" y="176" />
+              <mxPoint x="778" y="614" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- boot-guard -> Key Vault (authoritative lease read) -->
+        <mxCell id="ec4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=open;endFill=0;dashed=1;dashPattern=2 4;strokeColor=#7A8895;strokeWidth=1.5;exitX=1;exitY=0.5;entryX=0.25;entryY=1;" edge="1" parent="1" source="ha-boot" target="data-kv">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="806" y="789" />
+              <mxPoint x="806" y="726" />
+              <mxPoint x="1282" y="726" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- firewall keeper -> PG -->
+        <mxCell id="ec5" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=open;endFill=0;dashed=1;dashPattern=2 4;strokeColor=#7A8895;strokeWidth=1.5;exitX=1;exitY=0.5;entryX=0.5;entryY=1;" edge="1" parent="1" source="ha-fw" target="data-pg">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="804" y="853" />
+              <mxPoint x="804" y="714" />
+              <mxPoint x="1019" y="714" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- image freshness -> ACR -->
+        <mxCell id="ec6" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=open;endFill=0;dashed=1;dashPattern=2 4;strokeColor=#7A8895;strokeWidth=1.5;exitX=1;exitY=0.5;entryX=0;entryY=0.5;" edge="1" parent="1" source="ha-image" target="data-acr">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="796" y="821" />
+              <mxPoint x="796" y="795" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- share sync -> Azure Files (green dashed = data sync) -->
+        <mxCell id="ec7" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=block;endFill=1;dashed=1;dashPattern=6 3;strokeColor=#3C7A47;strokeWidth=2;exitX=1;exitY=0.5;entryX=0.5;entryY=1;" edge="1" parent="1" source="ha-sync" target="data-files">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="834" y="885" />
+              <mxPoint x="1192" y="885" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="ec7-lbl" value="azcopy · hourly · shares only — never the database" style="text;html=1;align=left;verticalAlign=middle;fontColor=#3C7A47;fontSize=10;fontStyle=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="860" y="866" width="320" height="20" as="geometry" />
+        </mxCell>
+
+        <!-- standby connector -> cf edge (idle tunnel) -->
+        <mxCell id="ec8" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=open;endFill=0;dashed=1;dashPattern=2 4;strokeColor=#E8862F;strokeWidth=1.5;exitX=0.5;exitY=0;entryX=1;entryY=0.5;" edge="1" parent="1" source="s-cfd" target="cf-edge">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="1443" y="254" />
+              <mxPoint x="524" y="254" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="ec8-lbl" value="second connector · same tunnel · idle until the lease flips" style="text;html=1;align=left;verticalAlign=middle;fontColor=#B06318;fontSize=10;fontStyle=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="800" y="243" width="340" height="20" as="geometry" />
+        </mxCell>
+
+        <!-- standby -> PG (dotted, when live) -->
+        <mxCell id="ec9" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=open;endFill=0;dashed=1;dashPattern=2 4;strokeColor=#7A8895;strokeWidth=1.5;exitX=0.25;exitY=1;entryX=0.5;entryY=0;" edge="1" parent="1" source="standby" target="data-pg">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="ec9-lbl" value="same DB when live" style="text;html=1;align=left;verticalAlign=middle;fontColor=#7A8895;fontSize=10;fontStyle=2;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="1030" y="532" width="130" height="20" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- LEGEND                                                        -->
+        <!-- ============================================================ -->
+        <mxCell id="legend-box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#AEB9C4;dashed=0;arcSize=4;" vertex="1" parent="1">
+          <mxGeometry x="830" y="1002" width="724" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="legend-title" value="Legend" style="text;html=1;align=left;verticalAlign=middle;fontColor=#1B2733;fontSize=11;fontStyle=1;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="844" y="1008" width="100" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="lg-b1" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#44546A;dashed=1;dashPattern=8 4;strokeWidth=2;arcSize=8;" vertex="1" parent="1">
+          <mxGeometry x="846" y="1036" width="34" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="lg-b1-t" value="dashed = site / trust boundary (slate = owned hardware, blue = Azure)" style="text;html=1;align=left;verticalAlign=middle;fontColor=#42505E;fontSize=10;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="888" y="1034" width="420" height="24" as="geometry" />
+        </mxCell>
+        <mxCell id="lg-flow-line" value="" style="endArrow=block;endFill=1;dashed=0;strokeColor=#0B3D66;strokeWidth=2;html=1;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="848" y="1072" as="sourcePoint" />
+            <mxPoint x="882" y="1072" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lg-flow-num" value="n" style="text;html=1;align=center;verticalAlign=middle;fontColor=#FFFFFF;fontSize=9;fontStyle=1;fillColor=#0B3D66;strokeColor=none;rounded=1;arcSize=50;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="856" y="1062" width="18" height="18" as="geometry" />
+        </mxCell>
+        <mxCell id="lg-flow-t" value="numbered request data-flow (live site)" style="text;html=1;align=left;verticalAlign=middle;fontColor=#42505E;fontSize=10;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="888" y="1060" width="260" height="24" as="geometry" />
+        </mxCell>
+        <mxCell id="lg-ctl-line" value="" style="endArrow=open;endFill=0;dashed=1;dashPattern=2 4;strokeColor=#7A8895;strokeWidth=1.5;html=1;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="848" y="1098" as="sourcePoint" />
+            <mxPoint x="882" y="1098" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lg-ctl-t" value="dotted = lease / control / secret access · green dashed = hourly share sync" style="text;html=1;align=left;verticalAlign=middle;fontColor=#42505E;fontSize=10;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="888" y="1086" width="440" height="24" as="geometry" />
+        </mxCell>
+        <mxCell id="lg-dorm" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F4F5F7;strokeColor=#8593A1;dashed=1;arcSize=8;" vertex="1" parent="1">
+          <mxGeometry x="1330" y="1036" width="34" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="lg-dorm-t" value="grey dashed fill = dormant standby&#10;(woken by a lease flip)" style="text;html=1;align=left;verticalAlign=middle;fontColor=#42505E;fontSize=10;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="1372" y="1030" width="176" height="32" as="geometry" />
+        </mxCell>
+        <mxCell id="lg-green" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F3FAF4;strokeColor=#3C7A47;arcSize=8;" vertex="1" parent="1">
+          <mxGeometry x="1330" y="1072" width="34" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="lg-green-t" value="green = shared data plane —&#10;never moves during failover" style="text;html=1;align=left;verticalAlign=middle;fontColor=#42505E;fontSize=10;fontFamily=Segoe UI,Helvetica,Arial,sans-serif;" vertex="1" parent="1">
+          <mxGeometry x="1372" y="1066" width="176" height="32" as="geometry" />
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/assets/diagrams/self-hosted-primary.svg
+++ b/docs/assets/diagrams/self-hosted-primary.svg
@@ -1,0 +1,325 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1654" height="1169" viewBox="0 0 1654 1169" font-family="Segoe UI, Helvetica, Arial, sans-serif">
+  <defs>
+    <linearGradient id="azBlue" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#3399E5"/>
+      <stop offset="1" stop-color="#0066B4"/>
+    </linearGradient>
+    <linearGradient id="azGreen" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#5CB36B"/>
+      <stop offset="1" stop-color="#2E7D3D"/>
+    </linearGradient>
+    <linearGradient id="azGold" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#E0B65C"/>
+      <stop offset="1" stop-color="#C18B27"/>
+    </linearGradient>
+    <linearGradient id="azSlate" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#5E708A"/>
+      <stop offset="1" stop-color="#38455A"/>
+    </linearGradient>
+    <linearGradient id="azGrey" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#AEB9C4"/>
+      <stop offset="1" stop-color="#8593A1"/>
+    </linearGradient>
+    <marker id="arrNavy" markerWidth="9" markerHeight="9" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="#0B3D66"/></marker>
+    <marker id="arrBlueS" markerWidth="9" markerHeight="9" refX="1" refY="4" orient="auto"><path d="M8,0 L0,4 L8,8 Z" fill="#2E6CA3"/></marker>
+    <marker id="arrBlueE" markerWidth="9" markerHeight="9" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="#2E6CA3"/></marker>
+    <marker id="arrGreenS" markerWidth="9" markerHeight="9" refX="1" refY="4" orient="auto"><path d="M8,0 L0,4 L8,8 Z" fill="#3C7A47"/></marker>
+    <marker id="arrGreenE" markerWidth="9" markerHeight="9" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="#3C7A47"/></marker>
+    <marker id="arrGold" markerWidth="9" markerHeight="9" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="#C9851F"/></marker>
+    <marker id="arrGrey" markerWidth="9" markerHeight="9" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="none" stroke="#7A8895" stroke-width="1.4"/></marker>
+    <marker id="arrSlate" markerWidth="9" markerHeight="9" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="none" stroke="#44546A" stroke-width="1.4"/></marker>
+    <marker id="arrOrange" markerWidth="9" markerHeight="9" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="none" stroke="#E8862F" stroke-width="1.4"/></marker>
+  </defs>
+
+  <rect width="1654" height="1169" fill="#FFFFFF"/>
+
+  <!-- ===== TITLE BLOCK ===== -->
+  <rect x="40" y="32" width="1574" height="62" fill="#0B3D66"/>
+  <text x="60" y="71" fill="#FFFFFF" font-size="22" font-weight="700">AzureAgentForge — Self-Hosted Primary · Cloud Warm Standby</text>
+  <text x="1594" y="68" fill="#BBD7EE" font-size="12" text-anchor="end">Owned hardware runs the stack · Azure sleeps until a lease flip · steady-state ≈ $35–45/mo · reference topology</text>
+
+  <!-- ===== PUBLIC EDGE BAND ===== -->
+  <rect x="100" y="116" width="690" height="120" rx="8" fill="#F5F7FA" stroke="#AEB9C4"/>
+  <text x="116" y="135" fill="#5B7A95" font-size="11" font-weight="700">Public edge · one Cloudflare tunnel — the hostname never moves</text>
+  <g transform="translate(146,148)">
+    <circle cx="23" cy="15" r="9" fill="url(#azBlue)"/>
+    <path d="M6,40 a17,15 0 0 1 34,0 Z" fill="url(#azBlue)"/>
+    <text x="23" y="62" fill="#23272E" font-size="11" text-anchor="middle">End user</text>
+  </g>
+  <rect x="280" y="146" width="230" height="60" rx="8" fill="#FFFFFF" stroke="#E8862F"/>
+  <text x="395" y="172" fill="#23272E" font-size="11" text-anchor="middle">Cloudflare edge</text>
+  <text x="395" y="188" fill="#5B6B7B" font-size="10" text-anchor="middle">tunnel origin → live site only</text>
+  <text x="540" y="172" fill="#5B6B7B" font-size="10" font-style="italic">failover = lease flip,</text>
+  <text x="540" y="188" fill="#5B6B7B" font-size="10" font-style="italic">not a DNS change</text>
+
+  <!-- ===== OPERATOR CONTROL BAND ===== -->
+  <rect x="830" y="116" width="724" height="120" rx="8" fill="#F5F7FA" stroke="#AEB9C4"/>
+  <text x="846" y="135" fill="#5B7A95" font-size="11" font-weight="700">Operator control plane · every failover is a deliberate action</text>
+  <g transform="translate(872,148)">
+    <circle cx="23" cy="15" r="9" fill="url(#azSlate)"/>
+    <path d="M6,40 a17,15 0 0 1 34,0 Z" fill="url(#azSlate)"/>
+    <text x="23" y="62" fill="#23272E" font-size="11" text-anchor="middle">Operator</text>
+  </g>
+  <rect x="1000" y="146" width="330" height="60" rx="8" fill="#FFFFFF" stroke="#44546A" stroke-width="1.5"/>
+  <text x="1165" y="170" fill="#23272E" font-size="11" font-weight="700" text-anchor="middle">aaf-site {status | local | cloud}</text>
+  <text x="1165" y="188" fill="#5B6B7B" font-size="10" text-anchor="middle">flips lease · syncs shares · wakes / sleeps cloud</text>
+  <text x="1350" y="170" fill="#5B6B7B" font-size="10" font-style="italic">cloud --force = evacuation</text>
+  <text x="1350" y="186" fill="#5B6B7B" font-size="10" font-style="italic">(skips share sync · loud warning)</text>
+
+  <!-- ===== SELF-HOSTED PRIMARY SITE ===== -->
+  <rect x="100" y="262" width="690" height="716" rx="10" fill="none" stroke="#44546A" stroke-width="2" stroke-dasharray="8 4"/>
+  <g transform="translate(114,272)">
+    <rect x="0" y="2" width="26" height="18" rx="3" fill="url(#azSlate)"/>
+    <rect x="9" y="20" width="8" height="4" fill="url(#azSlate)"/>
+    <rect x="4" y="24" width="18" height="2" fill="url(#azSlate)"/>
+  </g>
+  <text x="148" y="290" fill="#44546A" font-size="12" font-weight="700">Self-hosted primary site · owned hardware (Apple-silicon mini / mini-PC / WSL2) · normally holds the lease</text>
+
+  <!-- Compose stack -->
+  <rect x="124" y="314" width="642" height="404" rx="6" fill="#F2F8FD" fill-opacity="0.9" stroke="#0B6BB0" stroke-width="1.5"/>
+  <text x="138" y="337" fill="#0B6BB0" font-size="11" font-weight="700">Docker Compose stack · deploy/mac-site (shared with windows-site) · brought up only via the site switch</text>
+
+  <rect x="146" y="354" width="290" height="88" rx="6" fill="#FFFFFF" stroke="#44546A" stroke-width="1.5"/>
+  <text x="158" y="376" fill="#1B2733" font-size="13" font-weight="700">lease-guard  (init container)</text>
+  <text x="160" y="400" fill="#5B6B7B" font-size="10">refuses to start the stack unless the</text>
+  <text x="160" y="414" fill="#5B6B7B" font-size="10">lease mirror (~/aaf/active-site) names this site</text>
+
+  <rect x="460" y="354" width="286" height="88" rx="6" fill="#FFF7EF" stroke="#E8862F" stroke-width="1.5"/>
+  <text x="472" y="376" fill="#1B2733" font-size="13" font-weight="700">cloudflared connector — LIVE</text>
+  <text x="474" y="400" fill="#5B6B7B" font-size="10">compose "live" profile · started only when</text>
+  <text x="474" y="414" fill="#5B6B7B" font-size="10">this site holds the lease · same tunnel as standby</text>
+
+  <rect x="146" y="462" width="290" height="88" rx="6" fill="#FFFFFF" stroke="#0078D4" stroke-width="1.5"/>
+  <text x="158" y="484" fill="#1B2733" font-size="13" font-weight="700">PaperClip</text>
+  <text x="160" y="508" fill="#5B6B7B" font-size="10">orchestrator + web UI · :3100</text>
+  <text x="160" y="522" fill="#5B6B7B" font-size="10">local bind-mounted workspace shares</text>
+
+  <rect x="460" y="462" width="286" height="88" rx="6" fill="#FFFFFF" stroke="#0078D4" stroke-width="1.5"/>
+  <text x="472" y="484" fill="#1B2733" font-size="13" font-weight="700">Hermes + Model Router</text>
+  <text x="474" y="508" fill="#5B6B7B" font-size="10">agent runtime · 13-role hierarchy · all inference</text>
+  <text x="474" y="522" fill="#5B6B7B" font-size="10">egress via the router (budgets + fallback)</text>
+
+  <rect x="146" y="570" width="290" height="88" rx="6" fill="#FFFFFF" stroke="#0078D4" stroke-width="1.5"/>
+  <text x="158" y="592" fill="#1B2733" font-size="13" font-weight="700">Honcho</text>
+  <text x="160" y="616" fill="#5B6B7B" font-size="10">agent memory · no local Postgres —</text>
+  <text x="160" y="630" fill="#5B6B7B" font-size="10">connects out to the shared Flexible Server</text>
+
+  <rect x="460" y="570" width="286" height="88" rx="6" fill="#F7F8F5" stroke="#8593A1" stroke-width="1.5" stroke-dasharray="5 3"/>
+  <text x="472" y="592" fill="#1B2733" font-size="13" font-weight="700">Lease mirror  ~/aaf/active-site</text>
+  <text x="474" y="616" fill="#5B6B7B" font-size="10">written by the site switch before every bring-up —</text>
+  <text x="474" y="630" fill="#5B6B7B" font-size="10">the host never holds a service principal</text>
+
+  <!-- Host automation -->
+  <rect x="124" y="738" width="642" height="216" rx="6" fill="#F7F8F5" stroke="#8593A1" stroke-width="1.5" stroke-dasharray="5 3"/>
+  <text x="138" y="761" fill="#5B6B7B" font-size="11" font-weight="700">Host automation · launchd (macOS) / Task Scheduler → WSL2 (Windows) · each job is a no-op without the lease</text>
+  <text x="154" y="793" fill="#42505E" font-size="10">boot-guard · startup + every 5 min — stops the stack if the authoritative lease moved (does nothing on Key Vault errors)</text>
+  <text x="154" y="825" fill="#42505E" font-size="10">image freshness · every 10 min — registry login + compose pull; roll the live profile only on a digest change</text>
+  <text x="154" y="857" fill="#42505E" font-size="10">firewall keeper · every 15 min — upsert the shared-PG "home-ip" rule when the home WAN address rotates</text>
+  <text x="154" y="889" fill="#42505E" font-size="10">warm-standby share sync · hourly — azcopy the file shares local→cloud; stamps standby_sync_completed for the watchdog</text>
+  <text x="154" y="921" fill="#42505E" font-size="10">skill curator · daily — one-shot maintenance job (compose "jobs" profile)</text>
+
+  <!-- ===== AZURE REGION ===== -->
+  <rect x="830" y="262" width="724" height="716" rx="10" fill="none" stroke="#0078D4" stroke-width="2" stroke-dasharray="8 4"/>
+  <g transform="translate(844,272)">
+    <rect x="0" y="0" width="26" height="26" rx="4" fill="url(#azBlue)"/>
+    <path d="M6,18 L13,6 L20,18 Z" fill="#FFFFFF"/>
+  </g>
+  <text x="878" y="290" fill="#0078D4" font-size="12" font-weight="700">Azure region · warm standby compute + the shared data plane</text>
+
+  <!-- Dormant CAE -->
+  <rect x="854" y="314" width="676" height="212" rx="6" fill="#F4F5F7" stroke="#8593A1" stroke-width="1.5" stroke-dasharray="5 3"/>
+  <g transform="translate(868,324)">
+    <rect x="0" y="0" width="24" height="24" rx="4" fill="url(#azGrey)"/>
+    <rect x="5" y="5" width="6" height="6" fill="#FFFFFF"/>
+    <rect x="13" y="5" width="6" height="6" fill="#FFFFFF"/>
+    <rect x="5" y="13" width="6" height="6" fill="#FFFFFF"/>
+  </g>
+  <text x="900" y="340" fill="#5B6B7B" font-size="11" font-weight="700">Container Apps Environment — DORMANT · scale-to-zero / asleep · woken only by aaf-site cloud</text>
+
+  <rect x="878" y="366" width="146" height="64" rx="6" fill="#FFFFFF" stroke="#8593A1" stroke-dasharray="5 3"/>
+  <text x="951" y="394" fill="#5B6B7B" font-size="11" text-anchor="middle">PaperClip</text>
+  <text x="951" y="410" fill="#5B6B7B" font-size="10" text-anchor="middle">(asleep)</text>
+  <rect x="1042" y="366" width="146" height="64" rx="6" fill="#FFFFFF" stroke="#8593A1" stroke-dasharray="5 3"/>
+  <text x="1115" y="394" fill="#5B6B7B" font-size="11" text-anchor="middle">Hermes + Router</text>
+  <text x="1115" y="410" fill="#5B6B7B" font-size="10" text-anchor="middle">(asleep)</text>
+  <rect x="1206" y="366" width="146" height="64" rx="6" fill="#FFFFFF" stroke="#8593A1" stroke-dasharray="5 3"/>
+  <text x="1279" y="394" fill="#5B6B7B" font-size="11" text-anchor="middle">Honcho</text>
+  <text x="1279" y="410" fill="#5B6B7B" font-size="10" text-anchor="middle">(asleep)</text>
+  <rect x="1370" y="366" width="146" height="64" rx="6" fill="#FFFFFF" stroke="#E8862F" stroke-dasharray="5 3"/>
+  <text x="1443" y="394" fill="#5B6B7B" font-size="11" text-anchor="middle">cloudflared</text>
+  <text x="1443" y="410" fill="#5B6B7B" font-size="10" text-anchor="middle">connector (idle)</text>
+  <text x="878" y="466" fill="#5B6B7B" font-size="10" font-style="italic">same images · same tunnel · same shared DB — a lease flip makes this the live site</text>
+  <text x="878" y="482" fill="#5B6B7B" font-size="10" font-style="italic">with shares at most one hour stale</text>
+
+  <!-- Shared data plane -->
+  <rect x="854" y="556" width="330" height="150" rx="6" fill="#F3FAF4" stroke="#3C7A47" stroke-width="1.5"/>
+  <g transform="translate(866,568)">
+    <path d="M4,6 a11,5 0 0 1 22,0 v14 a11,5 0 0 1 -22,0 Z" fill="url(#azGreen)"/>
+    <ellipse cx="15" cy="6" rx="11" ry="5" fill="#7BC98A"/>
+  </g>
+  <text x="904" y="582" fill="#1B2733" font-size="13" font-weight="700">PostgreSQL Flexible Server — SHARED</text>
+  <text x="868" y="620" fill="#5B6B7B" font-size="10">always-on · the failover pivot — the database never moves</text>
+  <text x="868" y="636" fill="#5B6B7B" font-size="10">both sites connect over the public endpoint, IP-firewalled,</text>
+  <text x="868" y="652" fill="#5B6B7B" font-size="10">sslmode=require · pgvector · RPO ≈ 0 for a site switch</text>
+  <g transform="translate(1148,568)">
+    <rect x="0" y="4" width="18" height="14" rx="2" fill="none" stroke="#3C7A47" stroke-width="1.6"/>
+    <path d="M4,4 v-1 a5,5 0 0 1 10,0 v1" fill="none" stroke="#3C7A47" stroke-width="1.6"/>
+  </g>
+
+  <rect x="1200" y="556" width="330" height="150" rx="6" fill="#F3FAF4" stroke="#3C7A47" stroke-width="1.5"/>
+  <g transform="translate(1212,568)">
+    <rect x="2" y="2" width="26" height="26" rx="4" fill="url(#azGreen)"/>
+    <circle cx="15" cy="12" r="5" fill="#FFFFFF"/>
+    <rect x="13" y="15" width="4" height="10" fill="#FFFFFF"/>
+  </g>
+  <text x="1250" y="582" fill="#1B2733" font-size="13" font-weight="700">Key Vault — the lease authority</text>
+  <text x="1214" y="620" fill="#5B6B7B" font-size="10">secret platform-active-site ∈ {cloud, local} —</text>
+  <text x="1214" y="636" fill="#5B6B7B" font-size="10">the single-writer lease (anti-split-brain)</text>
+  <text x="1214" y="652" fill="#5B6B7B" font-size="10">plus app credentials · public access default-deny + IP allowlist</text>
+
+  <!-- Supporting services -->
+  <rect x="854" y="736" width="200" height="118" rx="6" fill="#FFFFFF" stroke="#0078D4" stroke-width="1.5"/>
+  <g transform="translate(866,748)">
+    <rect x="0" y="4" width="28" height="20" rx="3" fill="url(#azBlue)"/>
+    <rect x="5" y="9" width="7" height="5" fill="#FFFFFF"/>
+    <rect x="16" y="9" width="7" height="5" fill="#FFFFFF"/>
+    <rect x="5" y="16" width="7" height="5" fill="#FFFFFF"/>
+  </g>
+  <text x="902" y="764" fill="#1B2733" font-size="12" font-weight="700">Container Registry</text>
+  <text x="868" y="800" fill="#5B6B7B" font-size="10">one image source for both sites</text>
+  <text x="868" y="816" fill="#5B6B7B" font-size="10">(arm64 + amd64 tags)</text>
+
+  <rect x="1078" y="736" width="228" height="118" rx="6" fill="#FFFFFF" stroke="#0078D4" stroke-width="1.5"/>
+  <g transform="translate(1090,748)">
+    <path d="M2,8 h9 l3,-4 h12 v20 h-24 Z" fill="url(#azBlue)"/>
+  </g>
+  <text x="1126" y="764" fill="#1B2733" font-size="12" font-weight="700">Azure Files shares</text>
+  <text x="1092" y="800" fill="#5B6B7B" font-size="10">agent workspaces + gateway config</text>
+  <text x="1092" y="816" fill="#5B6B7B" font-size="10">standby copy, refreshed by the hourly</text>
+  <text x="1092" y="832" fill="#5B6B7B" font-size="10">sync — at most 1 h stale</text>
+
+  <rect x="1330" y="736" width="200" height="118" rx="6" fill="#FFFFFF" stroke="#8593A1" stroke-width="1.5"/>
+  <g transform="translate(1342,748)">
+    <rect x="0" y="0" width="28" height="24" rx="3" fill="url(#azGrey)"/>
+    <path d="M5,17 l5,-6 l4,3 l6,-8" fill="none" stroke="#FFFFFF" stroke-width="1.8"/>
+  </g>
+  <text x="1378" y="764" fill="#1B2733" font-size="12" font-weight="700">Log Analytics</text>
+  <text x="1344" y="800" fill="#5B6B7B" font-size="10">minimal retention</text>
+  <text x="1344" y="816" fill="#5B6B7B" font-size="10">(self-hosted-primary profile</text>
+  <text x="1344" y="832" fill="#5B6B7B" font-size="10">keeps logs lean)</text>
+
+  <text x="858" y="936" fill="#5B6B7B" font-size="10" font-style="italic">steady-state cloud spend ≈ $35–45/mo — the always-on shared server is the price of RPO-0 failover</text>
+
+  <!-- ===== LLM BACKENDS BAND ===== -->
+  <rect x="100" y="1002" width="690" height="120" rx="8" fill="#FBF7F0" stroke="#C9A45B"/>
+  <text x="116" y="1021" fill="#8A6D1F" font-size="11" font-weight="700">LLM backends (external inference)</text>
+  <g transform="translate(160,1036)">
+    <rect x="0" y="0" width="44" height="44" rx="6" fill="url(#azGold)"/>
+    <circle cx="22" cy="22" r="11" fill="#FFFFFF" opacity="0.9"/>
+    <circle cx="22" cy="22" r="5" fill="url(#azGold)"/>
+    <text x="22" y="62" fill="#23272E" font-size="11" text-anchor="middle">Azure AI Foundry</text>
+    <text x="22" y="76" fill="#8A6D1F" font-size="10" text-anchor="middle">(primary)</text>
+  </g>
+  <rect x="330" y="1034" width="180" height="60" rx="8" fill="#FFFFFF" stroke="#C9A45B" stroke-dasharray="5 3"/>
+  <text x="420" y="1058" fill="#23272E" font-size="11" text-anchor="middle">OpenAI-compatible</text>
+  <text x="420" y="1074" fill="#5B6B7B" font-size="10" text-anchor="middle">endpoint (fallback)</text>
+  <text x="540" y="1058" fill="#5B6B7B" font-size="10" font-style="italic">egress from whichever site is live,</text>
+  <text x="540" y="1074" fill="#5B6B7B" font-size="10" font-style="italic">always via the Model Router (budget caps)</text>
+
+  <!-- ===== REQUEST FLOW EDGES ===== -->
+  <!-- 1: user -> cf edge -->
+  <path d="M196,171 H278" fill="none" stroke="#0B3D66" stroke-width="2" marker-end="url(#arrNavy)"/>
+  <rect x="228" y="160" width="20" height="20" rx="10" fill="#0B3D66"/>
+  <text x="238" y="174" fill="#FFFFFF" font-size="10" font-weight="700" text-anchor="middle">1</text>
+
+  <!-- 2: cf edge -> live connector -->
+  <path d="M452,206 V250 H603 V352" fill="none" stroke="#0B3D66" stroke-width="2" marker-end="url(#arrNavy)"/>
+  <rect x="520" y="240" width="20" height="20" rx="10" fill="#0B3D66"/>
+  <text x="530" y="254" fill="#FFFFFF" font-size="10" font-weight="700" text-anchor="middle">2</text>
+  <text x="548" y="242" fill="#0B3D66" font-size="10" font-style="italic">live connector only (lease holder)</text>
+
+  <!-- 3: connector -> PaperClip (drops through the inter-row channel) -->
+  <path d="M490,442 V452 H364 V460" fill="none" stroke="#0B3D66" stroke-width="2" marker-end="url(#arrNavy)"/>
+  <rect x="412" y="442" width="20" height="20" rx="10" fill="#0B3D66"/>
+  <text x="422" y="456" fill="#FFFFFF" font-size="10" font-weight="700" text-anchor="middle">3</text>
+
+  <!-- 4: PaperClip -> Hermes -->
+  <path d="M436,506 H458" fill="none" stroke="#0B3D66" stroke-width="2" marker-end="url(#arrNavy)"/>
+  <rect x="438" y="496" width="20" height="20" rx="10" fill="#0B3D66"/>
+  <text x="448" y="510" fill="#FFFFFF" font-size="10" font-weight="700" text-anchor="middle">4</text>
+
+  <!-- 5: Hermes <-> Honcho -->
+  <path d="M532,550 V560 H291 V568" fill="none" stroke="#2E6CA3" stroke-width="2" marker-start="url(#arrBlueS)" marker-end="url(#arrBlueE)"/>
+  <rect x="400" y="550" width="20" height="20" rx="10" fill="#2E6CA3"/>
+  <text x="410" y="564" fill="#FFFFFF" font-size="10" font-weight="700" text-anchor="middle">5</text>
+  <text x="300" y="564" fill="#2E6CA3" font-size="10" font-style="italic">memory read / write</text>
+
+  <!-- 6: Honcho <-> shared PG (below row 3, out through both site boundaries) -->
+  <path d="M291,658 V700 H798 V631 H852" fill="none" stroke="#3C7A47" stroke-width="2" marker-start="url(#arrGreenS)" marker-end="url(#arrGreenE)"/>
+  <rect x="788" y="650" width="20" height="20" rx="10" fill="#3C7A47"/>
+  <text x="798" y="664" fill="#FFFFFF" font-size="10" font-weight="700" text-anchor="middle">6</text>
+  <text x="545" y="692" fill="#3C7A47" font-size="10" font-style="italic" text-anchor="middle">TLS · public endpoint · IP-firewalled — crosses both site boundaries; the DB itself never moves</text>
+
+  <!-- 7: Hermes/Router -> Foundry (right gutter, under the site, into the LLM band) -->
+  <path d="M746,530 H818 V988 H182 V1034" fill="none" stroke="#C9851F" stroke-width="2" marker-end="url(#arrGold)"/>
+  <rect x="300" y="978" width="20" height="20" rx="10" fill="#C9851F"/>
+  <text x="310" y="992" fill="#FFFFFF" font-size="10" font-weight="700" text-anchor="middle">7</text>
+  <!-- 7b: Foundry -> fallback (dotted gold) -->
+  <path d="M204,1080 H328 V1064" fill="none" stroke="#C9851F" stroke-width="1.5" stroke-dasharray="4 4" marker-end="url(#arrGold)"/>
+
+  <!-- ===== CONTROL / LEASE / SYNC EDGES ===== -->
+  <!-- aaf-site -> Key Vault (lease write, around the dormant CAE via the far-right gutter) -->
+  <path d="M1165,206 V246 H1542 V631 H1532" fill="none" stroke="#44546A" stroke-width="1.8" stroke-dasharray="2 4" marker-end="url(#arrSlate)"/>
+  <text x="1300" y="544" fill="#44546A" font-size="10" font-style="italic">writes the lease (platform-active-site)</text>
+
+  <!-- aaf-site -> standby wake/sleep -->
+  <path d="M1082,206 V228 H1361 V312" fill="none" stroke="#44546A" stroke-width="1.8" stroke-dasharray="2 4" marker-end="url(#arrSlate)"/>
+  <text x="1090" y="300" fill="#44546A" font-size="10" font-style="italic">wakes / sleeps the cloud apps</text>
+
+  <!-- aaf-site -> lease mirror (left gutter inside the home site; mirror box text explains it) -->
+  <path d="M998,176 H778 V614 H748" fill="none" stroke="#44546A" stroke-width="1.8" stroke-dasharray="2 4" marker-end="url(#arrSlate)"/>
+
+  <!-- boot-guard -> Key Vault -->
+  <path d="M760,789 H806 V726 H1282 V708" fill="none" stroke="#7A8895" stroke-width="1.5" stroke-dasharray="2 4" marker-end="url(#arrGrey)"/>
+
+  <!-- firewall keeper -> PG -->
+  <path d="M772,853 H804 V714 H1019 V708" fill="none" stroke="#7A8895" stroke-width="1.5" stroke-dasharray="2 4" marker-end="url(#arrGrey)"/>
+
+  <!-- image freshness -> ACR -->
+  <path d="M760,821 H796 V795 H852" fill="none" stroke="#7A8895" stroke-width="1.5" stroke-dasharray="2 4" marker-end="url(#arrGrey)"/>
+
+  <!-- share sync -> Azure Files (green dashed) -->
+  <path d="M746,885 H1192 V856" fill="none" stroke="#3C7A47" stroke-width="2" stroke-dasharray="6 3" marker-end="url(#arrGreenE)"/>
+  <text x="860" y="878" fill="#3C7A47" font-size="10" font-style="italic">azcopy · hourly · shares only — never the database</text>
+
+  <!-- standby connector -> cf edge (idle tunnel) -->
+  <path d="M1443,364 V254 H524 V208" fill="none" stroke="#E8862F" stroke-width="1.5" stroke-dasharray="2 4" marker-end="url(#arrOrange)"/>
+  <text x="800" y="250" fill="#B06318" font-size="10" font-style="italic">second connector · same tunnel · idle until the lease flips</text>
+
+  <!-- standby -> PG (same DB when live) -->
+  <path d="M1019,526 V554" fill="none" stroke="#7A8895" stroke-width="1.5" stroke-dasharray="2 4" marker-end="url(#arrGrey)"/>
+  <text x="1032" y="546" fill="#7A8895" font-size="10" font-style="italic">same DB when live</text>
+
+  <!-- ===== LEGEND ===== -->
+  <rect x="830" y="1002" width="724" height="120" rx="6" fill="#FFFFFF" stroke="#AEB9C4"/>
+  <text x="844" y="1022" fill="#1B2733" font-size="11" font-weight="700">Legend</text>
+
+  <rect x="846" y="1036" width="34" height="20" rx="4" fill="none" stroke="#44546A" stroke-width="2" stroke-dasharray="8 4"/>
+  <text x="888" y="1050" fill="#42505E" font-size="10">dashed = site / trust boundary (slate = owned hardware, blue = Azure)</text>
+
+  <path d="M848,1072 H880" fill="none" stroke="#0B3D66" stroke-width="2" marker-end="url(#arrNavy)"/>
+  <rect x="856" y="1062" width="18" height="18" rx="9" fill="#0B3D66"/>
+  <text x="865" y="1075" fill="#FFFFFF" font-size="9" font-weight="700" text-anchor="middle">n</text>
+  <text x="888" y="1076" fill="#42505E" font-size="10">numbered request data-flow (live site)</text>
+
+  <path d="M848,1098 H880" fill="none" stroke="#7A8895" stroke-width="1.5" stroke-dasharray="2 4" marker-end="url(#arrGrey)"/>
+  <text x="888" y="1102" fill="#42505E" font-size="10">dotted = lease / control / secret access · green dashed = hourly share sync</text>
+
+  <rect x="1330" y="1036" width="34" height="20" rx="4" fill="#F4F5F7" stroke="#8593A1" stroke-dasharray="5 3"/>
+  <text x="1372" y="1044" fill="#42505E" font-size="10">grey dashed fill = dormant standby</text>
+  <text x="1372" y="1058" fill="#42505E" font-size="10">(woken by a lease flip)</text>
+
+  <rect x="1330" y="1072" width="34" height="20" rx="4" fill="#F3FAF4" stroke="#3C7A47"/>
+  <text x="1372" y="1080" fill="#42505E" font-size="10">green = shared data plane —</text>
+  <text x="1372" y="1094" fill="#42505E" font-size="10">never moves during failover</text>
+</svg>

--- a/docs/design/self-hosted-primary.md
+++ b/docs/design/self-hosted-primary.md
@@ -40,6 +40,12 @@ time; a one-tap **site switch** flips the lease, syncs the file shares, and wake
 or sleeps the cloud. Because the data lives in the shared database, a failover is
 a **stateless compute switch** — no dumps, no restores, near-zero RPO.
 
+<p align="center">
+  <img src="../assets/diagrams/self-hosted-primary.svg" alt="AzureAgentForge self-hosted-primary topology — owned hardware runs the compose stack as the live site, Azure holds a dormant warm standby, both sites share one always-on PostgreSQL Flexible Server, a Key Vault lease enforces a single live site, and one Cloudflare tunnel with two connectors keeps the public hostname fixed across failover" width="900">
+</p>
+
+<p align="center"><sub>Editable source: <a href="../assets/diagrams/self-hosted-primary.drawio"><code>self-hosted-primary.drawio</code></a> · <a href="../assets/diagrams/README.md">diagram conventions</a></sub></p>
+
 ## 1. Why invert primary and standby
 
 The default cloud deployment pays Azure Container Apps to keep the platform


### PR DESCRIPTION
## Summary
- Adds the sixth diagram pair `self-hosted-primary.{drawio,svg}` to `docs/assets/diagrams/` — the self-hosted-primary / cloud-warm-standby failover topology already specified in `docs/design/self-hosted-primary.md`, drawn in the same family conventions as the existing five.
- Registers it in the diagram-set README (count 5→6, table row, two new site-level conventions: slate dashed = owned-hardware boundary, grey dashed fill = dormant standby).
- Embeds the SVG in `docs/design/self-hosted-primary.md` §0 with the standard editable-source footer.

## What the diagram shows
- Owned hardware as the live compose site (lease-guard, PaperClip, Hermes + Model Router, Honcho, live cloudflared connector, host-automation timers)
- Azure as dormant warm standby (scale-to-zero CAE, idle second connector on the same tunnel)
- The shared always-on PostgreSQL Flexible Server pivot (never moves, RPO ≈ 0) and the Key Vault single-writer lease (`platform-active-site`)
- Numbered request flow 1–7 plus dotted control edges (`aaf-site` lease flip / wake-sleep, boot-guard lease reads, firewall keeper, image pulls, hourly azcopy share sync)

## Notes
- Existing five diagrams untouched.
- `.svg` is the hand-authored companion per set convention; canonical re-export from the `.drawio` in diagrams.net still applies after any future edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)